### PR TITLE
Add .claude/bin/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ design/exports/
 
 # Claude Code local settings
 .claude/settings.local.json
+.claude/bin/
 .mcp.json


### PR DESCRIPTION
Installed tooling (e.g. nushell) from session startup hooks
should not be tracked in the repository.

https://claude.ai/code/session_01K772jZorHhpCub67wnTPCH