### PR TITLE
Remove card library build from session start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -65,10 +65,3 @@ if [ ! -d "engine/node_modules/immer" ]; then
   bun install
 fi
 
-###############################################################################
-# Build card library (output is gitignored, needed for tests)
-###############################################################################
-if [ ! -d "library/build" ]; then
-  echo "Building card library..."
-  bun library/build.ts
-fi


### PR DESCRIPTION
Not every session needs the built library — often we're just editing
rules. Build can be triggered manually when needed.

https://claude.ai/code/session_01UGs8JwzkWzcqqnRACkLDcb