### PR TITLE
Add persistent CLI installation for remote sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (cloud) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+###############################################################################
+# Persistent bin directory — survives across remote sessions
+###############################################################################
+PERSISTENT_BIN="$CLAUDE_PROJECT_DIR/.claude/bin"
+mkdir -p "$PERSISTENT_BIN"
+export PATH="$PERSISTENT_BIN:$PATH"
+
+###############################################################################
+# GitHub CLI
+###############################################################################
+if ! command -v gh &>/dev/null; then
+  echo "Installing GitHub CLI..."
+  GH_VERSION="2.65.0"
+  GH_ARCH="$(uname -m)"
+  case "$GH_ARCH" in
+    x86_64)  GH_ARCH="amd64" ;;
+    aarch64) GH_ARCH="arm64" ;;
+  esac
+  GH_TAR="gh_${GH_VERSION}_linux_${GH_ARCH}.tar.gz"
+  curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_TAR}" -o "/tmp/${GH_TAR}"
+  tar -xzf "/tmp/${GH_TAR}" -C /tmp
+  cp "/tmp/gh_${GH_VERSION}_linux_${GH_ARCH}/bin/gh" "$PERSISTENT_BIN/gh"
+  chmod +x "$PERSISTENT_BIN/gh"
+  rm -rf "/tmp/${GH_TAR}" "/tmp/gh_${GH_VERSION}_linux_${GH_ARCH}"
+fi
+
+###############################################################################
+# Nushell — used by /card-query and /session-query skills
+###############################################################################
+if ! command -v nu &>/dev/null; then
+  echo "Installing Nushell..."
+  NU_VERSION="0.103.0"
+  NU_ARCH="$(uname -m)"
+  case "$NU_ARCH" in
+    x86_64)  NU_ARCH="x86_64" ;;
+    aarch64) NU_ARCH="aarch64" ;;
+  esac
+  NU_TAR="nu-${NU_VERSION}-${NU_ARCH}-unknown-linux-gnu.tar.gz"
+  curl -fsSL "https://github.com/nushell/nushell/releases/download/${NU_VERSION}/${NU_TAR}" -o "/tmp/${NU_TAR}"
+  tar -xzf "/tmp/${NU_TAR}" -C /tmp
+  cp "/tmp/nu-${NU_VERSION}-${NU_ARCH}-unknown-linux-gnu/nu" "$PERSISTENT_BIN/nu"
+  chmod +x "$PERSISTENT_BIN/nu"
+  rm -rf "/tmp/${NU_TAR}" "/tmp/nu-${NU_VERSION}-${NU_ARCH}-unknown-linux-gnu"
+fi
+
+###############################################################################
+# Bun dependencies — install only if node_modules appears incomplete
+###############################################################################
+cd "$CLAUDE_PROJECT_DIR"
+if [ ! -d "engine/node_modules/immer" ]; then
+  echo "Installing bun workspace dependencies..."
+  bun install
+fi
+
+###############################################################################
+# Build card library (output is gitignored, needed for tests)
+###############################################################################
+if [ ! -d "library/build" ]; then
+  echo "Building card library..."
+  bun library/build.ts
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Edit|Write",

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ design/exports/
 
 # Claude Code local settings
 .claude/settings.local.json
+
+# Persistent CLI binaries (installed by session-start hook)
+.claude/bin/


### PR DESCRIPTION
Install gh and nushell to .claude/bin/ instead of /usr/local/bin/ so
binaries survive across remote sessions. Adds SessionStart hook
configuration and gitignores the persistent bin directory.

https://claude.ai/code/session_017sAgMpVvsrAncFYpf42Cb7