### PR TITLE
#44 — Engine: support variant-replaceable phases

### DIFF
--- a/engine/src/__tests__/controller.test.ts
+++ b/engine/src/__tests__/controller.test.ts
@@ -3,7 +3,7 @@ import { BotAdapter } from "../bot-adapter";
 import { GameController } from "../controller";
 import type {
   Action,
-  DeckInput,
+  SetupInput,
   GameEvent,
   GameState,
   MainGameState,
@@ -13,7 +13,7 @@ import type {
 } from "../types";
 import { DEFAULT_CONFIG, SEED, TWO_PLAYERS } from "./helpers";
 
-const MAIN_DECK_INPUT: DeckInput = {
+const MAIN_SETUP_INPUT: SetupInput = {
   mode: "main",
   decks: {
     p1: {
@@ -47,7 +47,7 @@ function createController(
     config: DEFAULT_CONFIG,
     players: TWO_PLAYERS,
     seed: SEED,
-    deckInput: MAIN_DECK_INPUT,
+    setupInput: MAIN_SETUP_INPUT,
     adapters: createAdapters(),
     onEvent,
   });
@@ -98,7 +98,7 @@ describe("GameController", () => {
         config: DEFAULT_CONFIG,
         players: TWO_PLAYERS,
         seed: SEED,
-        deckInput: MAIN_DECK_INPUT,
+        setupInput: MAIN_SETUP_INPUT,
         adapters: new Map([
           ["p1", badAdapter],
           ["p2", badAdapter],
@@ -153,7 +153,7 @@ describe("GameController", () => {
 
       const replayed = GameController.fromSession(
         session,
-        MAIN_DECK_INPUT,
+        MAIN_SETUP_INPUT,
         createAdapters(),
       );
       expect((replayed.getState() as MainGameState).turn.round).toBe(
@@ -171,7 +171,7 @@ describe("GameController", () => {
 
       const resumed = GameController.fromSession(
         session,
-        MAIN_DECK_INPUT,
+        MAIN_SETUP_INPUT,
         createAdapters(),
       );
       expect((resumed.getState() as MainGameState).turn.activePlayerId).toBe(
@@ -188,7 +188,7 @@ describe("GameController", () => {
       const session = controller.toSession();
       const replayed = GameController.fromSession(
         session,
-        MAIN_DECK_INPUT,
+        MAIN_SETUP_INPUT,
         createAdapters(),
       );
 
@@ -214,7 +214,7 @@ describe("GameController", () => {
       };
 
       expect(() =>
-        GameController.fromSession(session, MAIN_DECK_INPUT, createAdapters()),
+        GameController.fromSession(session, MAIN_SETUP_INPUT, createAdapters()),
       ).toThrow(/action 1\/1/);
     });
   });

--- a/engine/src/__tests__/create-game.test.ts
+++ b/engine/src/__tests__/create-game.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { createGame } from "../create-game";
-import type { DeckInput, Grid } from "../types";
+import type { SetupInput, Grid } from "../types";
 import {
   createSeedingGame,
   createTestGame,
@@ -11,7 +11,7 @@ import {
   TWO_PLAYERS,
 } from "./helpers";
 
-const MAIN_DECK_INPUT: DeckInput = {
+const MAIN_SETUP_INPUT: SetupInput = {
   mode: "main",
   decks: {
     p1: {
@@ -144,7 +144,7 @@ describe("createGame", () => {
   describe("validation", () => {
     it("rejects empty players array", () => {
       expect(() =>
-        createGame(DEFAULT_CONFIG, [], SEED, MAIN_DECK_INPUT),
+        createGame(DEFAULT_CONFIG, [], SEED, MAIN_SETUP_INPUT),
       ).toThrow("at least one player");
     });
 
@@ -157,14 +157,14 @@ describe("createGame", () => {
             { id: "p1", name: "B" },
           ],
           SEED,
-          MAIN_DECK_INPUT,
+          MAIN_SETUP_INPUT,
         ),
       ).toThrow("Duplicate player IDs");
     });
 
     it("rejects empty seed", () => {
       expect(() =>
-        createGame(DEFAULT_CONFIG, TWO_PLAYERS, "", MAIN_DECK_INPUT),
+        createGame(DEFAULT_CONFIG, TWO_PLAYERS, "", MAIN_SETUP_INPUT),
       ).toThrow("non-empty seed");
     });
   });
@@ -183,7 +183,7 @@ describe("createGame", () => {
         ],
       ];
       const state = createTestGame({
-        deckInput: {
+        setupInput: {
           mode: "main",
           decks: {
             p1: { mainDeck: [], hand: [], prospectDeck: [], marketDeck: [], activePolicies: [] },
@@ -199,7 +199,7 @@ describe("createGame", () => {
     it("uses provided market instead of empty array", () => {
       const card = makeUnit({ ownerId: "p1" });
       const state = createTestGame({
-        deckInput: {
+        setupInput: {
           mode: "main",
           decks: {
             p1: { mainDeck: [], hand: [], prospectDeck: [], marketDeck: [], activePolicies: [] },
@@ -214,7 +214,7 @@ describe("createGame", () => {
 
     it("overrides starting gold per player", () => {
       const state = createTestGame({
-        deckInput: {
+        setupInput: {
           mode: "main",
           decks: {
             p1: { mainDeck: [], hand: [], prospectDeck: [], marketDeck: [], activePolicies: [], gold: 25 },
@@ -231,7 +231,7 @@ describe("createGame", () => {
     it("falls back to config starting_gold when gold not specified", () => {
       const state = createTestGame({
         config: { ...DEFAULT_CONFIG, starting_gold: 15 },
-        deckInput: {
+        setupInput: {
           mode: "main",
           decks: {
             p1: { mainDeck: [], hand: [], prospectDeck: [], marketDeck: [], activePolicies: [] },

--- a/engine/src/__tests__/helpers.ts
+++ b/engine/src/__tests__/helpers.ts
@@ -2,7 +2,7 @@ import prand from "pure-rand";
 import { createGame } from "../create-game";
 import type {
   Card,
-  DeckInput,
+  SetupInput,
   GameConfig,
   GameState,
   InstantEventCard,
@@ -169,10 +169,10 @@ export function createTestGame(overrides?: {
   config?: GameConfig;
   players?: PlayerDescriptor[];
   seed?: string;
-  deckInput?: DeckInput;
+  setupInput?: SetupInput;
 }): MainGameState {
   const players = overrides?.players ?? TWO_PLAYERS;
-  const deckInput: DeckInput = overrides?.deckInput ?? {
+  const setupInput: SetupInput = overrides?.setupInput ?? {
     mode: "main",
     decks: Object.fromEntries(
       players.map((p) => [
@@ -191,7 +191,7 @@ export function createTestGame(overrides?: {
     overrides?.config ?? DEFAULT_CONFIG,
     players,
     overrides?.seed ?? SEED,
-    deckInput,
+    setupInput,
   ) as MainGameState;
 }
 

--- a/engine/src/controller.ts
+++ b/engine/src/controller.ts
@@ -2,7 +2,7 @@ import { applyAction } from "./apply-action";
 import { createGame } from "./create-game";
 import type {
   Action,
-  DeckInput,
+  SetupInput,
   GameConfig,
   GameEvent,
   GameState,
@@ -18,7 +18,7 @@ export interface ControllerOptions {
   config: GameConfig;
   players: PlayerDescriptor[];
   seed: string;
-  deckInput: DeckInput;
+  setupInput: SetupInput;
   adapters: Map<string, PlayerAdapter>;
   /** Called after each action is applied. */
   onEvent?: (events: GameEvent[], state: GameState) => void;
@@ -42,7 +42,7 @@ export class GameController {
       options.config,
       options.players,
       options.seed,
-      options.deckInput,
+      options.setupInput,
     );
     this.adapters = options.adapters;
     this.onEvent = options.onEvent;
@@ -53,7 +53,7 @@ export class GameController {
   /** Resume a game from a session (replays action log or loads snapshot). */
   static fromSession(
     session: Session,
-    deckInput: DeckInput,
+    setupInput: SetupInput,
     adapters: Map<string, PlayerAdapter>,
     onEvent?: (events: GameEvent[], state: GameState) => void,
   ): GameController {
@@ -61,7 +61,7 @@ export class GameController {
       config: session.config,
       players: session.players,
       seed: session.seed,
-      deckInput,
+      setupInput,
       adapters,
       onEvent,
     });

--- a/engine/src/create-game.ts
+++ b/engine/src/create-game.ts
@@ -1,7 +1,7 @@
 import prand from "pure-rand";
 import { extractRngState, shuffle } from "./rng";
 import type {
-  DeckInput,
+  SetupInput,
   GameConfig,
   GameState,
   Grid,
@@ -51,20 +51,20 @@ function createEmptyGrid(config: GameConfig, playerCount: number): Grid {
 /**
  * Initialize a new game. Returns the starting GameState.
  *
- * DeckInput determines the starting mode:
+ * SetupInput determines the starting mode:
  * - "seeding": populate seeding decks + policy pools, start in seeding phase
  * - "main": populate pre-built decks, skip directly to main phase
  *   Accepts optional grid, market, and per-player gold overrides.
  *
  * Callers decide which mode to use based on variant config (e.g.
- * config["seeding-phase"] === "pre-built"). See buildPrebuiltDeckInput()
+ * config["seeding-phase"] === "pre-built"). See buildPrebuiltSetup()
  * for a convenience helper.
  */
 export function createGame(
   config: GameConfig,
   players: PlayerDescriptor[],
   seed: string,
-  deckInput: DeckInput,
+  setupInput: SetupInput,
 ): GameState {
   if (players.length === 0) {
     throw new Error("createGame requires at least one player");
@@ -97,9 +97,9 @@ export function createGame(
   });
 
   // Populate decks based on input mode
-  if (deckInput.mode === "seeding") {
+  if (setupInput.mode === "seeding") {
     for (const ps of playerStates) {
-      const input = deckInput.decks[ps.id];
+      const input = setupInput.decks[ps.id];
       if (!input) {
         throw new Error(`No seeding deck provided for player "${ps.id}"`);
       }
@@ -108,7 +108,7 @@ export function createGame(
     }
   } else {
     for (const ps of playerStates) {
-      const input = deckInput.decks[ps.id];
+      const input = setupInput.decks[ps.id];
       if (!input) {
         throw new Error(`No deck input provided for player "${ps.id}"`);
       }
@@ -134,19 +134,19 @@ export function createGame(
     config,
     players: orderedPlayers,
     grid:
-      deckInput.mode === "main" && deckInput.grid
-        ? deckInput.grid.map((row) => row.map((cell) => ({ ...cell })))
+      setupInput.mode === "main" && setupInput.grid
+        ? setupInput.grid.map((row) => row.map((cell) => ({ ...cell })))
         : createEmptyGrid(config, players.length),
     market:
-      deckInput.mode === "main" && deckInput.market
-        ? [...deckInput.market]
+      setupInput.mode === "main" && setupInput.market
+        ? [...setupInput.market]
         : [],
     rngState: extractRngState(nextRng),
     seed,
     actionLog: [],
   };
 
-  if (deckInput.mode === "seeding") {
+  if (setupInput.mode === "seeding") {
     return {
       ...base,
       phase: "seeding",

--- a/engine/src/index.ts
+++ b/engine/src/index.ts
@@ -21,7 +21,7 @@ export { GameController } from "./controller";
 export { createGame } from "./create-game";
 // Pre-built game setup
 export type { PrebuiltGameInput, PrebuiltPlayerInput } from "./prebuilt";
-export { buildPrebuiltDeckInput } from "./prebuilt";
+export { buildPrebuiltSetup } from "./prebuilt";
 // Rules config
 export {
   buildBaselineConfig,
@@ -35,7 +35,7 @@ export type {
   ActionForState,
   Card,
   CardType,
-  DeckInput,
+  SetupInput,
   DeckName,
   EndedGameState,
   ActivePassiveEvent,

--- a/engine/src/prebuilt.ts
+++ b/engine/src/prebuilt.ts
@@ -1,4 +1,4 @@
-import type { Card, DeckInput, Grid, PolicyCard } from "./types";
+import type { Card, Grid, PolicyCard, SetupInput } from "./types";
 
 export interface PrebuiltPlayerInput {
   mainDeck: Card[];
@@ -19,14 +19,14 @@ export interface PrebuiltGameInput {
 }
 
 /**
- * Build a DeckInput that skips seeding and starts directly in the main phase
+ * Build a SetupInput that skips seeding and starts directly in the main phase
  * with pre-constructed decks, a pre-populated grid, and optional market.
  *
  * Use when variant config has `seeding-phase` set to a non-baseline value
- * (e.g. "pre-built"). The caller inspects config and chooses the DeckInput
+ * (e.g. "pre-built"). The caller inspects config and chooses the SetupInput
  * mode — the engine itself does not route based on config.
  */
-export function buildPrebuiltDeckInput(input: PrebuiltGameInput): DeckInput {
+export function buildPrebuiltSetup(input: PrebuiltGameInput): SetupInput {
   return {
     mode: "main",
     decks: input.players,

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -325,7 +325,7 @@ export interface ApplyResult {
 // Deck Input (for createGame)
 // ---------------------------------------------------------------------------
 
-export type DeckInput =
+export type SetupInput =
   | {
       mode: "seeding";
       decks: Record<string, { seedingDeck: Card[]; policyPool: PolicyCard[] }>;

--- a/rules/ideas.md
+++ b/rules/ideas.md
@@ -46,5 +46,5 @@ This enables:
 - Single player support (see #31)
 
 Engine support landed in #44: callers set `seeding-phase: "pre-built"`
-in variant overrides, then use `buildPrebuiltDeckInput()` to construct
-the deck input with pre-populated grid, market, and per-player gold.
+in variant overrides, then use `buildPrebuiltSetup()` to construct
+the setup input with pre-populated grid, market, and per-player gold.

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -9,7 +9,7 @@ import { join } from "path";
 import {
   BotAdapter,
   GameController,
-  buildPrebuiltDeckInput,
+  buildPrebuiltSetup,
   createGame,
   createInstanceCounter,
   getActivePlayerId,
@@ -49,7 +49,7 @@ const DEFAULT_CONFIG: GameConfig = {
   combat_kill_ratio: 2,
 };
 
-type DeckInput = Parameters<typeof createGame>[3];
+type SetupInput = Parameters<typeof createGame>[3];
 
 function makePlayers(count: number): PlayerDescriptor[] {
   return Array.from({ length: count }, (_, i) => ({
@@ -70,7 +70,7 @@ function makeAdapters(
 function buildSeedingInput(
   players: PlayerDescriptor[],
   defs: CardDefinition[],
-): DeckInput {
+): SetupInput {
   const counter = createInstanceCounter();
   const nonPolicy = defs.filter((d) => d.type !== "policy");
   const policies = defs.filter((d) => d.type === "policy");
@@ -94,13 +94,13 @@ async function runFullGame(opts: {
 }): Promise<GameController> {
   const players = opts.players ?? makePlayers(2);
   const defs = loadCardDefinitionsFromBuild(BUILD_DIR);
-  const deckInput = buildSeedingInput(players, defs);
+  const setupInput = buildSeedingInput(players, defs);
 
   const controller = new GameController({
     config: opts.config ?? DEFAULT_CONFIG,
     players,
     seed: opts.seed ?? "integration-seed",
-    deckInput,
+    setupInput,
     adapters: makeAdapters(players),
   });
 
@@ -208,7 +208,7 @@ describe("determinism", () => {
   it("action log replay produces identical state", async () => {
     const players = makePlayers(2);
     const defs = loadCardDefinitionsFromBuild(BUILD_DIR);
-    const deckInput = buildSeedingInput(players, defs);
+    const setupInput = buildSeedingInput(players, defs);
 
     const controller = await runFullGame({ seed: DET_SEED, players });
     const session = controller.toSession();
@@ -216,7 +216,7 @@ describe("determinism", () => {
     // Replay from action log (no snapshot)
     const replayed = GameController.fromSession(
       { ...session, snapshot: undefined },
-      deckInput,
+      setupInput,
       makeAdapters(players),
     );
 
@@ -232,13 +232,13 @@ describe("determinism", () => {
   it("cross-client portability: session transfer mid-game", async () => {
     const players = makePlayers(2);
     const defs = loadCardDefinitionsFromBuild(BUILD_DIR);
-    const deckInput = buildSeedingInput(players, defs);
+    const setupInput = buildSeedingInput(players, defs);
 
     const controller = new GameController({
       config: DEFAULT_CONFIG,
       players,
       seed: "portability-test",
-      deckInput,
+      setupInput,
       adapters: makeAdapters(players),
     });
 
@@ -252,7 +252,7 @@ describe("determinism", () => {
     const session = controller.toSession(true);
     const c2 = GameController.fromSession(
       session,
-      deckInput,
+      setupInput,
       makeAdapters(players),
     );
 
@@ -296,9 +296,9 @@ describe("real card data", () => {
   it("creates a seeding game with real cards", () => {
     const players = makePlayers(2);
     const defs = loadCardDefinitionsFromBuild(BUILD_DIR);
-    const deckInput = buildSeedingInput(players, defs);
+    const setupInput = buildSeedingInput(players, defs);
 
-    const state = createGame(DEFAULT_CONFIG, players, "real-cards", deckInput);
+    const state = createGame(DEFAULT_CONFIG, players, "real-cards", setupInput);
     expect(state.phase).toBe("seeding");
     expect(state.players[0].seedingDeck.length).toBeGreaterThan(0);
   });
@@ -405,25 +405,25 @@ describe("pre-built game flow", () => {
       };
     }
 
-    const deckInput = buildPrebuiltDeckInput({
+    const setupInput = buildPrebuiltSetup({
       players: playerDecks,
       grid,
     });
 
-    return { players, deckInput, config, seed: opts?.seed ?? "prebuilt-seed" };
+    return { players, setupInput, config, seed: opts?.seed ?? "prebuilt-seed" };
   }
 
   it("starts directly in main phase (no seeding)", () => {
-    const { players, deckInput, config, seed } = buildPrebuiltGame();
-    const state = createGame(config, players, seed, deckInput);
+    const { players, setupInput, config, seed } = buildPrebuiltGame();
+    const state = createGame(config, players, seed, setupInput);
 
     expect(state.phase).toBe("main");
     expect("seedingState" in state).toBe(false);
   });
 
   it("preserves the pre-populated grid", () => {
-    const { players, deckInput, config, seed } = buildPrebuiltGame();
-    const state = createGame(config, players, seed, deckInput);
+    const { players, setupInput, config, seed } = buildPrebuiltGame();
+    const state = createGame(config, players, seed, setupInput);
 
     let locationCount = 0;
     for (const row of state.grid) {
@@ -435,12 +435,12 @@ describe("pre-built game flow", () => {
   });
 
   it("runs a pre-built game to completion with bots", async () => {
-    const { players, deckInput, config, seed } = buildPrebuiltGame();
+    const { players, setupInput, config, seed } = buildPrebuiltGame();
     const controller = new GameController({
       config,
       players,
       seed,
-      deckInput,
+      setupInput,
       adapters: makeAdapters(players),
     });
 
@@ -453,12 +453,12 @@ describe("pre-built game flow", () => {
   });
 
   it("produces a valid session from a pre-built game", async () => {
-    const { players, deckInput, config, seed } = buildPrebuiltGame();
+    const { players, setupInput, config, seed } = buildPrebuiltGame();
     const controller = new GameController({
       config,
       players,
       seed,
-      deckInput,
+      setupInput,
       adapters: makeAdapters(players),
     });
 


### PR DESCRIPTION
## Summary

- Extend `DeckInput` (mode: `"main"`) with optional `grid`, `market`, and per-player `gold` fields so callers can skip seeding with a fully populated game state
- Add `buildPrebuiltDeckInput()` convenience helper and `PrebuiltGameInput`/`PrebuiltPlayerInput` types
- Export new APIs (`DeckInput`, `buildPrebuiltDeckInput`, types) from engine index

Closes #44

## Test plan

- [x] 5 new unit tests in `create-game.test.ts` (grid, market, gold override, fallback, backward compat)
- [x] 4 new integration tests in `integration.test.ts` (pre-built game creation, grid preservation, full bot game to completion, session export)
- [x] All 267 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)