### PR TITLE
Persist .claude/bin PATH via CLAUDE_ENV_FILE in session start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -13,6 +13,11 @@ PERSISTENT_BIN="$CLAUDE_PROJECT_DIR/.claude/bin"
 mkdir -p "$PERSISTENT_BIN"
 export PATH="$PERSISTENT_BIN:$PATH"
 
+# Persist PATH for all subsequent Bash tool calls in this session
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  echo "export PATH=\"$PERSISTENT_BIN:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+fi
+
 ###############################################################################
 # GitHub CLI
 ###############################################################################


### PR DESCRIPTION
The hook was installing gh and nu to .claude/bin/ but only exported
PATH within its own subprocess. By writing to $CLAUDE_ENV_FILE,
the PATH is sourced before each Bash tool call in the session.

https://claude.ai/code/session_01CRj9jcHap3K1E6NTEayZqw