### PR TITLE
#97 — Engine fixes: passives + traps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
       "dependencies": {
         "cards-engine": "workspace:*",
         "idb-keyval": "^6.2.2",
+        "pure-rand": "^8.4.0",
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
@@ -353,5 +354,7 @@
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "cards-test/immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
+
+    "cards-web/pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
       "name": "cards-engine",
       "version": "0.1.0",
       "dependencies": {
+        "chevrotain": "^12.0.0",
         "immer": "^11.1.4",
         "pure-rand": "6",
       },
@@ -60,6 +61,16 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-LoFatS0tnHv6KkCVpIy3qZCih+MxUMvdYiPWLHRri7mhi2vyOOs8OrbZBcLTUEWCS+ktO72nZMy4F96oMhkOHQ=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.8", "", { "os": "win32", "cpu": "x64" }, "sha512-vAn7iXDoUbqFXqVocuq1sMYAd33p8+mmurqJkWl6CtIhobd/O6moe4rY5AJvzbunn/qZCdiDVcveqtkFh1e7Hg=="],
+
+    "@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@12.0.0", "", { "dependencies": { "@chevrotain/gast": "12.0.0", "@chevrotain/types": "12.0.0" } }, "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg=="],
+
+    "@chevrotain/gast": ["@chevrotain/gast@12.0.0", "", { "dependencies": { "@chevrotain/types": "12.0.0" } }, "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ=="],
+
+    "@chevrotain/regexp-to-ast": ["@chevrotain/regexp-to-ast@12.0.0", "", {}, "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA=="],
+
+    "@chevrotain/types": ["@chevrotain/types@12.0.0", "", {}, "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA=="],
+
+    "@chevrotain/utils": ["@chevrotain/utils@12.0.0", "", {}, "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
@@ -230,6 +241,8 @@
     "cards-test": ["cards-test@workspace:test"],
 
     "cards-web": ["cards-web@workspace:clients/web"],
+
+    "chevrotain": ["chevrotain@12.0.0", "", { "dependencies": { "@chevrotain/cst-dts-gen": "12.0.0", "@chevrotain/gast": "12.0.0", "@chevrotain/regexp-to-ast": "12.0.0", "@chevrotain/types": "12.0.0", "@chevrotain/utils": "12.0.0" } }, "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "cards-engine": "workspace:*",
-    "idb-keyval": "^6.2.2"
+    "idb-keyval": "^6.2.2",
+    "pure-rand": "^8.4.0"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^5.0.0",

--- a/clients/web/src/components/StartScreen.svelte
+++ b/clients/web/src/components/StartScreen.svelte
@@ -8,10 +8,11 @@
     clearError,
   } from "../lib/gameStore.svelte";
   import { deleteSession } from "../lib/persistence";
+  import { generateSeed } from "../lib/gameSetup";
 
   let p1Name = $state("Player 1");
   let p2Name = $state("Player 2");
-  let seed = $state("");
+  let seed = $state(generateSeed());
   let skipSeeding = $state(false);
 
   $effect(() => {
@@ -20,10 +21,6 @@
 
   function handleStart() {
     startNewGame(p1Name, p2Name, seed || undefined, skipSeeding);
-  }
-
-  function handleQuickStart() {
-    startNewGame(p1Name, p2Name, seed || undefined, true);
   }
 
   async function handleLoad(key: string) {
@@ -90,21 +87,12 @@
         <input type="checkbox" bind:checked={skipSeeding} class="accent-amber-600" />
         Skip seeding phase
       </label>
-      <div class="flex gap-2">
-        <button
-          onclick={handleStart}
-          class="flex-1 rounded bg-amber-600 px-4 py-2 font-semibold text-white hover:bg-amber-500"
-        >
-          Start Game
-        </button>
-        <button
-          onclick={handleQuickStart}
-          class="rounded bg-stone-600 px-4 py-2 text-sm text-stone-200 hover:bg-stone-500"
-          title="Auto-play seeding phase with random choices"
-        >
-          Quick Start
-        </button>
-      </div>
+      <button
+        onclick={handleStart}
+        class="w-full rounded bg-amber-600 px-4 py-2 font-semibold text-white hover:bg-amber-500"
+      >
+        Start Game
+      </button>
     </div>
 
     {#if sessions.length > 0}

--- a/clients/web/src/components/StartScreen.svelte
+++ b/clients/web/src/components/StartScreen.svelte
@@ -12,13 +12,14 @@
   let p1Name = $state("Player 1");
   let p2Name = $state("Player 2");
   let seed = $state("");
+  let skipSeeding = $state(false);
 
   $effect(() => {
     refreshSessions();
   });
 
   function handleStart() {
-    startNewGame(p1Name, p2Name, seed || undefined);
+    startNewGame(p1Name, p2Name, seed || undefined, skipSeeding);
   }
 
   async function handleLoad(key: string) {
@@ -81,6 +82,10 @@
           class="w-full rounded bg-stone-700 px-3 py-2 text-stone-100 placeholder-stone-400"
         />
       </div>
+      <label class="flex items-center gap-2 text-stone-300">
+        <input type="checkbox" bind:checked={skipSeeding} class="accent-amber-600" />
+        Skip seeding phase
+      </label>
       <button
         onclick={handleStart}
         class="w-full rounded bg-amber-600 px-4 py-2 font-semibold text-white hover:bg-amber-500"

--- a/clients/web/src/lib/eventDescriptions.ts
+++ b/clients/web/src/lib/eventDescriptions.ts
@@ -118,6 +118,16 @@ export function describeEvent(event: GameEvent, r?: NameResolvers): string {
       return `${p(event.playerId, r)} deck constructed`;
     case "policies_assigned":
       return `${p(event.playerId, r)} assigned policies: ${event.policyIds.map((id) => c(id, r)).join(", ")}`;
+    case "card_discarded":
+      return `${p(event.playerId, r)} discarded ${c(event.cardId, r)} (${event.reason})`;
+    case "unit_buffed":
+      return `${c(event.unitId, r)} got ${event.delta > 0 ? "+" : ""}${event.delta} ${event.stat}`;
+    case "cards_revealed":
+      return `${p(event.playerId, r)} revealed ${event.cardIds.length} card(s)`;
+    case "unit_controlled":
+      return `${p(event.controllerId, r)} took control of ${c(event.unitId, r)}`;
+    case "contest_resolved":
+      return `${event.stat} contest: ${c(event.attackerId, r)} (${event.attackerPower}) vs ${c(event.defenderId, r)} (${event.defenderPower}) — ${c(event.winnerId, r)} wins`;
     default:
       return `Unknown event: ${(event as { type: string }).type}`;
   }

--- a/clients/web/src/lib/gameSetup.ts
+++ b/clients/web/src/lib/gameSetup.ts
@@ -1,12 +1,15 @@
 import {
   createInstanceCounter,
   instantiateCards,
+  buildPrebuiltSetup,
   type Card,
   type CardDefinition,
   type GameConfig,
   type PlayerDescriptor,
   type PolicyCard,
   type SetupInput,
+  type Grid,
+  type LocationCard,
 } from "cards-engine";
 import cardDefsJson from "@library/all.json";
 
@@ -49,4 +52,78 @@ export function buildSeedingSetup(
     };
   }
   return { mode: "seeding" as const, decks };
+}
+
+/**
+ * Build a SetupInput that skips seeding and goes straight to main phase.
+ * Distributes cards evenly to players: locations go to prospect decks,
+ * non-locations split between hand and main deck. Builds a basic grid
+ * with locations placed.
+ */
+export function buildMainSetup(
+  players: PlayerDescriptor[],
+  config: GameConfig,
+): SetupInput {
+  const defs = getCardDefinitions();
+  const counter = createInstanceCounter();
+
+  const locations = defs.filter((d) => d.type === "location");
+  const policies = defs.filter((d) => d.type === "policy");
+  const other = defs.filter((d) => d.type !== "location" && d.type !== "policy");
+
+  const handSize = Number(config.starting_hand_size ?? 5);
+  const gridPadding = Number(config.grid_padding ?? 2);
+  const gridSize = players.length + gridPadding;
+
+  // Build per-player decks
+  const playerDecks: Record<string, {
+    mainDeck: Card[];
+    hand: Card[];
+    prospectDeck: Card[];
+    marketDeck: Card[];
+    activePolicies: PolicyCard[];
+  }> = {};
+
+  for (const p of players) {
+    const playerLocs = instantiateCards(locations, p.id, counter);
+    const playerOther = instantiateCards(other, p.id, counter);
+    const playerPolicies = instantiateCards(policies, p.id, counter) as PolicyCard[];
+
+    playerDecks[p.id] = {
+      hand: playerOther.splice(0, handSize),
+      mainDeck: playerOther,
+      prospectDeck: playerLocs,
+      marketDeck: [],
+      activePolicies: playerPolicies.length > 0 ? [playerPolicies[0]] : [],
+    };
+  }
+
+  // Build grid with locations placed
+  const grid: Grid = [];
+  for (let r = 0; r < gridSize; r++) {
+    grid.push(
+      Array.from({ length: gridSize }, () => ({ location: null, units: [], items: [] })),
+    );
+  }
+
+  // Place locations from each player's prospect deck onto the grid
+  let cellIdx = 0;
+  const locsPerPlayer = Math.floor((gridSize * gridSize) / players.length);
+  for (const p of players) {
+    const deck = playerDecks[p.id];
+    const locsToPlace = deck.prospectDeck.splice(0, locsPerPlayer);
+    for (const loc of locsToPlace) {
+      const r = Math.floor(cellIdx / gridSize);
+      const c = cellIdx % gridSize;
+      if (r < gridSize) {
+        grid[r][c].location = loc as LocationCard;
+      }
+      cellIdx++;
+    }
+  }
+
+  return buildPrebuiltSetup({
+    players: playerDecks,
+    grid,
+  });
 }

--- a/clients/web/src/lib/gameSetup.ts
+++ b/clients/web/src/lib/gameSetup.ts
@@ -1,3 +1,4 @@
+import prand from "pure-rand";
 import {
   createInstanceCounter,
   instantiateCards,
@@ -12,6 +13,10 @@ import {
   type LocationCard,
 } from "cards-engine";
 import cardDefsJson from "@library/all.json";
+
+export function generateSeed(): string {
+  return crypto.randomUUID().slice(0, 8);
+}
 
 export const DEFAULT_CONFIG: GameConfig = {
   starting_gold: 10,
@@ -63,9 +68,11 @@ export function buildSeedingSetup(
 export function buildMainSetup(
   players: PlayerDescriptor[],
   config: GameConfig,
+  seed: string,
 ): SetupInput {
   const defs = getCardDefinitions();
   const counter = createInstanceCounter();
+  let rng: prand.RandomGenerator = prand.mersenne(hashSeed(seed));
 
   const locations = defs.filter((d) => d.type === "location");
   const policies = defs.filter((d) => d.type === "policy");
@@ -85,15 +92,21 @@ export function buildMainSetup(
   }> = {};
 
   for (const p of players) {
-    const playerLocs = instantiateCards(locations, p.id, counter);
-    const playerOther = instantiateCards(other, p.id, counter);
+    const playerLocs = shuffleCards(instantiateCards(locations, p.id, counter));
+    const playerOther = shuffleCards(instantiateCards(other, p.id, counter));
     const playerPolicies = instantiateCards(policies, p.id, counter) as PolicyCard[];
 
+    const hand = playerOther.splice(0, handSize);
+    // Split remaining cards: half to main deck, half to market deck
+    const midpoint = Math.floor(playerOther.length / 2);
+    const mainDeck = playerOther.slice(0, midpoint);
+    const marketDeck = playerOther.slice(midpoint);
+
     playerDecks[p.id] = {
-      hand: playerOther.splice(0, handSize),
-      mainDeck: playerOther,
+      hand,
+      mainDeck,
       prospectDeck: playerLocs,
-      marketDeck: [],
+      marketDeck,
       activePolicies: playerPolicies.length > 0 ? [playerPolicies[0]] : [],
     };
   }
@@ -122,8 +135,36 @@ export function buildMainSetup(
     }
   }
 
+  // Pre-populate market by drawing from each player's market deck
+  const marketSize = Number(config.market_draw_count ?? 3);
+  const market: Card[] = [];
+  for (const p of players) {
+    const deck = playerDecks[p.id];
+    market.push(...deck.marketDeck.splice(0, marketSize));
+  }
+
   return buildPrebuiltSetup({
     players: playerDecks,
     grid,
+    market,
   });
+
+  function shuffleCards<T>(arr: T[]): T[] {
+    const result = [...arr];
+    for (let i = result.length - 1; i > 0; i--) {
+      const [j, nextRng] = prand.uniformIntDistribution(0, i, rng);
+      rng = nextRng;
+      [result[i], result[j]] = [result[j], result[i]];
+    }
+    return result;
+  }
+}
+
+function hashSeed(seed: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < seed.length; i++) {
+    hash ^= seed.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
 }

--- a/clients/web/src/lib/gameStore.svelte.ts
+++ b/clients/web/src/lib/gameStore.svelte.ts
@@ -279,10 +279,10 @@ export function startNewGame(
     { id: "p2", name: p2Name || "Player 2" },
   ];
 
-  const setupInput = skipSeeding
-    ? buildMainSetup(players, DEFAULT_CONFIG)
-    : buildSeedingSetup(players);
   const gameSeed = seed || crypto.randomUUID();
+  const setupInput = skipSeeding
+    ? buildMainSetup(players, DEFAULT_CONFIG, gameSeed)
+    : buildSeedingSetup(players);
 
   const adapters = new Map<string, HotseatAdapter>();
   for (const p of players) {

--- a/clients/web/src/lib/gameStore.svelte.ts
+++ b/clients/web/src/lib/gameStore.svelte.ts
@@ -8,7 +8,7 @@ import {
   type VisibleState,
 } from "cards-engine";
 import { HotseatAdapter } from "./HotseatAdapter";
-import { DEFAULT_CONFIG, buildSeedingSetup } from "./gameSetup";
+import { DEFAULT_CONFIG, buildSeedingSetup, buildMainSetup } from "./gameSetup";
 import { autoSave, listSessions, loadSession, saveSession } from "./persistence";
 
 // ---------------------------------------------------------------------------
@@ -156,13 +156,16 @@ export function startNewGame(
   p1Name: string,
   p2Name: string,
   seed?: string,
+  skipSeeding = false,
 ): void {
   players = [
     { id: "p1", name: p1Name || "Player 1" },
     { id: "p2", name: p2Name || "Player 2" },
   ];
 
-  const setupInput = buildSeedingSetup(players);
+  const setupInput = skipSeeding
+    ? buildMainSetup(players, DEFAULT_CONFIG)
+    : buildSeedingSetup(players);
   const gameSeed = seed || crypto.randomUUID();
 
   const adapters = new Map<string, HotseatAdapter>();
@@ -175,7 +178,7 @@ export function startNewGame(
 
   _eventLog = [];
   _error = null;
-  _gamePhase = "seeding";
+  _gamePhase = skipSeeding ? "main" : "seeding";
   isFirstTurn = true;
   autoSaveFailCount = 0;
 
@@ -259,7 +262,9 @@ export function selectAction(action: Action): void {
     const resolve = resolveAction;
     resolveAction = null;
     rejectAction = null;
-    resolve(action);
+    // Strip Svelte's $state proxy before passing back to the engine.
+    // Immer's produce uses Object.defineProperty which conflicts with $state proxies.
+    resolve(JSON.parse(JSON.stringify(action)));
   }
 }
 

--- a/engine/package.json
+++ b/engine/package.json
@@ -8,6 +8,7 @@
     "test": "bun test src/__tests__/"
   },
   "dependencies": {
+    "chevrotain": "^12.0.0",
     "immer": "^11.1.4",
     "pure-rand": "6"
   }

--- a/engine/src/__tests__/apply-action.test.ts
+++ b/engine/src/__tests__/apply-action.test.ts
@@ -130,4 +130,24 @@ describe("applyAction", () => {
       ).toThrow("not found on grid");
     });
   });
+
+  describe("frozen action objects", () => {
+    it("accepts Object.freeze'd actions without throwing", () => {
+      const state = createTestGame();
+      const action = Object.freeze({
+        type: "pass" as const,
+        playerId: state.turn.activePlayerId,
+      });
+      expect(() => applyAction(state, action)).not.toThrow();
+    });
+
+    it("accepts deeply frozen actions without throwing", () => {
+      const state = createTestGame();
+      const action = Object.freeze({
+        type: "draw" as const,
+        playerId: Object.freeze(state.turn.activePlayerId),
+      });
+      expect(() => applyAction(state, action)).not.toThrow();
+    });
+  });
 });

--- a/engine/src/__tests__/apply-action.test.ts
+++ b/engine/src/__tests__/apply-action.test.ts
@@ -117,8 +117,8 @@ describe("applyAction", () => {
     });
   });
 
