### PR TITLE
Add Penpot-based card design system and asset generator

### DIFF
--- a/design/.env.example
+++ b/design/.env.example
@@ -3,6 +3,9 @@ PENPOT_URL=http://localhost:9001
 PENPOT_EMAIL=your-email@example.com
 PENPOT_PASSWORD=your-password-here
 
+# Secret key for Penpot (generate with: python3 -c "import secrets; print(secrets.token_urlsafe(64))")
+PENPOT_SECRET_KEY=
+
 # File/page IDs (set after first run of setup-template.py)
 PENPOT_FILE_ID=
 PENPOT_PAGE_ID=

--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,42 @@
+# Card Rendering Pipeline
+
+Penpot-based pipeline that renders card data from `library/` CSVs into PNG and SVG images.
+
+## Pipeline flow
+
+1. **`setup-template.py`** — Creates the unit card template in Penpot (shapes, colors, tokens, component)
+2. **`compose-cards.py`** — Reads CSV data, populates the template per card, exports PNG/SVG
+3. **`postprocess-svg.py`** — Cleans exported SVGs (rewrites fonts, strips artifacts, reduces size ~35%)
+
+## tokens.json structure
+
+- **`layout`**, **`colors`**, **`stats`**, **`typography`**, **`mappings`** — Used by the Python scripts to build and populate card shapes
+- **`designTokens`** — W3C DTCG format tokens pushed to Penpot's token system via `set-tokens-lib`
+
+## Prerequisites
+
+- Docker & Docker Compose (for self-hosted Penpot)
+- Python 3.9+
+- Copy `design/.env.example` → `design/.env` and fill in credentials
+- Generate a secret key: `python3 -c "import secrets; print(secrets.token_urlsafe(64))"`
+
+## Quick start
+
+```bash
+# Start Penpot
+docker compose -f design/docker-compose.yaml up -d
+
+# Create .env with your credentials
+cp design/.env.example design/.env
+# Edit design/.env with your email, password, and generated secret key
+
+# Build the template (first time only)
+python3 design/setup-template.py
+
+# Export all unit cards as PNG
+python3 design/compose-cards.py
+```
+
+## Detailed API patterns
+
+See [`.claude/skills/penpot-card-renderer/SKILL.md`](../.claude/skills/penpot-card-renderer/SKILL.md) for Penpot API usage, shape discovery, text content format, and troubleshooting.


### PR DESCRIPTION
## Summary

Adds a self-hosted Penpot instance as the card design tool, with an API-driven pipeline that creates card templates from design tokens and batch-generates card images (PNG/SVG) from library CSV data.

- **`design/docker-compose.yaml`** — Self-hosted Penpot infrastructure (frontend, backend, exporter, Postgres, Redis)
- **`design/tokens.json`** — Single source of truth for all visual design: colors, layout coordinates, typography, stat definitions, rarity colors, attribute mappings, W3C DTCG tokens
- **`design/penpot.py`** — Shared module: `PenpotClient` (auth, file ops, PNG/SVG export via transit+json), shape builders (rect, circle, text, frame), geometry helpers, change builders
- **`design/setup-template.py`** — Creates the complete unit card template in Penpot (idempotent — safe to re-run after token changes)
- **`design/compose-cards.py`** — Reads card data from CSV, populates the template per card, exports PNG/SVG. Discovers shapes by name (zero hardcoded UUIDs)
- **`design/postprocess-svg.py`** — Cleans Penpot SVG exports for web: rewrites fonts to Google CDN, strips textLength, removes identity transforms (~34% size reduction)
- **`design/README.md`** — Pipeline overview, tokens.json structure, prerequisites, quick start

### Key Penpot API discoveries

Hard-won patterns preserved in the codebase:

1. Text shapes require approximate `position-data` for SVG export — without it the Playwright-based exporter times out. `make_position_data()` generates calibrated values with center-aware offsets
2. `text-align` must be set at both paragraph and text-attrs level for centering to work
3. `mod-obj` cannot update `selrect` — delete + re-add with same ID is the workaround
4. Design tokens must be passed as a JSON string (`json.dumps`) to `set-tokens-lib` to preserve `$type`/`$value` keys that Penpot's middleware would otherwise strip
5. `grow-type: "fixed"` on text shapes ensures consistent rendering

### Cleanup in this PR

- Scrubbed hardcoded secret key from git history (replaced with `${PENPOT_SECRET_KEY}`)
- Fixed rarity tier mismatch: `rare` → `uncommon` in tokens, `rare` → `epic` in CSV data
- Added empty CSV guard and improved Penpot client error handling (URLError catch, credential validation, quoted .env values)
- Added `PENPOT_SECRET_KEY` to `.env.example`
- Removed proposal document (investigation findings preserved in git history)

### Feature gaps tracked

- #4 Support all 5 card types
- #5 Card back design
- #6 Card art pipeline
- #7 Keyword rendering
- #8 Batch orchestration across types
- #9 Print-ready output
- #10 Multi-line text overflow

## Test plan

- [x] `setup-template.py` creates 28/28 named shapes in Penpot
- [x] Running `setup-template.py` twice produces no duplicates (idempotent)
- [x] `compose-cards.py` exports 5 unit card PNGs from `units.csv`
- [x] `compose-cards.py --format svg` exports 5 SVGs, post-processed to `.clean.svg`
- [x] `compose-cards.py --format both` exports both formats in one run
- [x] Visual verification: type circles centered, cost centered, stats centered, rarity bar colors differ by rarity, flavor text italicized
- [x] `git log -p -S "change-this-insecure-key"` returns nothing on feature branch
- [x] No `rare` rarity values in any CSV

🤖 Generated with [Claude Code](https://claude.com/claude-code)