-  describe("unimplemented actions", () => {
-    it("throws for activate action (deferred to #20)", () => {
+  describe("activate action", () => {
+    it("throws when card is not on the grid", () => {
       const state = createTestGame();
       expect(() =>
         applyAction(state, {
@@ -127,7 +127,7 @@ describe("applyAction", () => {
           cardId: "some-card",
           actionName: "test",
         }),
-      ).toThrow("not yet implemented");
+      ).toThrow("not found on grid");
     });
   });
 });

--- a/engine/src/__tests__/effect-dsl.test.ts
+++ b/engine/src/__tests__/effect-dsl.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { produce, type Draft } from "immer";
+import prand from "pure-rand";
+import { parse, type Expression } from "../effect-dsl";
+import { executeEffect, type ExecutionContext } from "../effect-dsl/executor";
+import type { MainGameState, GameEvent } from "../types";
+import { rebuildListeners } from "../listeners/rebuild";
+import {
+  createTestGame,
+  makeUnit,
+  makeLocation,
+  resetIds,
+} from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getPlayers(state: MainGameState) {
+  const active = state.turn.activePlayerId;
+  const other = state.players.find((p) => p.id !== active)!.id;
+  const activeIdx = state.players.findIndex((p) => p.id === active);
+  const otherIdx = state.players.findIndex((p) => p.id === other);
+  return { active, other, activeIdx, otherIdx };
+}
+
+function gameWith(
+  mutate: (d: Draft<MainGameState>, p: ReturnType<typeof getPlayers>) => void,
+): MainGameState {
+  const base = createTestGame();
+  const players = getPlayers(base);
+  return produce(base, (d) => mutate(d, players));
+}
+
+/** Run a DSL effect on a game state and return the updated state + events. */
+function runEffect(
+  state: MainGameState,
+  effectStr: string,
+  overrides?: Partial<ExecutionContext>,
+) {
+  const events: GameEvent[] = [];
+  const { active, activeIdx } = getPlayers(state);
+  const { queries } = rebuildListeners(state);
+
+  const nextState = produce(state, (draft) => {
+    const rng = prand.mersenne.fromState(draft.rngState);
+    const ctx: ExecutionContext = {
+      draft,
+      playerId: active,
+      emit: (e) => { events.push(e); },
+      events,
+      queries,
+      rng,
+      ...overrides,
+    };
+    const result = executeEffect(effectStr, ctx);
+    draft.rngState = (result.rng.getState?.() ?? draft.rngState) as number[];
+  });
+
+  return { state: nextState as MainGameState, events, activeIdx };
+}
+
+beforeEach(() => resetIds());
+
+// ---------------------------------------------------------------------------
+// Parser tests
+// ---------------------------------------------------------------------------
+
+describe("Effect DSL parser", () => {
+  it("parses simple verb with value", () => {
+    const ast = parse("gold[3]");
+    expect(ast).toHaveLength(1); // one compound member
+    expect(ast[0]).toHaveLength(1); // one step in chain
+    expect(ast[0][0].primitive.verb).toBe("gold");
+    expect(ast[0][0].primitive.value).toBe(3);
+  });
+
+  it("parses negative values", () => {
+    const ast = parse("gold[-2]");
+    expect(ast[0][0].primitive.value).toBe(-2);
+  });
+
+  it("parses dotted verb", () => {
+    const ast = parse("contest.strength(enemy)");
+    expect(ast[0][0].primitive.verb).toBe("contest");
+    expect(ast[0][0].primitive.subVerb).toBe("strength");
+  });
+
+  it("parses compound targets with +", () => {
+    const ast = parse("buff.strength(all + friendly)[2]~turn");
+    const target = ast[0][0].primitive.target!;
+    expect(target.tokens).toHaveLength(2);
+    expect(target.tokens[0].name).toBe("all");
+    expect(target.tokens[1].name).toBe("friendly");
+  });
+
+  it("parses target count inside parens", () => {
+    const ast = parse("move(friendly[2])");
+    const target = ast[0][0].primitive.target!;
+    expect(target.tokens[0].name).toBe("friendly");
+    expect(target.tokens[0].count).toBe(2);
+  });
+
+  it("parses modifiers", () => {
+    const ast = parse("move(friendly)~ignore_blocked");
+    expect(ast[0][0].primitive.modifiers).toEqual(["ignore_blocked"]);
+  });
+
+  it("parses compound effects with +", () => {
+    const ast = parse("move(self) + gold[1]");
+    expect(ast).toHaveLength(2);
+    expect(ast[0][0].primitive.verb).toBe("move");
+    expect(ast[1][0].primitive.verb).toBe("gold");
+  });
+
+  it("parses chain with >", () => {
+    const ast = parse("reveal(deck)[3] > pick[1]");
+    expect(ast).toHaveLength(1);
+    expect(ast[0]).toHaveLength(2);
+    expect(ast[0][0].primitive.verb).toBe("reveal");
+    expect(ast[0][1].primitive.verb).toBe("pick");
+  });
+
+  it("parses contest with win consequence", () => {
+    const ast = parse("contest.charisma(enemy + adjacent) > control(target)~round");
+    expect(ast[0]).toHaveLength(1); // single step (contest with consequence)
+    const step = ast[0][0];
+    expect(step.primitive.verb).toBe("contest");
+    expect(step.consequence).toBeDefined();
+    expect(step.consequence!.winEffect[0].primitive.verb).toBe("control");
+  });
+
+  it("parses contest with ternary win:lose", () => {
+    const ast = parse("contest.strength(enemy)[3] > gold[3] : gold[-2]");
+    const step = ast[0][0];
+    expect(step.consequence).toBeDefined();
+    expect(step.consequence!.winEffect[0].primitive.verb).toBe("gold");
+    expect(step.consequence!.winEffect[0].primitive.value).toBe(3);
+    expect(step.consequence!.loseEffect).toBeDefined();
+    expect(step.consequence!.loseEffect![0].primitive.value).toBe(-2);
+  });
+
+  it("rejects invalid input", () => {
+    expect(() => parse("!!!")).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Executor tests — simple verbs
+// ---------------------------------------------------------------------------
+
+describe("Effect DSL executor", () => {
+  it("gold[3]: adds 3 gold to active player", () => {
+    const state = gameWith((d, p) => {
+      d.players[p.activeIdx].gold = 5;
+    });
+    const { state: next, activeIdx, events } = runEffect(state, "gold[3]");
+    expect(next.players[activeIdx].gold).toBe(8);
+    expect(events.some((e) => e.type === "gold_changed")).toBe(true);
+  });
+
+  it("gold[-2]: removes 2 gold from active player", () => {
+    const state = gameWith((d, p) => {
+      d.players[p.activeIdx].gold = 5;
+    });
+    const { state: next, activeIdx } = runEffect(state, "gold[-2]");
+    expect(next.players[activeIdx].gold).toBe(3);
+  });
+
+  it("vp[1]: adds 1 VP to active player", () => {
+    const state = gameWith((d, p) => {
+      d.players[p.activeIdx].vp = 0;
+    });
+    const { state: next, activeIdx } = runEffect(state, "vp[1]");
+    expect(next.players[activeIdx].vp).toBe(1);
+  });
+
+  it("draw[2]: draws 2 cards from deck to hand", () => {
+    const state = gameWith((d, p) => {
+      d.players[p.activeIdx].mainDeck.push(
+        makeUnit({ ownerId: p.active }),
+        makeUnit({ ownerId: p.active }),
+        makeUnit({ ownerId: p.active }),
+      );
+      d.players[p.activeIdx].hand = [];
+    });
+    const { state: next, activeIdx } = runEffect(state, "draw[2]");
+    expect(next.players[activeIdx].hand).toHaveLength(2);
+    expect(next.players[activeIdx].mainDeck).toHaveLength(1);
+  });
+
+  it("kill(self): kills the acting unit", () => {
+    const state = gameWith((d, p) => {
+      const unit = makeUnit({ ownerId: p.active });
+      d.grid[0][0].location = makeLocation({ ownerId: p.active });
+      d.grid[0][0].units.push(unit);
+    });
+    const unit = state.grid[0][0].units[0];
+    const { state: next, events } = runEffect(state, "kill(self)", {
+      actingUnitId: unit.id,
+      position: { row: 0, col: 0 },
+    });
+    expect(next.grid[0][0].units).toHaveLength(0);
+    expect(events.some((e) => e.type === "unit_killed")).toBe(true);
+  });
+
+  it("injure(enemy): injures target enemy unit", () => {
+    const state = gameWith((d, p) => {
+      d.grid[0][0].location = makeLocation({ ownerId: p.active });
+      d.grid[0][0].units.push(makeUnit({ ownerId: p.active }));
+      d.grid[0][0].units.push(makeUnit({ ownerId: p.other }));
+    });
+    const actingUnit = state.grid[0][0].units[0];
+    const enemyUnit = state.grid[0][0].units[1];
+    const { state: next, events } = runEffect(state, "injure(enemy)", {
+      actingUnitId: actingUnit.id,
+      targetId: enemyUnit.id,
+      position: { row: 0, col: 0 },
+    });
+    const injured = next.grid[0][0].units.find((u) => u.id === enemyUnit.id);
+    expect(injured?.injured).toBe(true);
+    expect(events.some((e) => e.type === "unit_injured")).toBe(true);
+  });
+
+  it("compound: vp[1] + kill(self)", () => {
+    const state = gameWith((d, p) => {
+      d.players[p.activeIdx].vp = 0;
+      const unit = makeUnit({ ownerId: p.active });
+      d.grid[0][0].location = makeLocation({ ownerId: p.active });
+      d.grid[0][0].units.push(unit);
+    });
+    const unit = state.grid[0][0].units[0];
+    const { state: next, activeIdx, events } = runEffect(state, "vp[1] + kill(self)", {
+      actingUnitId: unit.id,
+      position: { row: 0, col: 0 },
+    });
+    expect(next.players[activeIdx].vp).toBe(1);
+    expect(next.grid[0][0].units).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Executor — buffs
+// ---------------------------------------------------------------------------
+
+describe("Effect DSL executor — buffs", () => {
+  it("buff.strength(all + friendly)[2]~turn: applies stat modifier to all friendly units", () => {
+    const state = gameWith((d, p) => {
+      d.grid[0][0].location = makeLocation({ ownerId: p.active });
+      d.grid[0][0].units.push(makeUnit({ ownerId: p.active, strength: 5 }));
+      d.grid[0][0].units.push(makeUnit({ ownerId: p.active, strength: 3 }));
+      d.grid[0][0].units.push(makeUnit({ ownerId: p.other, strength: 5 }));
+    });
+    const actingUnit = state.grid[0][0].units[0];
+    const { state: next, events } = runEffect(
+      state,
+      "buff.strength(all + friendly)[2]~turn",
+      { actingUnitId: actingUnit.id, position: { row: 0, col: 0 } },
+    );
+    // Both friendly units should have the modifier
+    const friendlyUnits = next.grid[0][0].units.filter(
+      (u) => u.ownerId === state.turn.activePlayerId,
+    );
+    for (const u of friendlyUnits) {
+      expect(u.statModifiers).toBeDefined();
+      expect(u.statModifiers!.some((m) => m.stat === "strength" && m.delta === 2)).toBe(true);
+    }
+    // Enemy unit should NOT have the modifier
+    const enemyUnit = next.grid[0][0].units.find(
+      (u) => u.ownerId !== state.turn.activePlayerId,
+    );
+    expect(enemyUnit?.statModifiers ?? []).toHaveLength(0);
+    expect(events.filter((e) => e.type === "unit_buffed")).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Executor — contests
+// ---------------------------------------------------------------------------
+
+describe("Effect DSL executor — contests", () => {
+  it("contest.strength(enemy): resolves with default consequence (loser injured)", () => {
+    const state = gameWith((d, p) => {
+      d.grid[0][0].location = makeLocation({ ownerId: p.active });
+      d.grid[0][0].units.push(makeUnit({ ownerId: p.active, strength: 10 }));
+      d.grid[0][0].units.push(makeUnit({ ownerId: p.other, strength: 1 }));
+    });
+    const actingUnit = state.grid[0][0].units[0];
+    const enemyUnit = state.grid[0][0].units[1];
+    const { events } = runEffect(state, "contest.strength(enemy)", {
+      actingUnitId: actingUnit.id,
+      targetId: enemyUnit.id,
+      position: { row: 0, col: 0 },
+    });
+    // With str 10 vs 1 + d6 each, the strong unit should almost certainly win
+    // and the loser should be injured or killed
+    expect(
+      events.some((e) => e.type === "unit_injured" || e.type === "unit_killed"),
+    ).toBe(true);
+  });
+});

--- a/engine/src/__tests__/effect-dsl.test.ts
+++ b/engine/src/__tests__/effect-dsl.test.ts
@@ -3,9 +3,10 @@ import { produce, type Draft } from "immer";
 import prand from "pure-rand";
 import { parse } from "../effect-dsl";
 import { executeEffect, type ExecutionContext } from "../effect-dsl/executor";
-import type { MainGameState, GameEvent } from "../types";
+import type { MainGameState, GameEvent, ItemCard } from "../types";
 import { applyAction } from "../apply-action";
-import { makeInstantEvent } from "./helpers";
+import { getValidActions } from "../valid-actions";
+import { makeInstantEvent, makeItem } from "./helpers";
 import { rebuildListeners } from "../listeners/rebuild";
 import {
   createTestGame,
@@ -200,7 +201,6 @@ describe("Effect DSL executor", () => {
     const unit = state.grid[0][0].units[0];
     const { state: next, events } = runEffect(state, "kill(self)", {
       actingUnitId: unit.id,
-      position: { row: 0, col: 0 },
     });
     expect(next.grid[0][0].units).toHaveLength(0);
     expect(events.some((e) => e.type === "unit_killed")).toBe(true);
@@ -217,7 +217,6 @@ describe("Effect DSL executor", () => {
     const { state: next, events } = runEffect(state, "injure(enemy)", {
       actingUnitId: actingUnit.id,
       targetId: enemyUnit.id,
-      position: { row: 0, col: 0 },
     });
     const injured = next.grid[0][0].units.find((u) => u.id === enemyUnit.id);
     expect(injured?.injured).toBe(true);
@@ -234,7 +233,6 @@ describe("Effect DSL executor", () => {
     const unit = state.grid[0][0].units[0];
     const { state: next, activeIdx, events } = runEffect(state, "vp[1] + kill(self)", {
       actingUnitId: unit.id,
-      position: { row: 0, col: 0 },
     });
     expect(next.players[activeIdx].vp).toBe(1);
     expect(next.grid[0][0].units).toHaveLength(0);
@@ -257,7 +255,7 @@ describe("Effect DSL executor — buffs", () => {
     const { state: next, events } = runEffect(
       state,
       "buff.strength(all + friendly)[2]~turn",
-      { actingUnitId: actingUnit.id, position: { row: 0, col: 0 } },
+      { actingUnitId: actingUnit.id },
     );
     // Both friendly units should have the modifier
     const friendlyUnits = next.grid[0][0].units.filter(
@@ -281,7 +279,7 @@ describe("Effect DSL executor — buffs", () => {
 // ---------------------------------------------------------------------------
 
 describe("Effect DSL executor — contests", () => {
-  it("contest.strength(enemy): resolves with default consequence (loser injured)", () => {
+  it("contest.strength(enemy): emits contest_resolved and applies default consequence", () => {
     const state = gameWith((d, p) => {
       d.grid[0][0].location = makeLocation({ ownerId: p.active });
       d.grid[0][0].units.push(makeUnit({ ownerId: p.active, strength: 10 }));
@@ -292,13 +290,202 @@ describe("Effect DSL executor — contests", () => {
     const { events } = runEffect(state, "contest.strength(enemy)", {
       actingUnitId: actingUnit.id,
       targetId: enemyUnit.id,
-      position: { row: 0, col: 0 },
     });
-    // With str 10 vs 1 + d6 each, the strong unit should almost certainly win
-    // and the loser should be injured or killed
+    // Contest event must always be emitted regardless of outcome
+    expect(events.some((e) => e.type === "contest_resolved")).toBe(true);
+    // Default strength consequence: loser is injured or killed
     expect(
       events.some((e) => e.type === "unit_injured" || e.type === "unit_killed"),
     ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Executor — gold floor
+// ---------------------------------------------------------------------------
+
+describe("Effect DSL executor — gold floor", () => {
+  it("gold[-10] does not go below zero", () => {
+    const state = gameWith((d, p) => {
+      d.players[p.activeIdx].gold = 3;
+    });
+    const { state: next, activeIdx } = runEffect(state, "gold[-10]");
+    expect(next.players[activeIdx].gold).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Executor — stat modifier expiry
+// ---------------------------------------------------------------------------
+
+describe("Effect DSL — stat modifier expiry", () => {
+  it("buff.strength~turn expires after end of turn", () => {
+    const state = gameWith((d, p) => {
+      d.grid[0][0].location = makeLocation({ ownerId: p.active });
+      d.grid[0][0].units.push(makeUnit({ ownerId: p.active, strength: 5 }));
+      d.players[p.activeIdx].mainDeck.push(makeUnit({ ownerId: p.active }));
+      d.players[p.otherIdx].mainDeck.push(makeUnit({ ownerId: p.other }));
+    });
+    const unit = state.grid[0][0].units[0];
+    const { active, other, activeIdx } = getPlayers(state);
+
+    // Apply buff
+    const { state: buffed } = runEffect(state, "buff.strength(all + friendly)[2]~turn", {
+      actingUnitId: unit.id,
+    });
+
+    // Verify modifier is present
+    const buffedUnit = (buffed as MainGameState).grid[0][0].units[0];
+    expect(buffedUnit.statModifiers).toHaveLength(1);
+
+    // Pass both players → triggers runEndOfTurn for active player
+    const { state: s1 } = applyAction(buffed, { type: "pass", playerId: active });
+    const { state: s2 } = applyAction(s1, { type: "pass", playerId: other });
+    const ns = s2 as MainGameState;
+
+    // Modifier should be expired after the turn ended
+    const expiredUnit = ns.grid[0][0].units.find((u) => u.id === unit.id);
+    expect(expiredUnit?.statModifiers ?? []).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Equipped items following units
+// ---------------------------------------------------------------------------
+
+describe("equipped items follow units", () => {
+  it("enter: equipped item moves from HQ to grid with unit", () => {
+    const state = gameWith((d, p) => {
+      const unit = makeUnit({ ownerId: p.active });
+      const item = makeItem({ ownerId: p.active, equippedTo: unit.id });
+      d.players[p.activeIdx].hq.push(unit, item);
+      d.grid[0][0].location = makeLocation({ ownerId: p.active });
+    });
+    const { active, activeIdx } = getPlayers(state);
+    const unit = state.players[activeIdx].hq.find((c) => c.type === "unit")!;
+
+    const { state: next } = applyAction(state, {
+      type: "enter",
+      playerId: active,
+      unitId: unit.id,
+      row: 0,
+      col: 0,
+    });
+    const ns = next as MainGameState;
+
+    expect(ns.grid[0][0].units).toHaveLength(1);
+    expect(ns.grid[0][0].items).toHaveLength(1);
+    expect((ns.grid[0][0].items[0] as ItemCard).equippedTo).toBe(unit.id);
+    expect(ns.players[activeIdx].hq.filter((c) => c.type === "item")).toHaveLength(0);
+  });
+
+  it("move: equipped item moves between grid cells with unit", () => {
+    const state = gameWith((d, p) => {
+      const unit = makeUnit({ ownerId: p.active });
+      const item = makeItem({ ownerId: p.active, equippedTo: unit.id });
+      d.grid[0][0].location = makeLocation({ ownerId: p.active });
+      d.grid[0][1].location = makeLocation({ ownerId: p.active });
+      d.grid[0][0].units.push(unit);
+      d.grid[0][0].items.push(item);
+    });
+    const { active } = getPlayers(state);
+    const unit = state.grid[0][0].units[0];
+
+    const { state: next } = applyAction(state, {
+      type: "move",
+      playerId: active,
+      unitId: unit.id,
+      row: 0,
+      col: 1,
+    });
+    const ns = next as MainGameState;
+
+    expect(ns.grid[0][0].units).toHaveLength(0);
+    expect(ns.grid[0][0].items).toHaveLength(0);
+    expect(ns.grid[0][1].units).toHaveLength(1);
+    expect(ns.grid[0][1].items).toHaveLength(1);
+  });
+
+  it("unit without equipment moves without affecting other items", () => {
+    const state = gameWith((d, p) => {
+      const unit = makeUnit({ ownerId: p.active });
+      const looseItem = makeItem({ ownerId: p.active }); // not equipped
+      d.grid[0][0].location = makeLocation({ ownerId: p.active });
+      d.grid[0][1].location = makeLocation({ ownerId: p.active });
+      d.grid[0][0].units.push(unit);
+      d.grid[0][0].items.push(looseItem);
+    });
+    const { active } = getPlayers(state);
+    const unit = state.grid[0][0].units[0];
+
+    const { state: next } = applyAction(state, {
+      type: "move",
+      playerId: active,
+      unitId: unit.id,
+      row: 0,
+      col: 1,
+    });
+    const ns = next as MainGameState;
+
+    expect(ns.grid[0][0].items).toHaveLength(1); // loose item stays
+    expect(ns.grid[0][1].items).toHaveLength(0); // nothing followed
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Valid actions — activate
+// ---------------------------------------------------------------------------
+
+describe("valid actions — activate", () => {
+  it("unit with gold[5] action appears in valid actions", () => {
+    const state = gameWith((d, p) => {
+      const unit = makeUnit({
+        ownerId: p.active,
+        actions: [{ name: "pilgrimage", apCost: 2, effect: "gold[5]" }],
+      });
+      d.grid[0][0].location = makeLocation({ ownerId: p.active });
+      d.grid[0][0].units.push(unit);
+    });
+    const { active } = getPlayers(state);
+    const actions = getValidActions(state, active);
+    const activateActions = actions.filter((a) => a.type === "activate");
+
+    expect(activateActions.length).toBeGreaterThan(0);
+    expect(activateActions[0].type === "activate" && activateActions[0].actionName).toBe("pilgrimage");
+  });
+
+  it("action does not appear when AP is insufficient", () => {
+    const state = gameWith((d, p) => {
+      d.turn.actionPointsRemaining = 1;
+      const unit = makeUnit({
+        ownerId: p.active,
+        actions: [{ name: "pilgrimage", apCost: 2, effect: "gold[5]" }],
+      });
+      d.grid[0][0].location = makeLocation({ ownerId: p.active });
+      d.grid[0][0].units.push(unit);
+    });
+    const { active } = getPlayers(state);
+    const actions = getValidActions(state, active);
+    const activateActions = actions.filter((a) => a.type === "activate");
+
+    expect(activateActions).toHaveLength(0);
+  });
+
+  it("enemy-targeted action only appears when enemies are co-located", () => {
+    const state = gameWith((d, p) => {
+      const unit = makeUnit({
+        ownerId: p.active,
+        actions: [{ name: "duel", apCost: 1, effect: "contest.strength(enemy)" }],
+      });
+      d.grid[0][0].location = makeLocation({ ownerId: p.active });
+      d.grid[0][0].units.push(unit);
+      // No enemy units at location
+    });
+    const { active } = getPlayers(state);
+    const actions = getValidActions(state, active);
+    const activateActions = actions.filter((a) => a.type === "activate");
+
+    expect(activateActions).toHaveLength(0);
   });
 });
 

--- a/engine/src/__tests__/effect-dsl.test.ts
+++ b/engine/src/__tests__/effect-dsl.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeEach } from "bun:test";
 import { produce, type Draft } from "immer";
 import prand from "pure-rand";
-import { parse, type Expression } from "../effect-dsl";
+import { parse } from "../effect-dsl";
 import { executeEffect, type ExecutionContext } from "../effect-dsl/executor";
 import type { MainGameState, GameEvent } from "../types";
+import { applyAction } from "../apply-action";
+import { makeInstantEvent } from "./helpers";
 import { rebuildListeners } from "../listeners/rebuild";
 import {
   createTestGame,
@@ -297,5 +299,95 @@ describe("Effect DSL executor — contests", () => {
     expect(
       events.some((e) => e.type === "unit_injured" || e.type === "unit_killed"),
     ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration — Bug 4: instant event effects
+// ---------------------------------------------------------------------------
+
+describe("Integration — instant event effects", () => {
+  it("Harvest Festival: play instant event → gain 3 gold", () => {
+    const state = gameWith((d, p) => {
+      d.players[p.activeIdx].gold = 10;
+      d.players[p.activeIdx].hand.push(
+        makeInstantEvent({ ownerId: p.active, definitionId: "harvest-festival", cost: "1", effect: "gold[3]" }),
+      );
+    });
+    const { active, activeIdx } = getPlayers(state);
+    const card = state.players[activeIdx].hand.find((c) => c.type === "event")!;
+
+    const { state: next, events } = applyAction(state, {
+      type: "play_event",
+      playerId: active,
+      cardId: card.id,
+    });
+    const ns = next as MainGameState;
+
+    // Started with 10, paid 1 gold cost, gained 3 = 12
+    expect(ns.players[activeIdx].gold).toBe(12);
+    expect(events.some((e) => e.type === "event_played")).toBe(true);
+    expect(events.some((e) => e.type === "gold_changed" && "reason" in e && e.reason === "effect")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration — Bug 5: activate unit actions
+// ---------------------------------------------------------------------------
+
+describe("Integration — activate unit actions", () => {
+  it("Mansa Musa pilgrimage: activate → gain 5 gold", () => {
+    const state = gameWith((d, p) => {
+      d.players[p.activeIdx].gold = 5;
+      const unit = makeUnit({
+        ownerId: p.active,
+        definitionId: "mansa-musa",
+        actions: [{ name: "pilgrimage", apCost: 2, effect: "gold[5]" }],
+      });
+      d.grid[0][0].location = makeLocation({ ownerId: p.active });
+      d.grid[0][0].units.push(unit);
+    });
+    const { active, activeIdx } = getPlayers(state);
+    const unit = state.grid[0][0].units[0];
+
+    const { state: next, events } = applyAction(state, {
+      type: "activate",
+      playerId: active,
+      cardId: unit.id,
+      actionName: "pilgrimage",
+    });
+    const ns = next as MainGameState;
+
+    expect(ns.players[activeIdx].gold).toBe(10); // 5 + 5
+    expect(ns.turn.actionPointsRemaining).toBe(1); // 3 - 2 AP
+  });
+
+  it("Da Vinci design: activate → draw 2 cards", () => {
+    const state = gameWith((d, p) => {
+      const unit = makeUnit({
+        ownerId: p.active,
+        definitionId: "leonardo-da-vinci",
+        actions: [{ name: "design", apCost: 1, effect: "draw[2]" }],
+      });
+      d.grid[0][0].location = makeLocation({ ownerId: p.active });
+      d.grid[0][0].units.push(unit);
+      d.players[p.activeIdx].hand = [];
+      for (let i = 0; i < 5; i++) {
+        d.players[p.activeIdx].mainDeck.push(makeUnit({ ownerId: p.active }));
+      }
+    });
+    const { active, activeIdx } = getPlayers(state);
+    const unit = state.grid[0][0].units[0];
+
+    const { state: next } = applyAction(state, {
+      type: "activate",
+      playerId: active,
+      cardId: unit.id,
+      actionName: "design",
+    });
+    const ns = next as MainGameState;
+
+    expect(ns.players[activeIdx].hand).toHaveLength(2);
+    expect(ns.players[activeIdx].mainDeck).toHaveLength(3);
   });
 });

--- a/engine/src/__tests__/listeners.test.ts
+++ b/engine/src/__tests__/listeners.test.ts
@@ -392,6 +392,70 @@ describe("trap listeners", () => {
 
     expect(events.some((e) => e.type === "trap_triggered")).toBe(true);
   });
+
+  it("highway-robbery: steals 2 gold from entering enemy unit's owner", () => {
+    const state = gameWith((d, p) => {
+      const trap = makeTrapEvent({
+        ownerId: p.other,
+        definitionId: "highway-robbery",
+        trigger: "enemy_unit_enters_location",
+      });
+      const unit = makeUnit({ ownerId: p.active, strength: 8 });
+      d.grid[0][0].location = makeLocation({ ownerId: p.active });
+      d.players[p.activeIdx].hq.push(unit);
+      d.players[p.otherIdx].activeTraps.push({ card: trap });
+      d.players[p.activeIdx].gold = 5;
+      d.players[p.otherIdx].gold = 3;
+    });
+
+    const { active, activeIdx, otherIdx } = getPlayers(state);
+    const unit = state.players[activeIdx].hq[0];
+
+    const { state: next, events } = applyAction(state, {
+      type: "enter",
+      playerId: active,
+      unitId: unit.id,
+      row: 0,
+      col: 0,
+    });
+
+    const ns = next as MainGameState;
+    expect(events.some((e) => e.type === "trap_triggered")).toBe(true);
+    expect(ns.players[activeIdx].gold).toBe(5 - 2); // victim loses 2
+    expect(ns.players[otherIdx].gold).toBe(3 + 2); // trap owner gains 2
+  });
+
+  it("highway-robbery: steals only available gold when victim has less than 2", () => {
+    const state = gameWith((d, p) => {
+      const trap = makeTrapEvent({
+        ownerId: p.other,
+        definitionId: "highway-robbery",
+        trigger: "enemy_unit_enters_location",
+      });
+      const unit = makeUnit({ ownerId: p.active, strength: 8 });
+      d.grid[0][0].location = makeLocation({ ownerId: p.active });
+      d.players[p.activeIdx].hq.push(unit);
+      d.players[p.otherIdx].activeTraps.push({ card: trap });
+      d.players[p.activeIdx].gold = 1;
+      d.players[p.otherIdx].gold = 0;
+    });
+
+    const { active, activeIdx, otherIdx } = getPlayers(state);
+    const unit = state.players[activeIdx].hq[0];
+
+    const { state: next, events } = applyAction(state, {
+      type: "enter",
+      playerId: active,
+      unitId: unit.id,
+      row: 0,
+      col: 0,
+    });
+
+    const ns = next as MainGameState;
+    expect(events.some((e) => e.type === "trap_triggered")).toBe(true);
+    expect(ns.players[activeIdx].gold).toBe(0); // had 1, lost 1
+    expect(ns.players[otherIdx].gold).toBe(1); // gained 1
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -422,6 +486,41 @@ describe("turn-start listeners", () => {
     )).toBe(true);
   });
 
+  it("Silk Road: bonus goes to player with units, not location owner", () => {
+    const state = gameWith((d, p) => {
+      // Location owned by other player, but active player has units there
+      d.grid[0][0].location = makeLocation({ ownerId: p.other, definitionId: "the-silk-road" });
+      d.grid[0][0].units.push(makeUnit({ ownerId: p.active }));
+      d.players[p.activeIdx].mainDeck.push(makeUnit({ ownerId: p.active }));
+      d.players[p.otherIdx].mainDeck.push(makeUnit({ ownerId: p.other }));
+    });
+
+    const { active } = getPlayers(state);
+    const { events } = passBothPlayers(state);
+
+    const goldEvent = events.find((e) =>
+      e.type === "gold_changed" && "reason" in e && e.reason === "the-silk-road"
+    );
+    expect(goldEvent).toBeDefined();
+    expect("playerId" in goldEvent! && goldEvent.playerId).toBe(active);
+  });
+
+  it("Silk Road: no gold for location owner without units there", () => {
+    const state = gameWith((d, p) => {
+      // Location owned by active player, but only opponent has units
+      d.grid[0][0].location = makeLocation({ ownerId: p.active, definitionId: "the-silk-road" });
+      d.grid[0][0].units.push(makeUnit({ ownerId: p.other }));
+      d.players[p.activeIdx].mainDeck.push(makeUnit({ ownerId: p.active }));
+      d.players[p.otherIdx].mainDeck.push(makeUnit({ ownerId: p.other }));
+    });
+
+    const { events } = passBothPlayers(state);
+
+    expect(events.some((e) =>
+      e.type === "gold_changed" && "reason" in e && e.reason === "the-silk-road"
+    )).toBe(false);
+  });
+
   it("Silk Road: no gold when no units at location", () => {
     const state = gameWith((d, p) => {
       d.grid[0][0].location = makeLocation({ ownerId: p.active, definitionId: "the-silk-road" });
@@ -449,6 +548,24 @@ describe("turn-start listeners", () => {
     expect(events.some((e) =>
       e.type === "gold_changed" && "reason" in e && e.reason === "trade-port"
     )).toBe(true);
+  });
+
+  it("Trade Port: bonus goes to player with Diplomat, not location owner", () => {
+    const state = gameWith((d, p) => {
+      d.grid[0][0].location = makeLocation({ ownerId: p.other, definitionId: "trade-port" });
+      d.grid[0][0].units.push(makeUnit({ ownerId: p.active, attributes: ["Diplomat"] }));
+      d.players[p.activeIdx].mainDeck.push(makeUnit({ ownerId: p.active }));
+      d.players[p.otherIdx].mainDeck.push(makeUnit({ ownerId: p.other }));
+    });
+
+    const { active } = getPlayers(state);
+    const { events } = passBothPlayers(state);
+
+    const goldEvent = events.find((e) =>
+      e.type === "gold_changed" && "reason" in e && e.reason === "trade-port"
+    );
+    expect(goldEvent).toBeDefined();
+    expect("playerId" in goldEvent! && goldEvent.playerId).toBe(active);
   });
 
   it("Trade Port: no gold without Diplomat", () => {

--- a/engine/src/__tests__/main-actions.test.ts
+++ b/engine/src/__tests__/main-actions.test.ts
@@ -692,6 +692,20 @@ describe("turn lifecycle", () => {
     expect(ns.players[ACTIVE_IDX].hand.length).toBeLessThanOrEqual(7);
   });
 
+  it("emits card_discarded events when hand exceeds limit", () => {
+    const state = gameWith((d) => {
+      for (let i = 0; i < 10; i++) {
+        d.players[ACTIVE_IDX].hand.push(makeUnit({ ownerId: ACTIVE }));
+      }
+    });
+
+    const { events } = applyAction(state, { type: "pass", playerId: ACTIVE });
+    const discardEvents = events.filter(
+      (e) => e.type === "card_discarded" && "reason" in e && e.reason === "hand_limit",
+    );
+    expect(discardEvents.length).toBe(3); // 10 → 7 = 3 discarded
+  });
+
   it("does not auto-advance when AP exhausted (player can still buy)", () => {
     const marketCard = makeUnit({ ownerId: "neutral", cost: "0" });
     const state = gameWith((d) => {

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -841,22 +841,19 @@ function handleActivate(
   cardId: string,
   actionName: string,
   targetId: string | undefined,
-  targetRow: number | undefined,
-  targetCol: number | undefined,
+  targetCell: { row: number; col: number } | undefined,
   emit: EmitFn,
   events: GameEvent[],
   queries: QueryListener[],
 ): void {
   // Find the card with actions — search grid units
   let card: Draft<UnitCard> | undefined;
-  let position: { row: number; col: number } | undefined;
 
   for (let r = 0; r < draft.grid.length; r++) {
     for (let c = 0; c < draft.grid[r].length; c++) {
       const found = draft.grid[r][c].units.find((u) => u.id === cardId);
       if (found) {
         card = found;
-        position = { row: r, col: c };
         break;
       }
     }
@@ -878,9 +875,7 @@ function handleActivate(
     playerId,
     actingUnitId: cardId,
     targetId,
-    targetRow,
-    targetCol,
-    position,
+    targetCell,
     emit,
     events,
     queries,
@@ -956,7 +951,7 @@ export function applyMainAction(
         handleActivate(
           draft, action.playerId, action.cardId,
           action.actionName, action.targetId,
-          action.targetRow, action.targetCol,
+          action.targetCell,
           emit, events, queries,
         );
         break;

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -304,6 +304,15 @@ function handleEnter(
   const unit = player.hq.splice(unitIdx, 1)[0] as UnitCard;
   cell.units.push(unit);
 
+  // Move equipped items from HQ to the grid cell with the unit
+  for (let i = player.hq.length - 1; i >= 0; i--) {
+    const card = player.hq[i];
+    if (card.type === "item" && card.equippedTo === unitId) {
+      player.hq.splice(i, 1);
+      cell.items.push(card as ItemCard);
+    }
+  }
+
   emit({ type: "unit_entered", playerId, unitId, row, col });
 }
 
@@ -366,6 +375,13 @@ function handleMove(
     const player = getPlayerById(draft, playerId);
     player.hq.push(removed);
 
+    // Move equipped items from grid cell to HQ with the unit
+    for (let i = cell.items.length - 1; i >= 0; i--) {
+      if (cell.items[i].equippedTo === unitId) {
+        player.hq.push(cell.items.splice(i, 1)[0]);
+      }
+    }
+
     emit({
       type: "unit_moved",
       playerId,
@@ -375,7 +391,6 @@ function handleMove(
       toRow: -1,
       toCol: -1,
     });
-
 
     return;
   }
@@ -408,6 +423,13 @@ function handleMove(
   }
   const removed = fromCell.units.splice(idx, 1)[0];
   draft.grid[toRow][toCol].units.push(removed);
+
+  // Move equipped items from source cell to destination cell with the unit
+  for (let i = fromCell.items.length - 1; i >= 0; i--) {
+    if (fromCell.items[i].equippedTo === unitId) {
+      draft.grid[toRow][toCol].items.push(fromCell.items.splice(i, 1)[0]);
+    }
+  }
 
   emit({ type: "unit_moved", playerId, unitId, fromRow, fromCol, toRow, toCol });
 }

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -112,6 +112,7 @@ function runEndOfTurn(
   while (player.hand.length > maxHandSize) {
     const discarded = player.hand.pop()!;
     player.discardPile.push(discarded);
+    emit({ type: "card_discarded", playerId: player.id, cardId: discarded.id, reason: "hand_limit" });
   }
 
   // Passive event duration tracking

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -21,6 +21,7 @@ import {
   placeLocationOnGrid,
 } from "./state-helpers";
 import { emit as emitEvent } from "./listeners/emit";
+import { executeEffect } from "./effect-dsl/executor";
 import { rebuildListeners } from "./listeners/rebuild";
 import { getModifiedStat, getModifiedCost, getModifiedAPCost } from "./listeners/query";
 import type { EmitFn, QueryListener } from "./listeners/types";
@@ -123,6 +124,31 @@ function runEndOfTurn(
       player.passiveEvents.splice(i, 1);
       player.discardPile.push(evt);
       emit({ type: "passive_expired", playerId: player.id, cardId: evt.id });
+    }
+  }
+
+  // Expire stat modifiers and control overrides on all grid units
+  for (const row of draft.grid) {
+    for (const cell of row) {
+      for (const unit of cell.units) {
+        // Stat modifiers
+        if (unit.statModifiers && unit.statModifiers.length > 0) {
+          for (let i = unit.statModifiers.length - 1; i >= 0; i--) {
+            unit.statModifiers[i].remainingDuration -= 1;
+            if (unit.statModifiers[i].remainingDuration <= 0) {
+              unit.statModifiers.splice(i, 1);
+            }
+          }
+        }
+        // Control override
+        if (unit.controlOverride) {
+          unit.controlOverride.remainingDuration -= 1;
+          if (unit.controlOverride.remainingDuration <= 0) {
+            unit.ownerId = unit.controlOverride.previousOwnerId;
+            unit.controlOverride = undefined;
+          }
+        }
+      }
     }
   }
 }
@@ -393,6 +419,7 @@ function handlePlayEvent(
   targetId: string | undefined,
   emit: EmitFn,
   events: GameEvent[],
+  queries: QueryListener[],
 ): void {
   const player = getPlayerById(draft, playerId);
   const cardIdx = player.hand.findIndex((c) => c.id === cardId);
@@ -412,11 +439,20 @@ function handlePlayEvent(
   player.hand.splice(cardIdx, 1);
 
   switch (card.subtype) {
-    case "instant":
-      // Effect resolution deferred — for now just discard
+    case "instant": {
+      if (card.effect) {
+        let rng = prand.mersenne.fromState(draft.rngState);
+        const result = executeEffect(card.effect, {
+          draft, playerId, emit,
+          events, queries,
+          rng,
+        });
+        draft.rngState = extractRngState(result.rng) as number[];
+      }
       player.discardPile.push(card);
       emit({ type: "event_played", playerId, cardId });
       break;
+    }
 
     case "passive":
       player.passiveEvents.push({
@@ -778,17 +814,57 @@ function handleAttemptMission(
 }
 
 function handleActivate(
-  _draft: Draft<MainGameState>,
-  _playerId: string,
-  _cardId: string,
-  _actionName: string,
-  _targetId: string | undefined,
-  _emit: EmitFn,
+  draft: Draft<MainGameState>,
+  playerId: string,
+  cardId: string,
+  actionName: string,
+  targetId: string | undefined,
+  targetRow: number | undefined,
+  targetCol: number | undefined,
+  emit: EmitFn,
+  events: GameEvent[],
+  queries: QueryListener[],
 ): void {
-  // Stub — effect resolution deferred to issue #20
-  throw new Error(
-    "activate action is not yet implemented — waiting on stat contest mechanics (#20)",
-  );
+  // Find the card with actions — search grid units
+  let card: Draft<UnitCard> | undefined;
+  let position: { row: number; col: number } | undefined;
+
+  for (let r = 0; r < draft.grid.length; r++) {
+    for (let c = 0; c < draft.grid[r].length; c++) {
+      const found = draft.grid[r][c].units.find((u) => u.id === cardId);
+      if (found) {
+        card = found;
+        position = { row: r, col: c };
+        break;
+      }
+    }
+    if (card) break;
+  }
+
+  if (!card) throw new Error(`Card "${cardId}" not found on grid`);
+  if (!card.actions) throw new Error(`Card "${cardId}" has no actions`);
+  if (card.ownerId !== playerId) throw new Error(`Card "${cardId}" not owned by "${playerId}"`);
+
+  const actionDef = card.actions.find((a) => a.name === actionName);
+  if (!actionDef) throw new Error(`Action "${actionName}" not found on card "${cardId}"`);
+
+  spendAP(draft, actionDef.apCost);
+
+  let rng = prand.mersenne.fromState(draft.rngState);
+  const result = executeEffect(actionDef.effect, {
+    draft,
+    playerId,
+    actingUnitId: cardId,
+    targetId,
+    targetRow,
+    targetCol,
+    position,
+    emit,
+    events,
+    queries,
+    rng,
+  });
+  draft.rngState = extractRngState(result.rng) as number[];
 }
 
 // ---------------------------------------------------------------------------
@@ -832,7 +908,7 @@ export function applyMainAction(
         break;
 
       case "play_event":
-        handlePlayEvent(draft, action.playerId, action.cardId, action.targetId, emit, events);
+        handlePlayEvent(draft, action.playerId, action.cardId, action.targetId, emit, events, queries);
         break;
 
       case "equip":
@@ -857,7 +933,9 @@ export function applyMainAction(
       case "activate":
         handleActivate(
           draft, action.playerId, action.cardId,
-          action.actionName, action.targetId, emit,
+          action.actionName, action.targetId,
+          action.targetRow, action.targetCol,
+          emit, events, queries,
         );
         break;
 

--- a/engine/src/card-loader.ts
+++ b/engine/src/card-loader.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type {
+  ActionDef,
   Card,
   CardType,
   EventSubtype,
@@ -34,7 +35,7 @@ export interface CardDefinition {
   cunning?: number | null;
   charisma?: number | null;
   attributes?: string[];
-  actions?: { name: string; apCost: number; effect: string }[];
+  actions?: ActionDef[];
 
   // Location fields
   mission?: string | null;

--- a/engine/src/card-loader.ts
+++ b/engine/src/card-loader.ts
@@ -268,6 +268,7 @@ export function instantiateCard(
         charisma: def.charisma ?? 0,
         attributes: def.attributes ?? [],
         injured: false,
+        actions: def.actions ?? undefined,
       } satisfies UnitCard;
 
     case "location":
@@ -294,7 +295,7 @@ export function instantiateCard(
       }
       switch (def.subtype) {
         case "instant":
-          return { ...base, type: "event", subtype: "instant" } satisfies InstantEventCard;
+          return { ...base, type: "event", subtype: "instant", effect: def.effect ?? undefined } satisfies InstantEventCard;
         case "passive":
           return {
             ...base,

--- a/engine/src/create-game.ts
+++ b/engine/src/create-game.ts
@@ -97,13 +97,16 @@ export function createGame(
   });
 
   // Populate decks based on input mode
+  let currentRng = nextRng;
   if (setupInput.mode === "seeding") {
     for (const ps of playerStates) {
       const input = setupInput.decks[ps.id];
       if (!input) {
         throw new Error(`No seeding deck provided for player "${ps.id}"`);
       }
-      ps.seedingDeck = [...input.seedingDeck];
+      const [shuffled, rngAfter] = shuffle([...input.seedingDeck], currentRng);
+      currentRng = rngAfter;
+      ps.seedingDeck = shuffled;
       ps.policyPool = [...input.policyPool];
     }
   } else {
@@ -141,7 +144,7 @@ export function createGame(
       setupInput.mode === "main" && setupInput.market
         ? [...setupInput.market]
         : [],
-    rngState: extractRngState(nextRng),
+    rngState: extractRngState(currentRng),
     seed,
     actionLog: [],
   };

--- a/engine/src/effect-dsl/executor.ts
+++ b/engine/src/effect-dsl/executor.ts
@@ -2,9 +2,8 @@ import type { Draft } from "immer";
 import prand from "pure-rand";
 import { parse } from "./parser";
 import type { Expression, Effect, Step, Primitive, Selector } from "./types";
-import type { GameEvent, MainGameState, UnitCard } from "../types";
-import type { QueryListener } from "../listeners/types";
-import type { EmitFn } from "../listeners/types";
+import type { Card, GameEvent, LocationCard, MainGameState, StatName, UnitCard } from "../types";
+import type { QueryListener, EmitFn } from "../listeners/types";
 import { getPlayerById } from "../state-helpers";
 import { drawOneCard } from "../deck-helpers";
 import { killUnit, injureUnit } from "../unit-helpers";
@@ -20,15 +19,24 @@ export interface ExecutionContext {
   playerId: string;
   actingUnitId?: string;
   targetId?: string;
-  targetRow?: number;
-  targetCol?: number;
-  position?: { row: number; col: number };
+  targetCell?: { row: number; col: number };
   emit: EmitFn;
   events: GameEvent[];
   queries: QueryListener[];
   rng: prand.RandomGenerator;
   /** Back-reference to last resolved target (for chains). */
   _lastTarget?: Draft<UnitCard>;
+  /** Cards revealed by a `reveal` verb, consumed by a subsequent `pick`. */
+  _revealedCards?: Draft<Card>[];
+  /** Location removed by a `raze` verb, consumed by a subsequent `to`. */
+  _razedLocation?: Draft<LocationCard>;
+}
+
+/** Resolve the acting unit's current position from the grid (lazy, always fresh). */
+function getActingPosition(ctx: ExecutionContext): { row: number; col: number } | undefined {
+  if (!ctx.actingUnitId) return undefined;
+  const found = findUnitOnGrid(ctx.draft.grid, ctx.actingUnitId);
+  return found ? { row: found.row, col: found.col } : undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -49,7 +57,6 @@ export function executeEffect(
 // ---------------------------------------------------------------------------
 
 function executeExpression(expr: Expression, ctx: ExecutionContext): void {
-  // Compound effects ("+"): execute all in parallel (sequential in practice)
   for (const effect of expr) {
     executeEffectChain(effect, ctx);
   }
@@ -123,7 +130,6 @@ function resolveUnitTargets(
 
   const tokenNames = selector.tokens.map((t) => t.name);
   const hasAll = tokenNames.includes("all");
-  const hasHere = tokenNames.includes("here");
   const hasAdjacent = tokenNames.includes("adjacent");
   const hasSelf = tokenNames.includes("self");
   const hasEnemy = tokenNames.includes("enemy");
@@ -147,13 +153,13 @@ function resolveUnitTargets(
     return found ? [found.unit as Draft<UnitCard>] : [];
   }
 
-  // Positional: collect units at location(s)
-  if (!ctx.position) return [];
-  const { row, col } = ctx.position;
+  // Positional: resolve lazily from acting unit's current position
+  const position = getActingPosition(ctx);
+  if (!position) return [];
+  const { row, col } = position;
   let units: Draft<UnitCard>[] = [];
 
   if (hasAdjacent) {
-    // Units at adjacent cells
     const dirs = [[-1, 0], [1, 0], [0, -1], [0, 1]];
     for (const [dr, dc] of dirs) {
       const r = row + dr;
@@ -163,7 +169,6 @@ function resolveUnitTargets(
       }
     }
   } else {
-    // Units at same cell (here)
     units = [...(ctx.draft.grid[row][col].units as Draft<UnitCard>[])];
   }
 
@@ -172,11 +177,10 @@ function resolveUnitTargets(
     units = units.filter((u) => u.ownerId !== ctx.playerId);
   } else if (hasFriendly) {
     units = units.filter((u) => u.ownerId === ctx.playerId);
-  }
-
-  // Exclude self from friendly (unless "all" is also specified)
-  if (hasFriendly && !hasAll && ctx.actingUnitId) {
-    // Keep self in "all + friendly"
+    // Exclude self from single-target friendly (unless "all" is specified)
+    if (!hasAll && ctx.actingUnitId) {
+      units = units.filter((u) => u.id !== ctx.actingUnitId);
+    }
   }
 
   // Apply count limit from token
@@ -195,7 +199,7 @@ function resolveUnitTargets(
 function execGold(p: Primitive, ctx: ExecutionContext): void {
   const amount = p.value ?? 0;
   const player = getPlayerById(ctx.draft, ctx.playerId);
-  player.gold += amount;
+  player.gold = Math.max(0, player.gold + amount);
   ctx.emit({ type: "gold_changed", playerId: ctx.playerId, amount, reason: "effect" });
 }
 
@@ -211,6 +215,8 @@ function execDraw(p: Primitive, ctx: ExecutionContext): void {
   for (let i = 0; i < count; i++) {
     drawOneCard(ctx.draft, player, ctx.events);
   }
+  // Sync RNG — drawOneCard may have updated draft.rngState via deck reshuffle
+  ctx.rng = prand.mersenne.fromState(ctx.draft.rngState);
 }
 
 function execKill(p: Primitive, ctx: ExecutionContext): void {
@@ -238,7 +244,7 @@ function execInjure(p: Primitive, ctx: ExecutionContext): void {
 }
 
 function execBuff(p: Primitive, ctx: ExecutionContext): void {
-  const stat = p.subVerb as "strength" | "cunning" | "charisma";
+  const stat = p.subVerb as StatName;
   if (!stat) throw new Error("buff verb requires a stat subVerb (e.g. buff.strength)");
   const delta = p.value ?? 0;
   const duration = p.modifiers.includes("turn") ? 1 : p.modifiers.includes("round") ? 2 : 1;
@@ -259,7 +265,8 @@ function execBuff(p: Primitive, ctx: ExecutionContext): void {
 function execMove(p: Primitive, ctx: ExecutionContext): void {
   const targets = resolveUnitTargets(p.target, ctx);
   if (targets.length === 0) return;
-  if (ctx.targetRow === undefined || ctx.targetCol === undefined) return;
+  if (!ctx.targetCell) return;
+  const { row: toRow, col: toCol } = ctx.targetCell;
 
   for (const unit of targets) {
     const pos = findUnitOnGrid(ctx.draft.grid, unit.id);
@@ -271,9 +278,15 @@ function execMove(p: Primitive, ctx: ExecutionContext): void {
     if (idx === -1) continue;
     srcCell.units.splice(idx, 1);
 
+    // Move equipped items with the unit
+    for (let i = srcCell.items.length - 1; i >= 0; i--) {
+      if (srcCell.items[i].equippedTo === unit.id) {
+        ctx.draft.grid[toRow][toCol].items.push(srcCell.items.splice(i, 1)[0]);
+      }
+    }
+
     // Add to destination cell
-    const dstCell = ctx.draft.grid[ctx.targetRow][ctx.targetCol];
-    dstCell.units.push(unit);
+    ctx.draft.grid[toRow][toCol].units.push(unit);
 
     ctx.emit({
       type: "unit_moved",
@@ -281,8 +294,8 @@ function execMove(p: Primitive, ctx: ExecutionContext): void {
       unitId: unit.id,
       fromRow: pos.row,
       fromCol: pos.col,
-      toRow: ctx.targetRow,
-      toCol: ctx.targetCol,
+      toRow,
+      toCol,
     });
   }
 }
@@ -297,24 +310,21 @@ function execReveal(p: Primitive, ctx: ExecutionContext): void {
     const cardIds = opponent.hand.map((c) => c.id);
     ctx.emit({ type: "cards_revealed", playerId: ctx.playerId, cardIds, source: "reveal" });
   } else if (tokenNames.includes("deck")) {
-    // Reveal top N from player's deck
     const player = getPlayerById(ctx.draft, ctx.playerId);
     const revealed = player.mainDeck.slice(0, count);
     const cardIds = revealed.map((c) => c.id);
     ctx.emit({ type: "cards_revealed", playerId: ctx.playerId, cardIds, source: "reveal-deck" });
-    // Store revealed cards for pick step
-    (ctx as any)._revealedCards = revealed;
+    ctx._revealedCards = revealed as Draft<Card>[];
   }
 }
 
 function execPick(p: Primitive, ctx: ExecutionContext): void {
   const count = p.value ?? 1;
-  const revealed = (ctx as any)._revealedCards as Draft<typeof ctx.draft.players[0]["mainDeck"]> | undefined;
-  if (!revealed || revealed.length === 0) return;
+  if (!ctx._revealedCards || ctx._revealedCards.length === 0) return;
 
   const player = getPlayerById(ctx.draft, ctx.playerId);
-  // Auto-pick first N cards for v0.1 (player choice refinement later)
-  const picked = revealed.slice(0, count);
+  // Auto-pick first N cards for v0.1 (player choice refinement: #101)
+  const picked = ctx._revealedCards.slice(0, count);
   for (const card of picked) {
     const idx = player.mainDeck.findIndex((c) => c.id === card.id);
     if (idx !== -1) {
@@ -322,6 +332,7 @@ function execPick(p: Primitive, ctx: ExecutionContext): void {
       player.hand.push(card);
     }
   }
+  ctx._revealedCards = undefined;
 }
 
 function execControl(p: Primitive, ctx: ExecutionContext): void {
@@ -347,14 +358,15 @@ function execControl(p: Primitive, ctx: ExecutionContext): void {
 
 function execRemove(p: Primitive, ctx: ExecutionContext): void {
   const tokenNames = p.target?.tokens.map((t) => t.name) ?? [];
-  if (tokenNames.includes("location") && ctx.position) {
-    const { row, col } = ctx.position;
-    const cell = ctx.draft.grid[row][col];
-    if (cell.location) {
-      const locId = cell.location.id;
-      cell.location = null;
-      ctx.emit({ type: "location_razed", row, col, cardId: locId });
-    }
+  if (!tokenNames.includes("location")) return;
+  const position = getActingPosition(ctx);
+  if (!position) return;
+  const { row, col } = position;
+  const cell = ctx.draft.grid[row][col];
+  if (cell.location) {
+    const locId = cell.location.id;
+    cell.location = null;
+    ctx.emit({ type: "location_razed", row, col, cardId: locId });
   }
 }
 
@@ -364,7 +376,6 @@ function execBuy(p: Primitive, ctx: ExecutionContext): void {
   const typeFilter = tokenNames.find((t) => ["item", "unit", "event"].includes(t));
 
   const player = getPlayerById(ctx.draft, ctx.playerId);
-  // Find first matching card in market
   const marketIdx = ctx.draft.market.findIndex((c) => {
     if (!c) return false;
     if (typeFilter && c.type !== typeFilter) return false;
@@ -381,28 +392,25 @@ function execBuy(p: Primitive, ctx: ExecutionContext): void {
 }
 
 function execRaze(p: Primitive, ctx: ExecutionContext): void {
-  // Raze the location at the acting unit's position
-  if (!ctx.position) return;
-  const { row, col } = ctx.position;
+  const position = getActingPosition(ctx);
+  if (!position) return;
+  const { row, col } = position;
   const cell = ctx.draft.grid[row][col];
   if (!cell.location) return;
 
   const loc = cell.location;
   cell.location = null;
   ctx.emit({ type: "location_razed", row, col, cardId: loc.id });
-
-  // Store for potential "to" redirect
-  (ctx as any)._razedLocation = loc;
+  ctx._razedLocation = loc as Draft<LocationCard>;
 }
 
 function execTo(p: Primitive, ctx: ExecutionContext): void {
   const tokenNames = p.target?.tokens.map((t) => t.name) ?? [];
-  const razedLoc = (ctx as any)._razedLocation;
 
-  if (tokenNames.includes("hq") && razedLoc) {
+  if (tokenNames.includes("hq") && ctx._razedLocation) {
     const player = getPlayerById(ctx.draft, ctx.playerId);
-    player.hq.push(razedLoc);
-    (ctx as any)._razedLocation = undefined;
+    player.hq.push(ctx._razedLocation);
+    ctx._razedLocation = undefined;
   }
 }
 
@@ -412,7 +420,7 @@ function execTo(p: Primitive, ctx: ExecutionContext): void {
 
 function executeContest(step: Step, ctx: ExecutionContext): void {
   const p = step.primitive;
-  const stat = p.subVerb as "strength" | "cunning" | "charisma";
+  const stat = p.subVerb as StatName;
   if (!stat) throw new Error("contest verb requires a stat subVerb");
 
   const bonus = p.value ?? 0;
@@ -443,8 +451,8 @@ function executeContest(step: Step, ctx: ExecutionContext): void {
   );
 
   // Roll d6 for each
-  let [atkRoll, rng1] = prand.uniformIntDistribution(1, 6, ctx.rng);
-  let [defRoll, rng2] = prand.uniformIntDistribution(1, 6, rng1);
+  const [atkRoll, rng1] = prand.uniformIntDistribution(1, 6, ctx.rng);
+  const [defRoll, rng2] = prand.uniformIntDistribution(1, 6, rng1);
   ctx.rng = rng2;
 
   const atkPower = atkStat + atkRoll + bonus;
@@ -464,7 +472,6 @@ function executeContest(step: Step, ctx: ExecutionContext): void {
   });
 
   if (step.consequence) {
-    // Custom consequences
     if (attackerWins && step.consequence.winEffect) {
       for (const winStep of step.consequence.winEffect) {
         executeStep(winStep, ctx);
@@ -477,7 +484,6 @@ function executeContest(step: Step, ctx: ExecutionContext): void {
   } else {
     // Default consequences for strength contests
     if (stat === "strength") {
-      const winner = attackerWins ? attacker : target;
       const loser = attackerWins ? target : attacker;
       const loserPos = findUnitOnGrid(ctx.draft.grid, loser.id);
       if (!loserPos) return;
@@ -492,6 +498,5 @@ function executeContest(step: Step, ctx: ExecutionContext): void {
         injureUnit(cell, loser, loserPos.row, loserPos.col, ctx.emit);
       }
     }
-    // Other stats: no default consequence
   }
 }

--- a/engine/src/effect-dsl/executor.ts
+++ b/engine/src/effect-dsl/executor.ts
@@ -1,0 +1,487 @@
+import type { Draft } from "immer";
+import prand from "pure-rand";
+import { parse } from "./parser";
+import type { Expression, Effect, Step, Primitive, Selector } from "./types";
+import type { GameEvent, MainGameState, UnitCard } from "../types";
+import type { QueryListener } from "../listeners/types";
+import type { EmitFn } from "../listeners/types";
+import { getPlayerById } from "../state-helpers";
+import { drawOneCard } from "../deck-helpers";
+import { killUnit, injureUnit } from "../unit-helpers";
+import { findUnitOnGrid } from "../grid-helpers";
+import { getModifiedStat } from "../listeners/query";
+
+// ---------------------------------------------------------------------------
+// Execution context
+// ---------------------------------------------------------------------------
+
+export interface ExecutionContext {
+  draft: Draft<MainGameState>;
+  playerId: string;
+  actingUnitId?: string;
+  targetId?: string;
+  targetRow?: number;
+  targetCol?: number;
+  position?: { row: number; col: number };
+  emit: EmitFn;
+  events: GameEvent[];
+  queries: QueryListener[];
+  rng: prand.RandomGenerator;
+  /** Back-reference to last resolved target (for chains). */
+  _lastTarget?: Draft<UnitCard>;
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+export function executeEffect(
+  effectStr: string,
+  ctx: ExecutionContext,
+): { rng: prand.RandomGenerator } {
+  const ast = parse(effectStr);
+  executeExpression(ast, ctx);
+  return { rng: ctx.rng };
+}
+
+// ---------------------------------------------------------------------------
+// AST walkers
+// ---------------------------------------------------------------------------
+
+function executeExpression(expr: Expression, ctx: ExecutionContext): void {
+  // Compound effects ("+"): execute all in parallel (sequential in practice)
+  for (const effect of expr) {
+    executeEffectChain(effect, ctx);
+  }
+}
+
+function executeEffectChain(effect: Effect, ctx: ExecutionContext): void {
+  for (const step of effect) {
+    executeStep(step, ctx);
+  }
+}
+
+function executeStep(step: Step, ctx: ExecutionContext): void {
+  const p = step.primitive;
+
+  if (p.verb === "contest") {
+    executeContest(step, ctx);
+    return;
+  }
+
+  executePrimitive(p, ctx);
+}
+
+// ---------------------------------------------------------------------------
+// Verb dispatch
+// ---------------------------------------------------------------------------
+
+function executePrimitive(p: Primitive, ctx: ExecutionContext): void {
+  switch (p.verb) {
+    case "gold":
+      return execGold(p, ctx);
+    case "vp":
+      return execVp(p, ctx);
+    case "draw":
+      return execDraw(p, ctx);
+    case "kill":
+      return execKill(p, ctx);
+    case "injure":
+      return execInjure(p, ctx);
+    case "buff":
+      return execBuff(p, ctx);
+    case "move":
+      return execMove(p, ctx);
+    case "reveal":
+      return execReveal(p, ctx);
+    case "pick":
+      return execPick(p, ctx);
+    case "control":
+      return execControl(p, ctx);
+    case "remove":
+      return execRemove(p, ctx);
+    case "buy":
+      return execBuy(p, ctx);
+    case "raze":
+      return execRaze(p, ctx);
+    case "to":
+      return execTo(p, ctx);
+    default:
+      throw new Error(`Unknown DSL verb: "${p.verb}"`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Target resolution
+// ---------------------------------------------------------------------------
+
+function resolveUnitTargets(
+  selector: Selector | undefined,
+  ctx: ExecutionContext,
+): Draft<UnitCard>[] {
+  if (!selector) return [];
+
+  const tokenNames = selector.tokens.map((t) => t.name);
+  const hasAll = tokenNames.includes("all");
+  const hasHere = tokenNames.includes("here");
+  const hasAdjacent = tokenNames.includes("adjacent");
+  const hasSelf = tokenNames.includes("self");
+  const hasEnemy = tokenNames.includes("enemy");
+  const hasFriendly = tokenNames.includes("friendly");
+  const hasTarget = tokenNames.includes("target");
+
+  // Back-reference to last resolved target
+  if (hasTarget && ctx._lastTarget) {
+    return [ctx._lastTarget];
+  }
+
+  // Self
+  if (hasSelf && ctx.actingUnitId) {
+    const found = findUnitOnGrid(ctx.draft.grid, ctx.actingUnitId);
+    return found ? [found.unit as Draft<UnitCard>] : [];
+  }
+
+  // Specific target by ID
+  if ((hasEnemy || hasFriendly) && ctx.targetId && !hasAll) {
+    const found = findUnitOnGrid(ctx.draft.grid, ctx.targetId);
+    return found ? [found.unit as Draft<UnitCard>] : [];
+  }
+
+  // Positional: collect units at location(s)
+  if (!ctx.position) return [];
+  const { row, col } = ctx.position;
+  let units: Draft<UnitCard>[] = [];
+
+  if (hasAdjacent) {
+    // Units at adjacent cells
+    const dirs = [[-1, 0], [1, 0], [0, -1], [0, 1]];
+    for (const [dr, dc] of dirs) {
+      const r = row + dr;
+      const c = col + dc;
+      if (r >= 0 && r < ctx.draft.grid.length && c >= 0 && c < ctx.draft.grid[0].length) {
+        units.push(...(ctx.draft.grid[r][c].units as Draft<UnitCard>[]));
+      }
+    }
+  } else {
+    // Units at same cell (here)
+    units = [...(ctx.draft.grid[row][col].units as Draft<UnitCard>[])];
+  }
+
+  // Filter by ownership
+  if (hasEnemy) {
+    units = units.filter((u) => u.ownerId !== ctx.playerId);
+  } else if (hasFriendly) {
+    units = units.filter((u) => u.ownerId === ctx.playerId);
+  }
+
+  // Exclude self from friendly (unless "all" is also specified)
+  if (hasFriendly && !hasAll && ctx.actingUnitId) {
+    // Keep self in "all + friendly"
+  }
+
+  // Apply count limit from token
+  const countToken = selector.tokens.find((t) => t.count !== undefined);
+  if (countToken?.count !== undefined && !hasAll) {
+    units = units.slice(0, countToken.count);
+  }
+
+  return units;
+}
+
+// ---------------------------------------------------------------------------
+// Verb implementations
+// ---------------------------------------------------------------------------
+
+function execGold(p: Primitive, ctx: ExecutionContext): void {
+  const amount = p.value ?? 0;
+  const player = getPlayerById(ctx.draft, ctx.playerId);
+  player.gold += amount;
+  ctx.emit({ type: "gold_changed", playerId: ctx.playerId, amount, reason: "effect" });
+}
+
+function execVp(p: Primitive, ctx: ExecutionContext): void {
+  const amount = p.value ?? 0;
+  const player = getPlayerById(ctx.draft, ctx.playerId);
+  player.vp += amount;
+}
+
+function execDraw(p: Primitive, ctx: ExecutionContext): void {
+  const count = p.value ?? 1;
+  const player = getPlayerById(ctx.draft, ctx.playerId);
+  for (let i = 0; i < count; i++) {
+    drawOneCard(ctx.draft, player, ctx.events);
+  }
+}
+
+function execKill(p: Primitive, ctx: ExecutionContext): void {
+  const targets = resolveUnitTargets(p.target, ctx);
+  for (const unit of targets) {
+    const pos = findUnitOnGrid(ctx.draft.grid, unit.id);
+    if (!pos) continue;
+    const cell = ctx.draft.grid[pos.row][pos.col];
+    killUnit(ctx.draft, cell, unit, pos.row, pos.col, ctx.emit);
+  }
+}
+
+function execInjure(p: Primitive, ctx: ExecutionContext): void {
+  const targets = resolveUnitTargets(p.target, ctx);
+  for (const unit of targets) {
+    const pos = findUnitOnGrid(ctx.draft.grid, unit.id);
+    if (!pos) continue;
+    const cell = ctx.draft.grid[pos.row][pos.col];
+    if (unit.injured) {
+      killUnit(ctx.draft, cell, unit, pos.row, pos.col, ctx.emit);
+    } else {
+      injureUnit(cell, unit, pos.row, pos.col, ctx.emit);
+    }
+  }
+}
+
+function execBuff(p: Primitive, ctx: ExecutionContext): void {
+  const stat = p.subVerb as "strength" | "cunning" | "charisma";
+  if (!stat) throw new Error("buff verb requires a stat subVerb (e.g. buff.strength)");
+  const delta = p.value ?? 0;
+  const duration = p.modifiers.includes("turn") ? 1 : p.modifiers.includes("round") ? 2 : 1;
+  const targets = resolveUnitTargets(p.target, ctx);
+
+  for (const unit of targets) {
+    if (!unit.statModifiers) unit.statModifiers = [];
+    unit.statModifiers.push({
+      stat,
+      delta,
+      remainingDuration: duration,
+      source: `buff-${stat}`,
+    });
+    ctx.emit({ type: "unit_buffed", unitId: unit.id, stat, delta, source: `buff-${stat}` });
+  }
+}
+
+function execMove(p: Primitive, ctx: ExecutionContext): void {
+  const targets = resolveUnitTargets(p.target, ctx);
+  if (targets.length === 0) return;
+  if (ctx.targetRow === undefined || ctx.targetCol === undefined) return;
+
+  for (const unit of targets) {
+    const pos = findUnitOnGrid(ctx.draft.grid, unit.id);
+    if (!pos) continue;
+
+    // Remove from source cell
+    const srcCell = ctx.draft.grid[pos.row][pos.col];
+    const idx = srcCell.units.findIndex((u) => u.id === unit.id);
+    if (idx === -1) continue;
+    srcCell.units.splice(idx, 1);
+
+    // Add to destination cell
+    const dstCell = ctx.draft.grid[ctx.targetRow][ctx.targetCol];
+    dstCell.units.push(unit);
+
+    ctx.emit({
+      type: "unit_moved",
+      playerId: unit.ownerId,
+      unitId: unit.id,
+      fromRow: pos.row,
+      fromCol: pos.col,
+      toRow: ctx.targetRow,
+      toCol: ctx.targetCol,
+    });
+  }
+}
+
+function execReveal(p: Primitive, ctx: ExecutionContext): void {
+  const tokenNames = p.target?.tokens.map((t) => t.name) ?? [];
+  const count = p.value ?? 0;
+
+  if (tokenNames.includes("opponent") && tokenNames.includes("hand")) {
+    const opponent = ctx.draft.players.find((pl) => pl.id !== ctx.playerId);
+    if (!opponent) return;
+    const cardIds = opponent.hand.map((c) => c.id);
+    ctx.emit({ type: "cards_revealed", playerId: ctx.playerId, cardIds, source: "reveal" });
+  } else if (tokenNames.includes("deck")) {
+    // Reveal top N from player's deck
+    const player = getPlayerById(ctx.draft, ctx.playerId);
+    const revealed = player.mainDeck.slice(0, count);
+    const cardIds = revealed.map((c) => c.id);
+    ctx.emit({ type: "cards_revealed", playerId: ctx.playerId, cardIds, source: "reveal-deck" });
+    // Store revealed cards for pick step
+    (ctx as any)._revealedCards = revealed;
+  }
+}
+
+function execPick(p: Primitive, ctx: ExecutionContext): void {
+  const count = p.value ?? 1;
+  const revealed = (ctx as any)._revealedCards as Draft<typeof ctx.draft.players[0]["mainDeck"]> | undefined;
+  if (!revealed || revealed.length === 0) return;
+
+  const player = getPlayerById(ctx.draft, ctx.playerId);
+  // Auto-pick first N cards for v0.1 (player choice refinement later)
+  const picked = revealed.slice(0, count);
+  for (const card of picked) {
+    const idx = player.mainDeck.findIndex((c) => c.id === card.id);
+    if (idx !== -1) {
+      player.mainDeck.splice(idx, 1);
+      player.hand.push(card);
+    }
+  }
+}
+
+function execControl(p: Primitive, ctx: ExecutionContext): void {
+  const targets = resolveUnitTargets(p.target, ctx);
+  const duration = p.modifiers.includes("turn") ? 1 : p.modifiers.includes("round") ? 2 : 1;
+
+  for (const unit of targets) {
+    unit.controlOverride = {
+      previousOwnerId: unit.ownerId,
+      remainingDuration: duration,
+    };
+    const prevOwner = unit.ownerId;
+    unit.ownerId = ctx.playerId;
+    ctx.emit({
+      type: "unit_controlled",
+      unitId: unit.id,
+      controllerId: ctx.playerId,
+      previousOwnerId: prevOwner,
+      duration,
+    });
+  }
+}
+
+function execRemove(p: Primitive, ctx: ExecutionContext): void {
+  const tokenNames = p.target?.tokens.map((t) => t.name) ?? [];
+  if (tokenNames.includes("location") && ctx.position) {
+    const { row, col } = ctx.position;
+    const cell = ctx.draft.grid[row][col];
+    if (cell.location) {
+      const locId = cell.location.id;
+      cell.location = null;
+      ctx.emit({ type: "location_razed", row, col, cardId: locId });
+    }
+  }
+}
+
+function execBuy(p: Primitive, ctx: ExecutionContext): void {
+  const costOverride = p.value ?? 0;
+  const tokenNames = p.target?.tokens.map((t) => t.name) ?? [];
+  const typeFilter = tokenNames.find((t) => ["item", "unit", "event"].includes(t));
+
+  const player = getPlayerById(ctx.draft, ctx.playerId);
+  // Find first matching card in market
+  const marketIdx = ctx.draft.market.findIndex((c) => {
+    if (!c) return false;
+    if (typeFilter && c.type !== typeFilter) return false;
+    return true;
+  });
+
+  if (marketIdx === -1) return;
+  const card = ctx.draft.market.splice(marketIdx, 1)[0];
+  if (costOverride > 0) {
+    player.gold -= Math.min(costOverride, player.gold);
+  }
+  player.hand.push(card);
+  ctx.emit({ type: "card_bought", playerId: ctx.playerId, cardId: card.id, cost: costOverride });
+}
+
+function execRaze(p: Primitive, ctx: ExecutionContext): void {
+  // Raze the location at the acting unit's position
+  if (!ctx.position) return;
+  const { row, col } = ctx.position;
+  const cell = ctx.draft.grid[row][col];
+  if (!cell.location) return;
+
+  const loc = cell.location;
+  cell.location = null;
+  ctx.emit({ type: "location_razed", row, col, cardId: loc.id });
+
+  // Store for potential "to" redirect
+  (ctx as any)._razedLocation = loc;
+}
+
+function execTo(p: Primitive, ctx: ExecutionContext): void {
+  const tokenNames = p.target?.tokens.map((t) => t.name) ?? [];
+  const razedLoc = (ctx as any)._razedLocation;
+
+  if (tokenNames.includes("hq") && razedLoc) {
+    const player = getPlayerById(ctx.draft, ctx.playerId);
+    player.hq.push(razedLoc);
+    (ctx as any)._razedLocation = undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Contest resolution
+// ---------------------------------------------------------------------------
+
+function executeContest(step: Step, ctx: ExecutionContext): void {
+  const p = step.primitive;
+  const stat = p.subVerb as "strength" | "cunning" | "charisma";
+  if (!stat) throw new Error("contest verb requires a stat subVerb");
+
+  const bonus = p.value ?? 0;
+  const targets = resolveUnitTargets(p.target, ctx);
+  if (targets.length === 0) return;
+
+  const target = targets[0];
+  ctx._lastTarget = target;
+
+  if (!ctx.actingUnitId) throw new Error("contest requires an acting unit");
+  const actingPos = findUnitOnGrid(ctx.draft.grid, ctx.actingUnitId);
+  if (!actingPos) return;
+  const attacker = actingPos.unit as Draft<UnitCard>;
+
+  const targetPos = findUnitOnGrid(ctx.draft.grid, target.id);
+  if (!targetPos) return;
+
+  // Get modified stats
+  const atkStat = getModifiedStat(
+    ctx.draft as MainGameState, ctx.queries, attacker as UnitCard, stat,
+    { row: actingPos.row, col: actingPos.col },
+    { role: "attacker", row: actingPos.row, col: actingPos.col },
+  );
+  const defStat = getModifiedStat(
+    ctx.draft as MainGameState, ctx.queries, target as UnitCard, stat,
+    { row: targetPos.row, col: targetPos.col },
+    { role: "defender", row: targetPos.row, col: targetPos.col },
+  );
+
+  // Roll d6 for each
+  let [atkRoll, rng1] = prand.uniformIntDistribution(1, 6, ctx.rng);
+  let [defRoll, rng2] = prand.uniformIntDistribution(1, 6, rng1);
+  ctx.rng = rng2;
+
+  const atkPower = atkStat + atkRoll + bonus;
+  const defPower = defStat + defRoll;
+
+  // Ties go to defender
+  const attackerWins = atkPower > defPower;
+
+  if (step.consequence) {
+    // Custom consequences
+    if (attackerWins && step.consequence.winEffect) {
+      for (const winStep of step.consequence.winEffect) {
+        executeStep(winStep, ctx);
+      }
+    } else if (!attackerWins && step.consequence.loseEffect) {
+      for (const loseStep of step.consequence.loseEffect) {
+        executeStep(loseStep, ctx);
+      }
+    }
+  } else {
+    // Default consequences for strength contests
+    if (stat === "strength") {
+      const winner = attackerWins ? attacker : target;
+      const loser = attackerWins ? target : attacker;
+      const loserPos = findUnitOnGrid(ctx.draft.grid, loser.id);
+      if (!loserPos) return;
+      const cell = ctx.draft.grid[loserPos.row][loserPos.col];
+      const killRatio = 2;
+      const winnerPower = attackerWins ? atkPower : defPower;
+      const loserPower = attackerWins ? defPower : atkPower;
+
+      if (loser.injured || winnerPower >= killRatio * loserPower) {
+        killUnit(ctx.draft, cell, loser, loserPos.row, loserPos.col, ctx.emit);
+      } else {
+        injureUnit(cell, loser, loserPos.row, loserPos.col, ctx.emit);
+      }
+    }
+    // Other stats: no default consequence
+  }
+}

--- a/engine/src/effect-dsl/executor.ts
+++ b/engine/src/effect-dsl/executor.ts
@@ -453,6 +453,16 @@ function executeContest(step: Step, ctx: ExecutionContext): void {
   // Ties go to defender
   const attackerWins = atkPower > defPower;
 
+  ctx.emit({
+    type: "contest_resolved",
+    stat,
+    attackerId: attacker.id,
+    defenderId: target.id,
+    attackerPower: atkPower,
+    defenderPower: defPower,
+    winnerId: attackerWins ? attacker.id : target.id,
+  });
+
   if (step.consequence) {
     // Custom consequences
     if (attackerWins && step.consequence.winEffect) {

--- a/engine/src/effect-dsl/index.ts
+++ b/engine/src/effect-dsl/index.ts
@@ -1,0 +1,10 @@
+export { parse, DSLParseError } from "./parser";
+export type {
+  Expression,
+  Effect,
+  Step,
+  Primitive,
+  Selector,
+  Token,
+  Consequence,
+} from "./types";

--- a/engine/src/effect-dsl/parser.ts
+++ b/engine/src/effect-dsl/parser.ts
@@ -1,0 +1,155 @@
+import { EmbeddedActionsParser } from "chevrotain";
+import { allTokens, Ident, Int, LParen, RParen, LBrack, RBrack, Plus, Dot, Gt, Tilde, Colon } from "./tokens";
+import { lexer } from "./tokens";
+import type { Expression, Effect, Step, Primitive, Selector, Token } from "./types";
+
+// ---------------------------------------------------------------------------
+// Post-processing: raw chain segments → proper AST with consequences
+// ---------------------------------------------------------------------------
+
+interface ChainSegment {
+  sep: ">" | ":";
+  primitive: Primitive;
+}
+
+function buildEffect(first: Primitive, segments: ChainSegment[]): Effect {
+  const steps: Step[] = [];
+  let current: Step = { primitive: first };
+
+  for (const seg of segments) {
+    if (seg.sep === ":") {
+      // Lose branch of ternary consequence
+      if (current.consequence) {
+        current.consequence.loseEffect = [{ primitive: seg.primitive }];
+      } else {
+        current.consequence = { winEffect: [], loseEffect: [{ primitive: seg.primitive }] };
+      }
+    } else if (current.primitive.verb === "contest" && !current.consequence) {
+      // First ">" after a contest = win consequence
+      current.consequence = { winEffect: [{ primitive: seg.primitive }] };
+    } else {
+      // Regular chain step
+      steps.push(current);
+      current = { primitive: seg.primitive };
+    }
+  }
+  steps.push(current);
+  return steps;
+}
+
+// ---------------------------------------------------------------------------
+// Chevrotain parser — keeps rules flat and simple
+// ---------------------------------------------------------------------------
+
+class EffectDSLParser extends EmbeddedActionsParser {
+  constructor() {
+    super(allTokens);
+    this.performSelfAnalysis();
+  }
+
+  // expression = chainedEffect ("+" chainedEffect)*
+  public expression = this.RULE("expression", (): Expression => {
+    const effects: Effect[] = [this.SUBRULE(this.chainedEffect)];
+    this.MANY(() => {
+      this.CONSUME(Plus);
+      effects.push(this.SUBRULE2(this.chainedEffect));
+    });
+    return effects;
+  });
+
+  // chainedEffect = primitive ((">" | ":") primitive)*
+  // Flat parse — post-processed by buildEffect
+  private chainedEffect = this.RULE("chainedEffect", (): Effect => {
+    const first = this.SUBRULE(this.primitive);
+    const segments: ChainSegment[] = [];
+    this.MANY(() => {
+      const sep = this.OR([
+        { ALT: () => { this.CONSUME(Gt); return ">" as const; } },
+        { ALT: () => { this.CONSUME(Colon); return ":" as const; } },
+      ]);
+      const prim = this.SUBRULE2(this.primitive);
+      segments.push({ sep, primitive: prim });
+    });
+    return buildEffect(first, segments);
+  });
+
+  // primitive = verb ("." subVerb)? target? value? modifier*
+  private primitive = this.RULE("primitive", (): Primitive => {
+    const verb = this.CONSUME(Ident).image;
+    let subVerb: string | undefined;
+    this.OPTION(() => {
+      this.CONSUME(Dot);
+      subVerb = this.CONSUME2(Ident).image;
+    });
+    let target: Selector | undefined;
+    this.OPTION2(() => {
+      target = this.SUBRULE(this.target);
+    });
+    let value: number | undefined;
+    this.OPTION3(() => {
+      value = this.SUBRULE(this.value);
+    });
+    const modifiers: string[] = [];
+    this.MANY2(() => {
+      this.CONSUME(Tilde);
+      modifiers.push(this.CONSUME3(Ident).image);
+    });
+    return { verb, subVerb, target, value, modifiers };
+  });
+
+  // target = "(" token ("+" token)* ")"
+  private target = this.RULE("target", (): Selector => {
+    this.CONSUME(LParen);
+    const tokens: Token[] = [this.SUBRULE(this.token)];
+    this.MANY(() => {
+      this.CONSUME(Plus);
+      tokens.push(this.SUBRULE2(this.token));
+    });
+    this.CONSUME(RParen);
+    return { tokens };
+  });
+
+  // token = ident value?
+  private token = this.RULE("token", (): Token => {
+    const name = this.CONSUME(Ident).image;
+    let count: number | undefined;
+    this.OPTION(() => {
+      count = this.SUBRULE(this.value);
+    });
+    return { name, count };
+  });
+
+  // value = "[" int "]"
+  private value = this.RULE("value", (): number => {
+    this.CONSUME(LBrack);
+    const n = parseInt(this.CONSUME(Int).image, 10);
+    this.CONSUME(RBrack);
+    return n;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+const parserInstance = new EffectDSLParser();
+
+export class DSLParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DSLParseError";
+  }
+}
+
+export function parse(input: string): Expression {
+  const { tokens, errors: lexErrors } = lexer.tokenize(input);
+  if (lexErrors.length > 0) {
+    throw new DSLParseError(`Lexer error in "${input}": ${lexErrors[0].message}`);
+  }
+  parserInstance.input = tokens;
+  const ast = parserInstance.expression();
+  if (parserInstance.errors.length > 0) {
+    throw new DSLParseError(`Parse error in "${input}": ${parserInstance.errors[0].message}`);
+  }
+  return ast;
+}

--- a/engine/src/effect-dsl/tokens.ts
+++ b/engine/src/effect-dsl/tokens.ts
@@ -1,0 +1,17 @@
+import { createToken, Lexer } from "chevrotain";
+
+export const Ident = createToken({ name: "Ident", pattern: /[a-zA-Z_][a-zA-Z0-9_]*/ });
+export const Int = createToken({ name: "Int", pattern: /-?[0-9]+/, longer_alt: Ident });
+export const LParen = createToken({ name: "LParen", pattern: /\(/ });
+export const RParen = createToken({ name: "RParen", pattern: /\)/ });
+export const LBrack = createToken({ name: "LBrack", pattern: /\[/ });
+export const RBrack = createToken({ name: "RBrack", pattern: /\]/ });
+export const Plus = createToken({ name: "Plus", pattern: /\+/ });
+export const Dot = createToken({ name: "Dot", pattern: /\./ });
+export const Gt = createToken({ name: "Gt", pattern: />/ });
+export const Tilde = createToken({ name: "Tilde", pattern: /~/ });
+export const Colon = createToken({ name: "Colon", pattern: /:/ });
+export const WS = createToken({ name: "WS", pattern: /\s+/, group: Lexer.SKIPPED });
+
+export const allTokens = [WS, Int, Ident, LParen, RParen, LBrack, RBrack, Plus, Dot, Gt, Tilde, Colon];
+export const lexer = new Lexer(allTokens);

--- a/engine/src/effect-dsl/types.ts
+++ b/engine/src/effect-dsl/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Effect DSL AST types.
+ *
+ * Expression = Effect[]  (compound: "+" joins parallel effects)
+ * Effect     = Step[]    (chain: ">" pipes sequential steps)
+ */
+
+/** Top-level: one or more parallel effects joined by "+". */
+export type Expression = Effect[];
+
+/** A chain of steps joined by ">". */
+export type Effect = Step[];
+
+export interface Step {
+  primitive: Primitive;
+  /** Ternary consequence — appears after ":" in a chain. */
+  consequence?: Consequence;
+}
+
+export interface Primitive {
+  verb: string;
+  subVerb?: string;
+  target?: Selector;
+  value?: number;
+  modifiers: string[];
+}
+
+export interface Selector {
+  tokens: Token[];
+}
+
+export interface Token {
+  name: string;
+  count?: number;
+}
+
+/** Win/lose branching for contests: `> winEffect : loseEffect` */
+export interface Consequence {
+  winEffect: Effect;
+  loseEffect?: Effect;
+}

--- a/engine/src/effect-dsl/types.ts
+++ b/engine/src/effect-dsl/types.ts
@@ -6,36 +6,36 @@
  */
 
 /** Top-level: one or more parallel effects joined by "+". */
-export type Expression = Effect[];
+export type Expression = readonly Effect[];
 
 /** A chain of steps joined by ">". */
-export type Effect = Step[];
+export type Effect = readonly Step[];
 
 export interface Step {
-  primitive: Primitive;
+  readonly primitive: Primitive;
   /** Ternary consequence — appears after ":" in a chain. */
-  consequence?: Consequence;
+  readonly consequence?: Consequence;
 }
 
 export interface Primitive {
-  verb: string;
-  subVerb?: string;
-  target?: Selector;
-  value?: number;
-  modifiers: string[];
+  readonly verb: string;
+  readonly subVerb?: string;
+  readonly target?: Selector;
+  readonly value?: number;
+  readonly modifiers: readonly string[];
 }
 
 export interface Selector {
-  tokens: Token[];
+  readonly tokens: readonly Token[];
 }
 
 export interface Token {
-  name: string;
-  count?: number;
+  readonly name: string;
+  readonly count?: number;
 }
 
 /** Win/lose branching for contests: `> winEffect : loseEffect` */
 export interface Consequence {
-  winEffect: Effect;
-  loseEffect?: Effect;
+  readonly winEffect: Effect;
+  readonly loseEffect?: Effect;
 }

--- a/engine/src/listeners/effects.ts
+++ b/engine/src/listeners/effects.ts
@@ -59,14 +59,15 @@ export const LOCATION_EFFECTS: Record<string, LocationEffectFactory> = {
       source: { type: "location", cardId: loc.id, definitionId: "the-silk-road", ownerId, position: { row, col } },
       on: "turn_started",
       condition: (state, event) => {
-        if (!("playerId" in event) || event.playerId !== ownerId) return false;
+        if (!("playerId" in event)) return false;
         const cell = state.grid[row]?.[col];
-        return cell != null && cell.units.length > 0;
+        return cell != null && cell.units.some((u) => u.ownerId === event.playerId);
       },
       apply: (_draft, _event, emit) => {
-        const player = getPlayerById(_draft, ownerId);
+        const pid = ("playerId" in _event) ? _event.playerId as string : ownerId;
+        const player = getPlayerById(_draft, pid);
         player.gold += 1;
-        emit({ type: "gold_changed", playerId: ownerId, amount: 1, reason: "the-silk-road" });
+        emit({ type: "gold_changed", playerId: pid, amount: 1, reason: "the-silk-road" });
       },
     }],
     queries: [],
@@ -77,15 +78,16 @@ export const LOCATION_EFFECTS: Record<string, LocationEffectFactory> = {
       source: { type: "location", cardId: loc.id, definitionId: "trade-port", ownerId, position: { row, col } },
       on: "turn_started",
       condition: (state, event) => {
-        if (!("playerId" in event) || event.playerId !== ownerId) return false;
+        if (!("playerId" in event)) return false;
         const cell = state.grid[row]?.[col];
         if (!cell) return false;
-        return cell.units.some((u) => u.attributes.includes("Diplomat"));
+        return cell.units.some((u) => u.ownerId === event.playerId && u.attributes.includes("Diplomat"));
       },
       apply: (_draft, _event, emit) => {
-        const player = getPlayerById(_draft, ownerId);
+        const pid = ("playerId" in _event) ? _event.playerId as string : ownerId;
+        const player = getPlayerById(_draft, pid);
         player.gold += 1;
-        emit({ type: "gold_changed", playerId: ownerId, amount: 1, reason: "trade-port" });
+        emit({ type: "gold_changed", playerId: pid, amount: 1, reason: "trade-port" });
       },
     }],
     queries: [],
@@ -602,6 +604,21 @@ export const TRAP_EFFECTS: Record<string, TrapEffectFactory> = {
         killUnit(draft, cell, unit, row, col, emit);
       } else {
         injureUnit(cell, unit, row, col, emit);
+      }
+    }),
+    queries: [],
+  }),
+
+  "highway-robbery": (trap, ownerId) => ({
+    listeners: makeEntryTrapListeners(trap, ownerId, (draft, _cell, unit, _row, _col, emit) => {
+      const victim = getPlayerById(draft, unit.ownerId);
+      const trapOwner = getPlayerById(draft, ownerId);
+      const stolen = Math.min(2, victim.gold);
+      victim.gold -= stolen;
+      trapOwner.gold += stolen;
+      if (stolen > 0) {
+        emit({ type: "gold_changed", playerId: unit.ownerId, amount: -stolen, reason: "highway-robbery" });
+        emit({ type: "gold_changed", playerId: ownerId, amount: stolen, reason: "highway-robbery" });
       }
     }),
     queries: [],

--- a/engine/src/listeners/query.ts
+++ b/engine/src/listeners/query.ts
@@ -32,6 +32,11 @@ export function getModifiedStat(
     delta += q.modify(state, ctx);
   }
 
+  // Include temporary stat modifiers from effects (buff verb)
+  for (const mod of unit.statModifiers ?? []) {
+    if (mod.stat === stat) delta += mod.delta;
+  }
+
   return Math.max(0, base + delta);
 }
 

--- a/engine/src/listeners/types.ts
+++ b/engine/src/listeners/types.ts
@@ -42,7 +42,6 @@ export interface EffectListener {
 // Query listeners (pure — no mutation)
 // ---------------------------------------------------------------------------
 
-// StatName imported from ../types (canonical definition)
 
 export interface StatQueryContext {
   unit: UnitCard;

--- a/engine/src/listeners/types.ts
+++ b/engine/src/listeners/types.ts
@@ -1,5 +1,5 @@
 import type { Draft } from "immer";
-import type { Card, GameEvent, MainAction, MainGameState, UnitCard } from "../types";
+import type { Card, GameEvent, MainAction, MainGameState, StatName, UnitCard } from "../types";
 
 /** Where the effect originates — enough to identify the source card. */
 export interface EffectSource {
@@ -42,7 +42,7 @@ export interface EffectListener {
 // Query listeners (pure — no mutation)
 // ---------------------------------------------------------------------------
 
-export type StatName = "strength" | "cunning" | "charisma";
+// StatName imported from ../types (canonical definition)
 
 export interface StatQueryContext {
   unit: UnitCard;

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -47,6 +47,11 @@ export type CardType = "unit" | "location" | "item" | "event" | "policy";
 export type Rarity = "common" | "uncommon" | "rare" | "epic" | "legendary";
 export type EventSubtype = "instant" | "passive" | "trap";
 
+export interface GridPosition {
+  row: number;
+  col: number;
+}
+
 /** Edge state for location cards. */
 export interface LocationEdges {
   n: boolean; // true = open, false = blocked
@@ -67,11 +72,25 @@ interface CardBase {
   ownerId: string;
 }
 
+export type StatName = "strength" | "cunning" | "charisma";
+
+export interface ActionDef {
+  name: string;
+  apCost: number;
+  effect: string;
+}
+
 export interface StatModifier {
-  stat: "strength" | "cunning" | "charisma";
+  stat: StatName;
   delta: number;
+  /** Decremented at end of each turn. Removed when reaching 0. */
   remainingDuration: number;
   source: string;
+}
+
+export interface ControlOverride {
+  previousOwnerId: string;
+  remainingDuration: number;
 }
 
 export interface UnitCard extends CardBase {
@@ -81,9 +100,9 @@ export interface UnitCard extends CardBase {
   charisma: number;
   attributes: string[];
   injured: boolean;
-  actions?: { name: string; apCost: number; effect: string }[];
+  actions?: ActionDef[];
   statModifiers?: StatModifier[];
-  controlOverride?: { previousOwnerId: string; remainingDuration: number };
+  controlOverride?: ControlOverride;
 }
 
 export interface LocationCard extends CardBase {
@@ -283,8 +302,7 @@ export type MainAction =
       cardId: string;
       actionName: string;
       targetId?: string;
-      targetRow?: number;
-      targetCol?: number;
+      targetCell?: GridPosition;
     }
   | { type: "draw"; playerId: string }
   | {
@@ -443,9 +461,10 @@ export type GameEvent =
       slotIndex: number;
     }
   | { type: "card_discarded"; playerId: string; cardId: string; reason: string }
-  | { type: "unit_buffed"; unitId: string; stat: string; delta: number; source: string }
+  | { type: "unit_buffed"; unitId: string; stat: StatName; delta: number; source: string }
   | { type: "cards_revealed"; playerId: string; cardIds: string[]; source: string }
   | { type: "unit_controlled"; unitId: string; controllerId: string; previousOwnerId: string; duration: number }
+  | { type: "contest_resolved"; stat: StatName; attackerId: string; defenderId: string; attackerPower: number; defenderPower: number; winnerId: string }
   | { type: "passive_expired"; playerId: string; cardId: string }
   | { type: "unit_healed"; playerId: string; unitId: string }
   // Seeding phase events

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -67,6 +67,13 @@ interface CardBase {
   ownerId: string;
 }
 
+export interface StatModifier {
+  stat: "strength" | "cunning" | "charisma";
+  delta: number;
+  remainingDuration: number;
+  source: string;
+}
+
 export interface UnitCard extends CardBase {
   type: "unit";
   strength: number;
@@ -74,6 +81,9 @@ export interface UnitCard extends CardBase {
   charisma: number;
   attributes: string[];
   injured: boolean;
+  actions?: { name: string; apCost: number; effect: string }[];
+  statModifiers?: StatModifier[];
+  controlOverride?: { previousOwnerId: string; remainingDuration: number };
 }
 
 export interface LocationCard extends CardBase {
@@ -98,6 +108,7 @@ interface EventCardBase extends CardBase {
 
 export interface InstantEventCard extends EventCardBase {
   subtype: "instant";
+  effect?: string;
 }
 
 export interface PassiveEventCard extends EventCardBase {
@@ -272,6 +283,8 @@ export type MainAction =
       cardId: string;
       actionName: string;
       targetId?: string;
+      targetRow?: number;
+      targetCol?: number;
     }
   | { type: "draw"; playerId: string }
   | {
@@ -430,6 +443,9 @@ export type GameEvent =
       slotIndex: number;
     }
   | { type: "card_discarded"; playerId: string; cardId: string; reason: string }
+  | { type: "unit_buffed"; unitId: string; stat: string; delta: number; source: string }
+  | { type: "cards_revealed"; playerId: string; cardIds: string[]; source: string }
+  | { type: "unit_controlled"; unitId: string; controllerId: string; previousOwnerId: string; duration: number }
   | { type: "passive_expired"; playerId: string; cardId: string }
   | { type: "unit_healed"; playerId: string; unitId: string }
   // Seeding phase events

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -429,6 +429,7 @@ export type GameEvent =
       cardId: string;
       slotIndex: number;
     }
+  | { type: "card_discarded"; playerId: string; cardId: string; reason: string }
   | { type: "passive_expired"; playerId: string; cardId: string }
   | { type: "unit_healed"; playerId: string; unitId: string }
   // Seeding phase events

--- a/engine/src/valid-actions.ts
+++ b/engine/src/valid-actions.ts
@@ -1,3 +1,4 @@
+import { parse } from "./effect-dsl";
 import { tryParseCost } from "./cost-helpers";
 import { checkMissionRequirements, parseRequirements } from "./mission-helpers";
 import type { BoardPosition } from "./position-helpers";
@@ -333,7 +334,156 @@ function getMainValidActions(
     }
   }
 
-  // activate — deferred to #20
+  // activate — unit actions from grid units
+  for (let r = 0; r < gridRows; r++) {
+    for (let c = 0; c < gridCols; c++) {
+      for (const unit of state.grid[r][c].units) {
+        if (unit.ownerId !== playerId) continue;
+        if (!unit.actions) continue;
+        for (const actionDef of unit.actions) {
+          if (ap < actionDef.apCost) continue;
+          const targets = inferActivateTargets(state, unit.id, actionDef.effect, r, c, playerId);
+          for (const t of targets) {
+            actions.push({
+              type: "activate",
+              playerId,
+              cardId: unit.id,
+              actionName: actionDef.name,
+              ...t,
+            });
+          }
+        }
+      }
+    }
+  }
 
   return actions;
+}
+
+// ---------------------------------------------------------------------------
+// Activate target inference
+// ---------------------------------------------------------------------------
+
+type ActivateTarget = {
+  targetId?: string;
+  targetRow?: number;
+  targetCol?: number;
+};
+
+/**
+ * Infer valid targets for an activate action by doing a shallow parse of
+ * the DSL effect string. Returns one entry per valid target combination.
+ */
+function inferActivateTargets(
+  state: MainGameState,
+  unitId: string,
+  effectStr: string,
+  unitRow: number,
+  unitCol: number,
+  playerId: string,
+): ActivateTarget[] {
+  let ast;
+  try {
+    ast = parse(effectStr);
+  } catch {
+    return [{}]; // Unparseable — let executor handle the error
+  }
+
+  // Scan the first verb in each compound member to determine targeting needs
+  const targetSets: ActivateTarget[][] = [];
+
+  for (const effect of ast) {
+    if (effect.length === 0) continue;
+    const first = effect[0].primitive;
+    const tokenNames = first.target?.tokens.map((t) => t.name) ?? [];
+
+    if (tokenNames.includes("self") || tokenNames.length === 0) {
+      // Self or no target — check if the verb is "move"
+      if (first.verb === "move" && tokenNames.includes("self")) {
+        // One action per valid adjacent cell
+        const moves = getAdjacentMoveTargets(state, unitRow, unitCol);
+        targetSets.push(moves.map((m) => ({ targetRow: m.row, targetCol: m.col })));
+      } else {
+        targetSets.push([{}]);
+      }
+    } else if (tokenNames.includes("enemy")) {
+      const adjacent = tokenNames.includes("adjacent");
+      const enemies = getUnitsInRange(state, unitRow, unitCol, playerId, "enemy", adjacent);
+      if (enemies.length === 0) return []; // No valid targets
+      targetSets.push(enemies.map((u) => ({ targetId: u.id })));
+    } else if (tokenNames.includes("friendly")) {
+      if (tokenNames.includes("all")) {
+        targetSets.push([{}]); // All friendly — no individual targeting
+      } else {
+        const friends = getUnitsInRange(state, unitRow, unitCol, playerId, "friendly", false);
+        if (friends.length === 0) return [];
+        targetSets.push(friends.map((u) => ({ targetId: u.id })));
+      }
+    } else if (tokenNames.includes("opponent") || tokenNames.includes("deck") ||
+               tokenNames.includes("location") || tokenNames.includes("market")) {
+      targetSets.push([{}]); // No unit targeting needed
+    } else {
+      targetSets.push([{}]);
+    }
+  }
+
+  if (targetSets.length === 0) return [{}];
+
+  // For compound effects, the first compound member that needs targeting
+  // determines the action targets. Later members use the same context.
+  // Find the first set with actual targeting (not just [{}])
+  for (const set of targetSets) {
+    if (set.length > 0 && set.some((t) => t.targetId || t.targetRow !== undefined)) {
+      return set;
+    }
+  }
+  return [{}];
+}
+
+function getAdjacentMoveTargets(
+  state: MainGameState,
+  row: number,
+  col: number,
+): { row: number; col: number }[] {
+  const results: { row: number; col: number }[] = [];
+  const dirs = [[-1, 0], [1, 0], [0, -1], [0, 1]] as const;
+  for (const [dr, dc] of dirs) {
+    const r = row + dr;
+    const c = col + dc;
+    if (r < 0 || r >= state.grid.length || c < 0 || c >= state.grid[0].length) continue;
+    if (!state.grid[r][c].location) continue;
+    if (areFacingEdgesOpen(state.grid, row, col, r, c)) {
+      results.push({ row: r, col: c });
+    }
+  }
+  return results;
+}
+
+function getUnitsInRange(
+  state: MainGameState,
+  row: number,
+  col: number,
+  playerId: string,
+  filter: "enemy" | "friendly",
+  adjacent: boolean,
+): { id: string }[] {
+  const units: { id: string }[] = [];
+  if (adjacent) {
+    const dirs = [[-1, 0], [1, 0], [0, -1], [0, 1]] as const;
+    for (const [dr, dc] of dirs) {
+      const r = row + dr;
+      const c = col + dc;
+      if (r < 0 || r >= state.grid.length || c < 0 || c >= state.grid[0].length) continue;
+      for (const u of state.grid[r][c].units) {
+        if (filter === "enemy" && u.ownerId !== playerId) units.push({ id: u.id });
+        if (filter === "friendly" && u.ownerId === playerId) units.push({ id: u.id });
+      }
+    }
+  } else {
+    for (const u of state.grid[row][col].units) {
+      if (filter === "enemy" && u.ownerId !== playerId) units.push({ id: u.id });
+      if (filter === "friendly" && u.ownerId === playerId) units.push({ id: u.id });
+    }
+  }
+  return units;
 }

--- a/engine/src/valid-actions.ts
+++ b/engine/src/valid-actions.ts
@@ -1,4 +1,4 @@
-import { parse } from "./effect-dsl";
+import { parse, DSLParseError } from "./effect-dsl";
 import { tryParseCost } from "./cost-helpers";
 import { checkMissionRequirements, parseRequirements } from "./mission-helpers";
 import type { BoardPosition } from "./position-helpers";
@@ -366,8 +366,7 @@ function getMainValidActions(
 
 type ActivateTarget = {
   targetId?: string;
-  targetRow?: number;
-  targetCol?: number;
+  targetCell?: { row: number; col: number };
 };
 
 /**
@@ -376,7 +375,7 @@ type ActivateTarget = {
  */
 function inferActivateTargets(
   state: MainGameState,
-  unitId: string,
+  _unitId: string,
   effectStr: string,
   unitRow: number,
   unitCol: number,
@@ -385,8 +384,12 @@ function inferActivateTargets(
   let ast;
   try {
     ast = parse(effectStr);
-  } catch {
-    return [{}]; // Unparseable — let executor handle the error
+  } catch (err) {
+    if (err instanceof DSLParseError) {
+      console.warn(`Unparseable effect "${effectStr}": ${err.message}`);
+      return [{}];
+    }
+    throw err;
   }
 
   // Scan the first verb in each compound member to determine targeting needs
@@ -402,7 +405,7 @@ function inferActivateTargets(
       if (first.verb === "move" && tokenNames.includes("self")) {
         // One action per valid adjacent cell
         const moves = getAdjacentMoveTargets(state, unitRow, unitCol);
-        targetSets.push(moves.map((m) => ({ targetRow: m.row, targetCol: m.col })));
+        targetSets.push(moves.map((m) => ({ targetCell: { row: m.row, col: m.col } })));
       } else {
         targetSets.push([{}]);
       }
@@ -433,7 +436,7 @@ function inferActivateTargets(
   // determines the action targets. Later members use the same context.
   // Find the first set with actual targeting (not just [{}])
   for (const set of targetSets) {
-    if (set.length > 0 && set.some((t) => t.targetId || t.targetRow !== undefined)) {
+    if (set.length > 0 && set.some((t) => t.targetId || t.targetCell)) {
       return set;
     }
   }

--- a/engine/src/valid-actions.ts
+++ b/engine/src/valid-actions.ts
@@ -251,12 +251,17 @@ function getMainValidActions(
     ];
 
     for (const pos of positions) {
+      // HQ: all items/units belong to the player by definition.
+      // Grid: filter by ownerId since multiple players share cells.
+      const ownerFilter = pos.type === "hq";
       const items = getItemsAtPosition(state.players, state.grid, pos)
-        .filter((i) => i.ownerId === playerId);
+        .filter((i) => ownerFilter || i.ownerId === playerId);
       const units = getUnitsAtPosition(state.players, state.grid, pos)
-        .filter((u) => u.ownerId === playerId);
+        .filter((u) => ownerFilter || u.ownerId === playerId);
       for (const item of items) {
         for (const unit of units) {
+          // Skip if already equipped on this unit
+          if (item.equippedTo === unit.id) continue;
           actions.push({ type: "equip", playerId, itemId: item.id, unitId: unit.id });
         }
       }

--- a/library/build.ts
+++ b/library/build.ts
@@ -10,7 +10,8 @@
  */
 
 import { readdirSync, readFileSync, mkdirSync, writeFileSync, existsSync } from "fs";
-import { join, basename } from "path";
+import { join } from "path";
+import { parse as parseDSL, DSLParseError } from "../engine/src/effect-dsl";
 
 const LIBRARY_DIR = join(import.meta.dir);
 const SETS_DIR = join(LIBRARY_DIR, "sets");
@@ -141,6 +142,7 @@ function transformCard(type: CardType, raw: Record<string, string>): Record<stri
       base.subtype = raw.subtype;
       base.duration = intOrNull(raw.duration || "");
       base.trigger = raw.trigger || null;
+      if (raw.effect) base.effect = raw.effect;
       break;
 
     case "policies":
@@ -168,6 +170,27 @@ function validate(type: CardType, card: Record<string, unknown>): ValidationErro
 
   if (type === "events" && !EVENT_SUBTYPES.includes(card.subtype as any)) {
     errors.push({ card: id, field: "subtype", message: `invalid subtype: ${card.subtype}` });
+  }
+
+  // DSL effect validation
+  const actions = card.actions as { name: string; apCost: number; effect: string }[] | undefined;
+  if (actions) {
+    for (const action of actions) {
+      try {
+        parseDSL(action.effect);
+      } catch (e) {
+        const msg = e instanceof DSLParseError ? e.message : String(e);
+        errors.push({ card: id, field: "actions", message: `invalid DSL in action "${action.name}": ${msg}` });
+      }
+    }
+  }
+  if (card.subtype === "instant" && card.effect) {
+    try {
+      parseDSL(card.effect as string);
+    } catch (e) {
+      const msg = e instanceof DSLParseError ? e.message : String(e);
+      errors.push({ card: id, field: "effect", message: `invalid DSL: ${msg}` });
+    }
   }
 
   return errors;

--- a/library/schema.md
+++ b/library/schema.md
@@ -81,3 +81,172 @@ Stat checks always sum across all friendly units at the location — the attribu
 - **Semicolons** (`;`) separate list items within a single field (attributes, keywords, actions, requirements)
 - **Pipes** (`|`) separate alternative costs
 - **Colons** (`:`) separate action components (name:ap_cost:effect)
+
+## Effect DSL
+
+A structured mini-language for encoding card effects as data. Used in the
+`effect` component of action definitions (`name:ap_cost:effect`) and in
+instant event effects. The engine interprets the DSL — new cards are data,
+not code.
+
+### Grammar
+
+```
+expression  = effect ( "+" effect )*          -- compound (parallel)
+effect      = step ( ">" step )*              -- chain (sequential / pipe)
+step        = primitive consequence?
+primitive   = verb target? value? modifier*
+verb        = IDENT ( "." IDENT )?            -- e.g. contest.strength, buff.charisma
+target      = "(" selector ")"
+selector    = token ( "+" token )*            -- composable filters
+token       = IDENT value?                    -- e.g. friendly, enemy[2], deck
+value       = "[" NUMBER "]"                  -- e.g. [3], [-1], [0]
+modifier    = "~" IDENT                       -- e.g. ~turn, ~round, ~ignore_blocked
+consequence = ">" effect ( ":" effect )?      -- ternary: win_effect : lose_effect
+```
+
+### Operators
+
+| Operator | Context | Meaning |
+|----------|---------|---------|
+| `.`      | verb    | Verb parameter — stat name, subtype. `contest.strength`, `buff.charisma` |
+| `()`     | target  | Who/what is affected. Encloses a selector expression. |
+| `+` inside `()` | target | Composable filter. Each token narrows the selection: `(all + friendly + here)` |
+| `+` outside `()` | effect | Compound — both effects happen in parallel. `gold[1] + move(self)` |
+| `[]`     | value   | Numeric parameter. Inside `()` = target count. Outside = effect value. |
+| `>`      | chain   | Pipe/sequence — output of left feeds into right. `reveal(deck)[3] > pick[1]` |
+| `~`      | modifier | Modifies preceding effect. Duration (`~turn`, `~round`) or rule flag (`~ignore_blocked`). |
+| `:`      | consequence | Separates win/lose effects (ternary). `> win_effect : lose_effect` |
+
+### Verbs
+
+Core primitives the engine implements. New cards compose these — no per-card code.
+
+| Verb | Value meaning | Description |
+|------|---------------|-------------|
+| `gold` | amount | Gain (positive) or lose (negative) gold. `gold[3]`, `gold[-2]` |
+| `vp` | amount | Gain victory points. `vp[1]` |
+| `draw` | count | Draw cards from your deck. `draw[2]`. Implicit `[1]`. |
+| `buy` | cost override | Buy a card from market. `buy(item)[0]` = buy item for free. `buy[-1]` = 1 gold discount on anything. |
+| `move` | distance | Move a unit. `move(self)[2]` = 2 spaces. Implicit `[1]`. |
+| `reveal` | count | Reveal cards from a zone. `reveal(deck)[3]`, `reveal(opponent + hand)` |
+| `pick` | count | Player picks N from previously revealed cards (used after `>` pipe from `reveal`). `reveal(deck)[3] > pick[1]` |
+| `buff.STAT` | amount | Temporary stat increase. Requires `~duration`. `buff.strength(all + friendly)[2]~turn` |
+| `contest.STAT` | bonus | Stat contest using named stat. Value = attacker bonus. `contest.strength[3]` = +3 bonus. |
+| `injure` | — | Injure target unit. `injure(enemy)` |
+| `kill` | — | Kill target unit. `kill(self)` |
+| `control` | — | Take control of target. Requires `~duration`. `control(target)~round` |
+| `raze` | — | Remove a location from the grid. `raze(location)` |
+| `to` | — | Move result to a zone (used after `>` pipe). `raze(location) > to(hq)` |
+| `remove` | — | Remove card from play. `remove(location)` |
+
+### Targets
+
+Targets are composable selectors inside `()`. Each `+` token narrows the selection.
+Player choice is implied when multiple valid targets exist.
+
+#### Entity tokens
+
+| Token | Meaning |
+|-------|---------|
+| `self` | The unit performing the action |
+| `target` | The previously targeted entity (back-reference in chains) |
+| `enemy` | Enemy unit |
+| `friendly` | Friendly unit (not self) |
+| `all` | All matching entities (no player choice) |
+| `random` | Random selection (no player choice) |
+
+#### Scope tokens
+
+| Token | Meaning |
+|-------|---------|
+| `here` | Same location as acting unit (default for most effects — can be omitted) |
+| `adjacent` | Orthogonally adjacent location |
+
+#### Zone tokens
+
+| Token | Meaning |
+|-------|---------|
+| `deck` | Your main deck |
+| `hand` | Your hand |
+| `hq` | Your HQ |
+| `opponent` | Scopes to opponent. Combine: `(opponent + hand)`, `(opponent + deck)` |
+| `market` | The shared market |
+| `location` | A location on the grid |
+
+#### Target count
+
+`[N]` inside parentheses specifies how many targets: `(friendly[2])` = up to 2 friendly units.
+Omitting count implies 1 for targeted effects, or all for `(all + ...)`.
+
+### Modifiers
+
+Attached to the preceding effect with `~` (no space). Multiple modifiers
+can chain: `move(friendly)~ignore_blocked~no_ap`.
+
+#### Duration modifiers
+
+| Modifier | Meaning |
+|----------|---------|
+| `~turn` | Until end of current turn |
+| `~round` | Until end of round (both players have passed) |
+| `~N` | For N turns (e.g. `~3` for 3 turns) |
+
+#### Rule modifiers
+
+| Modifier | Meaning |
+|----------|---------|
+| `~ignore_blocked` | Ignore blocked edges when moving |
+
+### Contests
+
+Stat contests use the `contest.STAT` verb. Resolution follows [Stat Contests](../rules/stat-contests.md):
+each unit rolls d6, attack power = stat + d6 + bonus, higher wins, ties go to defender.
+
+**Default consequences** (when no `>` is specified):
+- `contest.strength` → loser is injured (killed if winner's power ≥ 2× loser's)
+- All other stats → no default consequence (must specify via `>`)
+
+**Custom consequences** use ternary syntax after `>`:
+```
+contest.charisma(enemy + adjacent) > control(target)~round
+```
+Win consequence only — no lose effect.
+
+```
+contest.strength(enemy)[3] > gold[3] : gold[-2]
+```
+Win: gain 3 gold. Lose: lose 2 gold. The `[3]` on contest is the attacker bonus.
+
+### Examples
+
+Complete action definitions (`name:ap_cost:effect`):
+
+| Card | Action definition |
+|------|-------------------|
+| Leonardo da Vinci | `design:1:draw[2]` |
+| Mansa Musa | `pilgrimage:2:gold[5]` |
+| Miyamoto Musashi | `duel:1:contest.strength(enemy)` |
+| Cleopatra | `diplomacy:1:contest.charisma(enemy + adjacent) > control(target)~round` |
+| Hannibal Barca | `flank:2:contest.strength(enemy)[3]` |
+| Joan of Arc | `rally:1:buff.strength(all + friendly)[2]~turn` |
+| Hypatia | `lecture:1:buff.cunning(friendly)[2]~turn` |
+| Nefertiti | `inspire:1:buff.charisma(all + friendly)[2]~turn` |
+| Marco Polo | `trade-route:1:move(self) + gold[1]` |
+| Ibn Battuta | `wander:1:move(self) + gold[1]` |
+| Sun Tzu | `stratagem:1:move(enemy)` |
+| Harriet Tubman | `underground:1:move(friendly)~ignore_blocked` |
+| Alexander the Great | `march:1:move(self) + contest.strength(enemy)` |
+| Ada Lovelace | `analyze:1:reveal(deck)[3] > pick[1]` |
+| Galileo Galilei | `observe:1:reveal(opponent + hand)` |
+| Nikola Tesla | `invent:2:buy(item)[0]` |
+| Genghis Khan | `conquer:3:raze(location) > to(hq)` |
+| Ramesses II | `monument:2:vp[1] + kill(self)` |
+
+Instant event effects (standalone, no name/cost wrapper):
+
+| Card | Effect |
+|------|--------|
+| Harvest Festival | `gold[3]` |
+| Earthquake | `injure(all + here) + remove(location)` |
+| Forced March | `move(friendly[2])` |

--- a/library/sets/alpha-1/events.csv
+++ b/library/sets/alpha-1/events.csv
@@ -6,7 +6,7 @@ diplomatic-summit,Diplomatic Summit,alpha-1,uncommon,2,passive,1,,Diplomacy,All 
 earthquake,Earthquake,alpha-1,epic,4,instant,,,Catastrophe,Remove target location from the grid. All units there are injured. Replacement is drawn.,The earth decides who stays.
 renaissance,Renaissance,alpha-1,epic,5,passive,3,,Prosperity,All your Scientist units get +2 cunning for 3 turns.,The world woke up and started asking questions.
 arms-race,Arms Race,alpha-1,uncommon,3,passive,2,,Military,All your Warrior units get +2 strength for 2 turns.,Build faster. Build stronger. Build more.
-sabotage,Sabotage,alpha-1,uncommon,2,trap,,enemy_unit_uses_action,Military,When an enemy unit at this location uses an action: cancel the action. Discard after triggering.,The gears were not supposed to stop.
+highway-robbery,Highway Robbery,alpha-1,uncommon,2,trap,,enemy_unit_enters_location,Commerce,When an enemy unit enters this location: steal 2 gold from that unit's owner.,The road giveth the road taketh away.
 trade-embargo,Trade Embargo,alpha-1,uncommon,3,passive,2,,Commerce,Target opponent's market purchases cost 2 more gold for 2 turns.,The ships turned away.
 assassination-attempt,Assassination Attempt,alpha-1,epic,4,trap,,enemy_unit_enters_location,Military,When an enemy unit enters this location: if that unit's strength is 6 or less kill it.,History turns on a single blade.
 forced-march,Forced March,alpha-1,common,1,instant,,,Military,Move up to 2 of your units to adjacent locations.,No rest until the objective.

--- a/library/sets/alpha-1/events.csv
+++ b/library/sets/alpha-1/events.csv
@@ -1,13 +1,13 @@
-id,name,set,rarity,cost,subtype,duration,trigger,keywords,text,flavor
-plague,Plague,alpha-1,epic,4,passive,,,Catastrophe,Place on target location. All units at this location and adjacent locations get -2 strength. Discarded when the location is removed from the grid.,It spared no one.
-golden-age,Golden Age,alpha-1,epic,5,passive,3,,Prosperity,You gain +1 gold per turn for 3 turns.,The coffers overflow and the people rejoice.
-ambush,Ambush,alpha-1,uncommon,2,trap,,enemy_unit_enters_location,Military,When an enemy unit enters this location: injure that unit.,They never saw it coming.
-diplomatic-summit,Diplomatic Summit,alpha-1,uncommon,2,passive,1,,Diplomacy,All Diplomat units get +2 charisma for 1 turn.,Words sharper than any blade.
-earthquake,Earthquake,alpha-1,epic,4,instant,,,Catastrophe,Remove target location from the grid. All units there are injured. Replacement is drawn.,The earth decides who stays.
-renaissance,Renaissance,alpha-1,epic,5,passive,3,,Prosperity,All your Scientist units get +2 cunning for 3 turns.,The world woke up and started asking questions.
-arms-race,Arms Race,alpha-1,uncommon,3,passive,2,,Military,All your Warrior units get +2 strength for 2 turns.,Build faster. Build stronger. Build more.
-highway-robbery,Highway Robbery,alpha-1,uncommon,2,trap,,enemy_unit_enters_location,Commerce,When an enemy unit enters this location: steal 2 gold from that unit's owner.,The road giveth the road taketh away.
-trade-embargo,Trade Embargo,alpha-1,uncommon,3,passive,2,,Commerce,Target opponent's market purchases cost 2 more gold for 2 turns.,The ships turned away.
-assassination-attempt,Assassination Attempt,alpha-1,epic,4,trap,,enemy_unit_enters_location,Military,When an enemy unit enters this location: if that unit's strength is 6 or less kill it.,History turns on a single blade.
-forced-march,Forced March,alpha-1,common,1,instant,,,Military,Move up to 2 of your units to adjacent locations.,No rest until the objective.
-harvest-festival,Harvest Festival,alpha-1,common,1,instant,,,Prosperity,Gain 3 gold.,The fields provide.
+id,name,set,rarity,cost,subtype,duration,trigger,keywords,text,flavor,effect
+plague,Plague,alpha-1,epic,4,passive,,,Catastrophe,Place on target location. All units at this location and adjacent locations get -2 strength. Discarded when the location is removed from the grid.,It spared no one.,
+golden-age,Golden Age,alpha-1,epic,5,passive,3,,Prosperity,You gain +1 gold per turn for 3 turns.,The coffers overflow and the people rejoice.,
+ambush,Ambush,alpha-1,uncommon,2,trap,,enemy_unit_enters_location,Military,When an enemy unit enters this location: injure that unit.,They never saw it coming.,
+diplomatic-summit,Diplomatic Summit,alpha-1,uncommon,2,passive,1,,Diplomacy,All Diplomat units get +2 charisma for 1 turn.,Words sharper than any blade.,
+earthquake,Earthquake,alpha-1,epic,4,instant,,,Catastrophe,Remove target location from the grid. All units there are injured. Replacement is drawn.,The earth decides who stays.,injure(all + here) + remove(location)
+renaissance,Renaissance,alpha-1,epic,5,passive,3,,Prosperity,All your Scientist units get +2 cunning for 3 turns.,The world woke up and started asking questions.,
+arms-race,Arms Race,alpha-1,uncommon,3,passive,2,,Military,All your Warrior units get +2 strength for 2 turns.,Build faster. Build stronger. Build more.,
+highway-robbery,Highway Robbery,alpha-1,uncommon,2,trap,,enemy_unit_enters_location,Commerce,When an enemy unit enters this location: steal 2 gold from that unit's owner.,The road giveth the road taketh away.,
+trade-embargo,Trade Embargo,alpha-1,uncommon,3,passive,2,,Commerce,Target opponent's market purchases cost 2 more gold for 2 turns.,The ships turned away.,
+assassination-attempt,Assassination Attempt,alpha-1,epic,4,trap,,enemy_unit_enters_location,Military,When an enemy unit enters this location: if that unit's strength is 6 or less kill it.,History turns on a single blade.,
+forced-march,Forced March,alpha-1,common,1,instant,,,Military,Move up to 2 of your units to adjacent locations.,No rest until the objective.,move(friendly[2])
+harvest-festival,Harvest Festival,alpha-1,common,1,instant,,,Prosperity,Gain 3 gold.,The fields provide.,gold[3]

--- a/library/sets/alpha-1/units.csv
+++ b/library/sets/alpha-1/units.csv
@@ -1,21 +1,21 @@
 id,name,set,rarity,cost,strength,cunning,charisma,attributes,keywords,actions,text,flavor
-cleopatra,Cleopatra,alpha-1,legendary,6,4,8,9,Politician;Diplomat,,diplomacy:1:charisma_contest_control,Target 1 adjacent unit. Move it to Cleopatra's location. Charisma contest: on win take control of target unit for this round.,The last pharaoh played Rome like a harp.
-nikola-tesla,Nikola Tesla,alpha-1,epic,4,3,9,5,Scientist;Engineer,,invent:2:buy_item_free,Buy an item from the market for free.,The man who lit the world — then vanished from it.
-miyamoto-musashi,Miyamoto Musashi,alpha-1,epic,5,9,7,4,Warrior,,duel:1:strength_contest_injure,Strength contest: injure target unit at same location.,Undefeated in sixty duels.
-ada-lovelace,Ada Lovelace,alpha-1,epic,3,3,8,5,Scientist,,analyze:1:look_at_top_3_deck,Look at the top 3 cards of your main deck. Keep one.,The first programmer — before the first computer.
-genghis-khan,Genghis Khan,alpha-1,legendary,7,8,7,6,Warrior;Politician,Military,conquer:3:raze_keep_location,Raze target location. Place it in your HQ instead of discarding. Mission VP is not awarded. Your Equip actions involving a Mount cost 0 AP.,He did not build. He took.
-leonardo-da-vinci,Leonardo da Vinci,alpha-1,legendary,7,5,10,7,Scientist;Engineer,,design:1:draw_2_cards,Draw 2 cards from your main deck.,The universal man needed no specialization.
-mansa-musa,Mansa Musa,alpha-1,legendary,8,4,6,10,Politician;Diplomat,,pilgrimage:2:gain_5_gold,Gain 5 gold.,His generosity crashed an economy.
-hypatia,Hypatia,alpha-1,epic,4,3,9,6,Scientist,,lecture:1:give_friendly_unit_plus2_cunning,Target friendly unit at same location gets +2 cunning until end of turn.,She taught Alexandria to think.
-sun-tzu,Sun Tzu,alpha-1,epic,5,7,9,4,Warrior;Scientist,,stratagem:1:move_enemy_unit,Move target enemy unit at same location to an adjacent location.,Supreme excellence consists in breaking the enemy's resistance without fighting.
-joan-of-arc,Joan of Arc,alpha-1,epic,5,7,4,8,Warrior;Spiritual,,rally:1:plus2_strength_friendly_units,All friendly units at this location get +2 strength until end of turn.,She heard voices — and a nation followed.
-marco-polo,Marco Polo,alpha-1,uncommon,3,4,5,8,Diplomat;Merchant,,trade-route:1:move_and_gain_gold,Move Marco Polo to an adjacent location and gain 1 gold.,Twenty-four years of road and wonder.
-alexander-the-great,Alexander the Great,alpha-1,legendary,8,9,7,8,Warrior;Politician,,march:1:move_and_attack,Move to adjacent location and initiate a strength contest against target unit there.,He wept for there were no more worlds to conquer.
-nefertiti,Nefertiti,alpha-1,uncommon,3,4,5,8,Politician;Spiritual,,inspire:1:plus2_charisma_all_friendly,All friendly units at this location get +2 charisma until end of turn.,Beauty was the least of her powers.
-galileo-galilei,Galileo Galilei,alpha-1,uncommon,3,3,8,4,Scientist,,observe:1:look_at_opponent_hand,Look at target opponent's hand.,And yet it moves.
-hannibal-barca,Hannibal Barca,alpha-1,epic,6,8,8,5,Warrior,,flank:2:strength_contest_plus3,Strength contest against target unit at same location with +3 bonus.,He brought elephants across mountains.
-harriet-tubman,Harriet Tubman,alpha-1,uncommon,2,5,7,7,Politician,,underground:1:move_friendly_unit_through_blocked,Move target friendly unit to an adjacent location ignoring one blocked edge.,She never lost a passenger.
-ibn-battuta,Ibn Battuta,alpha-1,common,2,3,7,6,Diplomat;Scientist,,wander:1:move_and_gain_gold,Move Ibn Battuta to an adjacent location and gain 1 gold.,Seventy-five thousand miles before the age of jet.
-ramesses-ii,Ramesses II,alpha-1,uncommon,4,7,5,7,Warrior;Politician,,monument:2:gain_1_vp_kill_self,Gain 1 VP. Ramesses II is killed.,He carved his name into eternity.
+cleopatra,Cleopatra,alpha-1,legendary,6,4,8,9,Politician;Diplomat,,diplomacy:1:contest.charisma(enemy + adjacent) > control(target)~round,Target 1 adjacent unit. Move it to Cleopatra's location. Charisma contest: on win take control of target unit for this round.,The last pharaoh played Rome like a harp.
+nikola-tesla,Nikola Tesla,alpha-1,epic,4,3,9,5,Scientist;Engineer,,invent:2:buy(item)[0],Buy an item from the market for free.,The man who lit the world — then vanished from it.
+miyamoto-musashi,Miyamoto Musashi,alpha-1,epic,5,9,7,4,Warrior,,duel:1:contest.strength(enemy),Strength contest: injure target unit at same location.,Undefeated in sixty duels.
+ada-lovelace,Ada Lovelace,alpha-1,epic,3,3,8,5,Scientist,,analyze:1:reveal(deck)[3] > pick[1],Look at the top 3 cards of your main deck. Keep one.,The first programmer — before the first computer.
+genghis-khan,Genghis Khan,alpha-1,legendary,7,8,7,6,Warrior;Politician,Military,conquer:3:raze(location) > to(hq),Raze target location. Place it in your HQ instead of discarding. Mission VP is not awarded. Your Equip actions involving a Mount cost 0 AP.,He did not build. He took.
+leonardo-da-vinci,Leonardo da Vinci,alpha-1,legendary,7,5,10,7,Scientist;Engineer,,design:1:draw[2],Draw 2 cards from your main deck.,The universal man needed no specialization.
+mansa-musa,Mansa Musa,alpha-1,legendary,8,4,6,10,Politician;Diplomat,,pilgrimage:2:gold[5],Gain 5 gold.,His generosity crashed an economy.
+hypatia,Hypatia,alpha-1,epic,4,3,9,6,Scientist,,lecture:1:buff.cunning(friendly)[2]~turn,Target friendly unit at same location gets +2 cunning until end of turn.,She taught Alexandria to think.
+sun-tzu,Sun Tzu,alpha-1,epic,5,7,9,4,Warrior;Scientist,,stratagem:1:move(enemy),Move target enemy unit at same location to an adjacent location.,Supreme excellence consists in breaking the enemy's resistance without fighting.
+joan-of-arc,Joan of Arc,alpha-1,epic,5,7,4,8,Warrior;Spiritual,,rally:1:buff.strength(all + friendly)[2]~turn,All friendly units at this location get +2 strength until end of turn.,She heard voices — and a nation followed.
+marco-polo,Marco Polo,alpha-1,uncommon,3,4,5,8,Diplomat;Merchant,,trade-route:1:move(self) + gold[1],Move Marco Polo to an adjacent location and gain 1 gold.,Twenty-four years of road and wonder.
+alexander-the-great,Alexander the Great,alpha-1,legendary,8,9,7,8,Warrior;Politician,,march:1:move(self) + contest.strength(enemy),Move to adjacent location and initiate a strength contest against target unit there.,He wept for there were no more worlds to conquer.
+nefertiti,Nefertiti,alpha-1,uncommon,3,4,5,8,Politician;Spiritual,,inspire:1:buff.charisma(all + friendly)[2]~turn,All friendly units at this location get +2 charisma until end of turn.,Beauty was the least of her powers.
+galileo-galilei,Galileo Galilei,alpha-1,uncommon,3,3,8,4,Scientist,,observe:1:reveal(opponent + hand),Look at target opponent's hand.,And yet it moves.
+hannibal-barca,Hannibal Barca,alpha-1,epic,6,8,8,5,Warrior,,flank:2:contest.strength(enemy)[3],Strength contest against target unit at same location with +3 bonus.,He brought elephants across mountains.
+harriet-tubman,Harriet Tubman,alpha-1,uncommon,2,5,7,7,Politician,,underground:1:move(friendly)~ignore_blocked,Move target friendly unit to an adjacent location ignoring one blocked edge.,She never lost a passenger.
+ibn-battuta,Ibn Battuta,alpha-1,common,2,3,7,6,Diplomat;Scientist,,wander:1:move(self) + gold[1],Move Ibn Battuta to an adjacent location and gain 1 gold.,Seventy-five thousand miles before the age of jet.
+ramesses-ii,Ramesses II,alpha-1,uncommon,4,7,5,7,Warrior;Politician,,monument:2:vp[1] + kill(self),Gain 1 VP. Ramesses II is killed.,He carved his name into eternity.
 mary-shelley,Mary Shelley,alpha-1,common,2,3,7,5,Scientist,,,The first event you play each turn costs 0 AP.,She gave lightning a soul.
 spartacus,Spartacus,alpha-1,common,2,7,4,6,Warrior,,,When Spartacus wins combat you may injure him to kill the target instead.,He fought not for glory but for freedom.


### PR DESCRIPTION
## Summary

Engine fixes for #97 playtest bugs + Effect DSL for card actions.

### Bug fixes
1. **Passive bonuses wrong player** — Location passives grant bonuses to player with units, not location owner
2. **Traps** — Replaced sabotage (unimplementable trigger) with highway-robbery. Sabotage deferred to #45
3. **Hand limit** — Emits `card_discarded` events during end-of-turn enforcement
4. **Instant event effects** — Execute via Effect DSL (Harvest Festival, Earthquake, Forced March)
5. **Unit actions (activate)** — All 18 unit actions work via DSL interpreter
6. **Equipped items not following units** — Items now move with units during enter/move/retreat

### Effect DSL
Structured mini-language for card effects as composable data. Chevrotain parser + executor.
```
draw[2]                                                    -- Da Vinci
contest.charisma(enemy + adjacent) > control(target)~round -- Cleopatra
buff.strength(all + friendly)[2]~turn                      -- Joan of Arc
gold[3]                                                    -- Harvest Festival
```
Build-time validation catches syntax errors. Full spec in `library/schema.md`.

### Client
- Skip seeding checkbox with seed-based shuffled distribution
- Pre-populated market for skip-seeding games
- Visible seed in input field
- Event log displays all new event types (buffs, contests, control, reveals)
- Fix Svelte `$state` proxy conflict with Immer via `$state.snapshot()`

## Related issues
- #101 — Card selection dialog for reveal > pick effects
- #102 — Unify start-of-turn lifecycle (remove first-turn special-casing)

## Test plan
- [x] 324 engine tests passing
- [x] Build-time DSL validation passes for all 66 cards
- [x] Hotseat: passive bonuses apply to correct player
- [x] Hotseat: hand limit enforced with discard events
- [x] Hotseat: Harvest Festival instant event gains gold
- [x] Hotseat: unit actions (activate) work
- [x] Hotseat: ambush trap triggers
- [x] Hotseat: equipped items follow units

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)