### PR TITLE
#101 — Engine: card selection dialog for reveal > pick effects

### DIFF
--- a/clients/web/src/lib/eventDescriptions.ts
+++ b/clients/web/src/lib/eventDescriptions.ts
@@ -124,6 +124,9 @@ export function describeEvent(event: GameEvent, r?: NameResolvers): string {
       return `${c(event.unitId, r)} got ${event.delta > 0 ? "+" : ""}${event.delta} ${event.stat}`;
     case "cards_revealed":
       return `${p(event.playerId, r)} revealed ${event.cardIds.length} card(s)`;
+    // TODO(#101 client PR): improve formatting + i18n; this is a stub
+    case "cards_picked":
+      return `${p(event.playerId, r)} picked ${event.cardIds.length} card(s)`;
     case "unit_controlled":
       return `${p(event.controllerId, r)} took control of ${c(event.unitId, r)}`;
     case "contest_resolved":

--- a/clients/web/vite.config.ts
+++ b/clients/web/vite.config.ts
@@ -1,12 +1,21 @@
+import { existsSync } from "node:fs";
 import tailwindcss from "@tailwindcss/vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { defineConfig } from "vite";
+
+const libraryBuildDir: string = new URL("../../library/build", import.meta.url).pathname;
+if (!existsSync(`${libraryBuildDir}/all.json`)) {
+  throw new Error(
+    `Card library not built (missing ${libraryBuildDir}/all.json).\n` +
+      `Run \`bun library/build.ts\` from the repo root, then retry.`,
+  );
+}
 
 export default defineConfig({
   plugins: [tailwindcss(), svelte()],
   resolve: {
     alias: {
-      "@library": new URL("../../library/build", import.meta.url).pathname,
+      "@library": libraryBuildDir,
       "node:fs": new URL("./src/stubs/node-fs.ts", import.meta.url).pathname,
       "node:path": new URL("./src/stubs/node-path.ts", import.meta.url).pathname,
     },

--- a/engine/src/__tests__/effect-dsl.test.ts
+++ b/engine/src/__tests__/effect-dsl.test.ts
@@ -117,10 +117,10 @@ describe("Effect DSL parser", () => {
   });
 
   it("parses chain with >", () => {
-    const ast = parse("reveal(deck)[3] > pick[1]");
+    const ast = parse("peek(deck)[3] > pick[1]");
     expect(ast).toHaveLength(1);
     expect(ast[0]).toHaveLength(2);
-    expect(ast[0][0].primitive.verb).toBe("reveal");
+    expect(ast[0][0].primitive.verb).toBe("peek");
     expect(ast[0][1].primitive.verb).toBe("pick");
   });
 

--- a/engine/src/__tests__/main-actions.test.ts
+++ b/engine/src/__tests__/main-actions.test.ts
@@ -9,6 +9,7 @@ import {
   makeItem,
   makeLocation,
   makePassiveEvent,
+  makePolicy,
   makeTrapEvent,
   makeUnit,
   resetIds,
@@ -350,6 +351,35 @@ describe("move", () => {
     expect(ns.grid[0][1].units).toHaveLength(1);
     expect(ns.grid[0][1].units[0].id).toBe(unit.id);
     expect(events.some((e) => e.type === "unit_moved")).toBe(true);
+  });
+
+  it("first move under Pioneer policy costs 0 AP", () => {
+    // Regression for #104: handleMove now uses getModifiedAPCost in the
+    // regular branch, matching the retreat branch and getValidActions.
+    // Previously the regular branch used raw AP cost, which made the
+    // pioneer policy's free-first-move discount inconsistent (validation
+    // accepted the move, apply threw "Not enough AP").
+    const unit = makeUnit({ ownerId: ACTIVE });
+    const state = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][1].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(unit);
+      d.players[ACTIVE_IDX].activePolicies.push(
+        makePolicy({ ownerId: ACTIVE, definitionId: "pioneer" }),
+      );
+      d.turn.actionPointsRemaining = 0; // would normally reject; pioneer makes it free
+    });
+
+    const { state: next } = applyAction(state, {
+      type: "move",
+      playerId: ACTIVE,
+      unitId: unit.id,
+      row: 0,
+      col: 1,
+    });
+    const ns = next as MainGameState;
+    expect(ns.grid[0][1].units[0].id).toBe(unit.id);
+    expect(ns.turn.actionPointsRemaining).toBe(0); // still 0 — was free
   });
 
   it("rejects move when facing edges are blocked", () => {

--- a/engine/src/__tests__/reveal-pick.test.ts
+++ b/engine/src/__tests__/reveal-pick.test.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { produce } from "immer";
+import { applyAction } from "../apply-action";
+import { parse } from "../effect-dsl";
+import { DSLValidationError } from "../effect-dsl/validate";
+import { getValidActions } from "../valid-actions";
+import { getVisibleState } from "../visible-state";
+import type { MainGameState, UnitCard } from "../types";
+import { createTestGame, makeUnit, resetIds } from "./helpers";
+
+beforeEach(() => resetIds());
+
+// With SEED="test-seed", shuffle produces ["p2","p1"].
+const ACTIVE = "p2";
+const ACTIVE_IDX = 0;
+
+function gameWith(fn: (draft: MainGameState) => void): MainGameState {
+  return produce(createTestGame(), fn);
+}
+
+/** Build a unit with an `analyze` action that reveals N from deck and picks M. */
+function makeAnalyzer(opts: { reveal: number; pick: number }): UnitCard {
+  return makeUnit({
+    ownerId: ACTIVE,
+    actions: [
+      {
+        name: "analyze",
+        apCost: 1,
+        effect: `reveal(deck)[${opts.reveal}] > pick[${opts.pick}]`,
+      },
+    ],
+  });
+}
+
+/** Place an analyzer unit on the grid with a 3-card top-deck setup. */
+function setupAnalyzeScenario(opts: { reveal: number; pick: number }) {
+  const analyzer = makeAnalyzer(opts);
+  const top1 = makeUnit({ ownerId: ACTIVE, name: "Top1" });
+  const top2 = makeUnit({ ownerId: ACTIVE, name: "Top2" });
+  const top3 = makeUnit({ ownerId: ACTIVE, name: "Top3" });
+  const state = gameWith((d) => {
+    d.grid[0][0].units.push(analyzer);
+    d.players[ACTIVE_IDX].mainDeck.push(top1, top2, top3);
+  });
+  return { state, analyzer, top1, top2, top3 };
+}
+
+describe("reveal > pick — player choice required", () => {
+  it("sets pendingPick instead of moving cards when pickCount < revealed", () => {
+    const { state, analyzer, top1, top2, top3 } = setupAnalyzeScenario({ reveal: 3, pick: 1 });
+
+    const { state: next, events } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: analyzer.id,
+      actionName: "analyze",
+    });
+    const ns = next as MainGameState;
+
+    expect(ns.pendingPick).toEqual({
+      playerId: ACTIVE,
+      revealedCardIds: [top1.id, top2.id, top3.id],
+      pickCount: 1,
+      source: "main_deck",
+    });
+    expect(ns.players[ACTIVE_IDX].hand).toHaveLength(0);
+    expect(ns.players[ACTIVE_IDX].mainDeck).toHaveLength(3);
+    expect(events.some((e) => e.type === "cards_revealed")).toBe(true);
+    expect(events.some((e) => e.type === "cards_picked")).toBe(false);
+  });
+
+  it("getValidActions returns one resolve_pick per candidate, nothing else", () => {
+    const { state, analyzer } = setupAnalyzeScenario({ reveal: 3, pick: 1 });
+    const { state: paused } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: analyzer.id,
+      actionName: "analyze",
+    });
+
+    const actions = getValidActions(paused, ACTIVE);
+    expect(actions).toHaveLength(3);
+    expect(actions.every((a) => a.type === "resolve_pick")).toBe(true);
+    const ids = actions.flatMap((a) => (a.type === "resolve_pick" ? a.pickedCardIds : []));
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  it("getVisibleState exposes pendingPick", () => {
+    const { state, analyzer } = setupAnalyzeScenario({ reveal: 3, pick: 1 });
+    const { state: paused } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: analyzer.id,
+      actionName: "analyze",
+    });
+
+    const vs = getVisibleState(paused, ACTIVE);
+    expect(vs.pendingPick?.pickCount).toBe(1);
+    expect(vs.pendingPick?.revealedCardIds).toHaveLength(3);
+  });
+
+  it("resolve_pick moves chosen card to hand and leaves others at top of deck", () => {
+    const { state, analyzer, top1, top2, top3 } = setupAnalyzeScenario({ reveal: 3, pick: 1 });
+    const { state: paused } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: analyzer.id,
+      actionName: "analyze",
+    });
+
+    const { state: resolved, events } = applyAction(paused, {
+      type: "resolve_pick",
+      playerId: ACTIVE,
+      pickedCardIds: [top2.id],
+    });
+    const ns = resolved as MainGameState;
+
+    expect(ns.pendingPick).toBeUndefined();
+    expect(ns.players[ACTIVE_IDX].hand.map((c) => c.id)).toEqual([top2.id]);
+    expect(ns.players[ACTIVE_IDX].mainDeck.map((c) => c.id)).toEqual([top1.id, top3.id]);
+    expect(events.some((e) => e.type === "cards_picked")).toBe(true);
+  });
+
+  it("rejects resolve_pick with wrong count", () => {
+    const { state, analyzer, top1, top2 } = setupAnalyzeScenario({ reveal: 3, pick: 1 });
+    const { state: paused } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: analyzer.id,
+      actionName: "analyze",
+    });
+
+    expect(() =>
+      applyAction(paused, {
+        type: "resolve_pick",
+        playerId: ACTIVE,
+        pickedCardIds: [top1.id, top2.id],
+      }),
+    ).toThrow("expected 1 cards, got 2");
+  });
+
+  it("rejects resolve_pick with duplicate ids", () => {
+    const { state, analyzer, top1 } = setupAnalyzeScenario({ reveal: 3, pick: 2 });
+    // pick=2 of 3 → choice still required
+    const { state: paused } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: analyzer.id,
+      actionName: "analyze",
+    });
+
+    expect(() =>
+      applyAction(paused, {
+        type: "resolve_pick",
+        playerId: ACTIVE,
+        pickedCardIds: [top1.id, top1.id],
+      }),
+    ).toThrow("duplicate card ids");
+  });
+
+  it("rejects resolve_pick with an unrevealed card id", () => {
+    const { state, analyzer } = setupAnalyzeScenario({ reveal: 3, pick: 1 });
+    const { state: paused } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: analyzer.id,
+      actionName: "analyze",
+    });
+
+    expect(() =>
+      applyAction(paused, {
+        type: "resolve_pick",
+        playerId: ACTIVE,
+        pickedCardIds: ["nonexistent-id"],
+      }),
+    ).toThrow("not revealed");
+  });
+
+  it("rejects normal actions while pendingPick is set", () => {
+    const { state, analyzer } = setupAnalyzeScenario({ reveal: 3, pick: 1 });
+    const { state: paused } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: analyzer.id,
+      actionName: "analyze",
+    });
+
+    expect(() =>
+      applyAction(paused, { type: "pass", playerId: ACTIVE }),
+    ).toThrow("pending pick must be resolved first");
+  });
+});
+
+describe("reveal > pick — no choice (forced)", () => {
+  it("auto-picks all revealed cards when pickCount >= revealed, no pendingPick", () => {
+    const { state, analyzer, top1, top2 } = setupAnalyzeScenario({ reveal: 2, pick: 2 });
+    // mainDeck still has top3 trailing, but reveal[2] only exposes top1+top2
+
+    const { state: next, events } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: analyzer.id,
+      actionName: "analyze",
+    });
+    const ns = next as MainGameState;
+
+    expect(ns.pendingPick).toBeUndefined();
+    expect(ns.players[ACTIVE_IDX].hand.map((c) => c.id).sort()).toEqual(
+      [top1.id, top2.id].sort(),
+    );
+    expect(events.some((e) => e.type === "cards_picked")).toBe(true);
+  });
+});
+
+describe("DSL validator: terminal pick", () => {
+  it("accepts pick as the last step of a chain", () => {
+    expect(() => parse("reveal(deck)[3] > pick[1]")).not.toThrow();
+  });
+
+  it("rejects pick followed by another step", () => {
+    expect(() => parse("reveal(deck)[3] > pick[1] > gold[1]")).toThrow(DSLValidationError);
+  });
+});

--- a/engine/src/__tests__/reveal-pick.test.ts
+++ b/engine/src/__tests__/reveal-pick.test.ts
@@ -10,7 +10,8 @@ import { createTestGame, makeUnit, resetIds } from "./helpers";
 
 beforeEach(() => resetIds());
 
-// With SEED="test-seed", shuffle produces ["p2","p1"].
+// Assumes the current shuffle puts p2 first under SEED="test-seed";
+// update if the RNG or shuffle algorithm changes.
 const ACTIVE = "p2";
 const ACTIVE_IDX = 0;
 
@@ -18,7 +19,6 @@ function gameWith(fn: (draft: MainGameState) => void): MainGameState {
   return produce(createTestGame(), fn);
 }
 
-/** Build a unit with an `analyze` action that reveals N from deck and picks M. */
 function makeAnalyzer(opts: { reveal: number; pick: number }): UnitCard {
   return makeUnit({
     ownerId: ACTIVE,
@@ -26,13 +26,12 @@ function makeAnalyzer(opts: { reveal: number; pick: number }): UnitCard {
       {
         name: "analyze",
         apCost: 1,
-        effect: `reveal(deck)[${opts.reveal}] > pick[${opts.pick}]`,
+        effect: `peek(deck)[${opts.reveal}] > pick[${opts.pick}]`,
       },
     ],
   });
 }
 
-/** Place an analyzer unit on the grid with a 3-card top-deck setup. */
 function setupAnalyzeScenario(opts: { reveal: number; pick: number }) {
   const analyzer = makeAnalyzer(opts);
   const top1 = makeUnit({ ownerId: ACTIVE, name: "Top1" });
@@ -46,7 +45,7 @@ function setupAnalyzeScenario(opts: { reveal: number; pick: number }) {
 }
 
 describe("reveal > pick — player choice required", () => {
-  it("sets pendingPick instead of moving cards when pickCount < revealed", () => {
+  it("sets pickPrompt instead of moving cards when count < revealed", () => {
     const { state, analyzer, top1, top2, top3 } = setupAnalyzeScenario({ reveal: 3, pick: 1 });
 
     const { state: next, events } = applyAction(state, {
@@ -57,15 +56,16 @@ describe("reveal > pick — player choice required", () => {
     });
     const ns = next as MainGameState;
 
-    expect(ns.pendingPick).toEqual({
+    expect(ns.pickPrompt).toEqual({
       playerId: ACTIVE,
-      revealedCardIds: [top1.id, top2.id, top3.id],
-      pickCount: 1,
+      options: [top1.id, top2.id, top3.id],
+      count: 1,
       source: "main_deck",
     });
     expect(ns.players[ACTIVE_IDX].hand).toHaveLength(0);
     expect(ns.players[ACTIVE_IDX].mainDeck).toHaveLength(3);
-    expect(events.some((e) => e.type === "cards_revealed")).toBe(true);
+    expect(events.some((e) => e.type === "cards_peeked")).toBe(true);
+    expect(events.some((e) => e.type === "cards_revealed")).toBe(false);
     expect(events.some((e) => e.type === "cards_picked")).toBe(false);
   });
 
@@ -85,7 +85,7 @@ describe("reveal > pick — player choice required", () => {
     expect(new Set(ids).size).toBe(3);
   });
 
-  it("getVisibleState exposes pendingPick", () => {
+  it("getVisibleState exposes pickPrompt to the picker", () => {
     const { state, analyzer } = setupAnalyzeScenario({ reveal: 3, pick: 1 });
     const { state: paused } = applyAction(state, {
       type: "activate",
@@ -95,8 +95,21 @@ describe("reveal > pick — player choice required", () => {
     });
 
     const vs = getVisibleState(paused, ACTIVE);
-    expect(vs.pendingPick?.pickCount).toBe(1);
-    expect(vs.pendingPick?.revealedCardIds).toHaveLength(3);
+    expect(vs.pickPrompt?.count).toBe(1);
+    expect(vs.pickPrompt?.options).toHaveLength(3);
+  });
+
+  it("getVisibleState hides pickPrompt from opponents (peek is private)", () => {
+    const { state, analyzer } = setupAnalyzeScenario({ reveal: 3, pick: 1 });
+    const { state: paused } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: analyzer.id,
+      actionName: "analyze",
+    });
+
+    const opponentView = getVisibleState(paused, "p1"); // p1 is non-active
+    expect(opponentView.pickPrompt).toBeUndefined();
   });
 
   it("resolve_pick moves chosen card to hand and leaves others at top of deck", () => {
@@ -115,7 +128,7 @@ describe("reveal > pick — player choice required", () => {
     });
     const ns = resolved as MainGameState;
 
-    expect(ns.pendingPick).toBeUndefined();
+    expect(ns.pickPrompt).toBeUndefined();
     expect(ns.players[ACTIVE_IDX].hand.map((c) => c.id)).toEqual([top2.id]);
     expect(ns.players[ACTIVE_IDX].mainDeck.map((c) => c.id)).toEqual([top1.id, top3.id]);
     expect(events.some((e) => e.type === "cards_picked")).toBe(true);
@@ -176,7 +189,7 @@ describe("reveal > pick — player choice required", () => {
     ).toThrow("not revealed");
   });
 
-  it("rejects normal actions while pendingPick is set", () => {
+  it("rejects normal actions while pickPrompt is set", () => {
     const { state, analyzer } = setupAnalyzeScenario({ reveal: 3, pick: 1 });
     const { state: paused } = applyAction(state, {
       type: "activate",
@@ -189,10 +202,138 @@ describe("reveal > pick — player choice required", () => {
       applyAction(paused, { type: "pass", playerId: ACTIVE }),
     ).toThrow("pending pick must be resolved first");
   });
+
+  it("rejects resolve_pick from a player who isn't the pending picker", () => {
+    const { state, analyzer, top1 } = setupAnalyzeScenario({ reveal: 3, pick: 1 });
+    const { state: paused } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: analyzer.id,
+      actionName: "analyze",
+    });
+
+    // p1 is non-active. applyAction rejects on the active-player check first
+    // (it's not p1's turn), so the message we see covers that case.
+    expect(() =>
+      applyAction(paused, {
+        type: "resolve_pick",
+        playerId: "p1",
+        pickedCardIds: [top1.id],
+      }),
+    ).toThrow(/player "p1" rejected|pending pick is for/);
+  });
+
+  it("rejects resolve_pick when there is no pending pick", () => {
+    const state = createTestGame();
+    expect(() =>
+      applyAction(state, {
+        type: "resolve_pick",
+        playerId: ACTIVE,
+        pickedCardIds: ["any-id"],
+      }),
+    ).toThrow("no pending pick");
+  });
+
+  it("rejects resolve_pick referencing a card no longer in deck (synthetic)", () => {
+    // Synthetic: simulate a deck mutation between pause and resolve to verify
+    // the defensive throw fires. Can't happen in valid DSL today.
+    const { state, analyzer, top2 } = setupAnalyzeScenario({ reveal: 3, pick: 1 });
+    const { state: paused } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: analyzer.id,
+      actionName: "analyze",
+    });
+    const tampered = produce(paused as MainGameState, (d) => {
+      d.players[ACTIVE_IDX].mainDeck = d.players[ACTIVE_IDX].mainDeck.filter(
+        (c) => c.id !== top2.id,
+      );
+    });
+
+    expect(() =>
+      applyAction(tampered, {
+        type: "resolve_pick",
+        playerId: ACTIVE,
+        pickedCardIds: [top2.id],
+      }),
+    ).toThrow(/no longer in deck/);
+  });
+
+  it("emits a fully-formed cards_picked event on resolve", () => {
+    const { state, analyzer, top2 } = setupAnalyzeScenario({ reveal: 3, pick: 1 });
+    const { state: paused } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: analyzer.id,
+      actionName: "analyze",
+    });
+
+    const { events } = applyAction(paused, {
+      type: "resolve_pick",
+      playerId: ACTIVE,
+      pickedCardIds: [top2.id],
+    });
+    const picked = events.find((e) => e.type === "cards_picked");
+    expect(picked).toEqual({
+      type: "cards_picked",
+      playerId: ACTIVE,
+      cardIds: [top2.id],
+      source: "main_deck",
+    });
+  });
+});
+
+describe("reveal > pick — multi-pick (M > 1)", () => {
+  it("getValidActions enumerates C(N, M) resolve_pick subsets", () => {
+    const { state, analyzer } = setupAnalyzeScenario({ reveal: 3, pick: 2 });
+    const { state: paused } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: analyzer.id,
+      actionName: "analyze",
+    });
+
+    const actions = getValidActions(paused, ACTIVE);
+    // C(3, 2) = 3 subsets
+    expect(actions).toHaveLength(3);
+    for (const a of actions) {
+      if (a.type !== "resolve_pick") throw new Error("expected resolve_pick only");
+      expect(a.pickedCardIds).toHaveLength(2);
+      expect(new Set(a.pickedCardIds).size).toBe(2); // no duplicates
+    }
+    // All subsets distinct
+    const keys = actions.map((a) =>
+      a.type === "resolve_pick" ? a.pickedCardIds.slice().sort().join(",") : "",
+    );
+    expect(new Set(keys).size).toBe(3);
+  });
+
+  it("resolve_pick with 2 ids moves both, leftover at top of deck in original order", () => {
+    const { state, analyzer, top1, top2, top3 } = setupAnalyzeScenario({ reveal: 3, pick: 2 });
+    const { state: paused } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: analyzer.id,
+      actionName: "analyze",
+    });
+
+    const { state: resolved } = applyAction(paused, {
+      type: "resolve_pick",
+      playerId: ACTIVE,
+      pickedCardIds: [top1.id, top3.id],
+    });
+    const ns = resolved as MainGameState;
+
+    // top1 + top3 in hand; top2 remains at deck top in original position
+    expect(ns.players[ACTIVE_IDX].hand.map((c) => c.id).sort()).toEqual(
+      [top1.id, top3.id].sort(),
+    );
+    expect(ns.players[ACTIVE_IDX].mainDeck.map((c) => c.id)).toEqual([top2.id]);
+  });
 });
 
 describe("reveal > pick — no choice (forced)", () => {
-  it("auto-picks all revealed cards when pickCount >= revealed, no pendingPick", () => {
+  it("auto-picks all revealed cards when count >= revealed, no pickPrompt", () => {
     const { state, analyzer, top1, top2 } = setupAnalyzeScenario({ reveal: 2, pick: 2 });
     // mainDeck still has top3 trailing, but reveal[2] only exposes top1+top2
 
@@ -204,7 +345,7 @@ describe("reveal > pick — no choice (forced)", () => {
     });
     const ns = next as MainGameState;
 
-    expect(ns.pendingPick).toBeUndefined();
+    expect(ns.pickPrompt).toBeUndefined();
     expect(ns.players[ACTIVE_IDX].hand.map((c) => c.id).sort()).toEqual(
       [top1.id, top2.id].sort(),
     );
@@ -214,10 +355,76 @@ describe("reveal > pick — no choice (forced)", () => {
 
 describe("DSL validator: terminal pick", () => {
   it("accepts pick as the last step of a chain", () => {
-    expect(() => parse("reveal(deck)[3] > pick[1]")).not.toThrow();
+    expect(() => parse("peek(deck)[3] > pick[1]")).not.toThrow();
   });
 
-  it("rejects pick followed by another step", () => {
-    expect(() => parse("reveal(deck)[3] > pick[1] > gold[1]")).toThrow(DSLValidationError);
+  it("rejects pick followed by another step in the same chain", () => {
+    expect(() => parse("peek(deck)[3] > pick[1] > gold[1]")).toThrow(DSLValidationError);
+  });
+
+  it("rejects pick in a non-terminal chain of a + compound", () => {
+    // executor would silently drop `draw[1]` after the pause
+    expect(() => parse("peek(deck)[3] > pick[1] + draw[1]")).toThrow(DSLValidationError);
+  });
+
+  it("accepts pick in the last chain of a + compound", () => {
+    // legal: pick is terminal in the last effect of the expression
+    expect(() => parse("gold[1] + peek(deck)[3] > pick[1]")).not.toThrow();
+  });
+});
+
+describe("DSL validator: pick requires a producer", () => {
+  it("rejects bare pick with no preceding producer", () => {
+    expect(() => parse("pick[1]")).toThrow(DSLValidationError);
+  });
+
+  it("rejects pick when the chain's producer is in a different + branch", () => {
+    // peek in chain #0 doesn't satisfy pick in chain #1 — `+` is parallel,
+    // not a producer relationship
+    expect(() => parse("peek(deck)[3] + pick[1]")).toThrow(DSLValidationError);
+  });
+
+  it("rejects pick following an unrelated chain step", () => {
+    expect(() => parse("gold[1] > pick[1]")).toThrow(DSLValidationError);
+  });
+
+  it("error message names the required producer", () => {
+    expect(() => parse("pick[1]")).toThrow(/producer.*peek/);
+  });
+});
+
+describe("DSL validator: positive counts", () => {
+  it("rejects peek[0]", () => {
+    expect(() => parse("peek(deck)[0] > pick[1]")).toThrow(DSLValidationError);
+  });
+
+  it("rejects pick[0]", () => {
+    expect(() => parse("peek(deck)[3] > pick[0]")).toThrow(DSLValidationError);
+  });
+});
+
+describe("getValidActions precondition: peek(deck) with empty deck", () => {
+  it("filters out the activate action when the deck is empty", () => {
+    // Build a scenario where Ada is on the grid but the deck is empty.
+    const analyzer = makeAnalyzer({ reveal: 3, pick: 1 });
+    const state = gameWith((d) => {
+      d.grid[0][0].units.push(analyzer);
+      // d.players[ACTIVE_IDX].mainDeck stays empty
+    });
+
+    const actions = getValidActions(state, ACTIVE);
+    const ada = actions.filter(
+      (a) => a.type === "activate" && a.cardId === analyzer.id,
+    );
+    expect(ada).toHaveLength(0);
+  });
+
+  it("offers the activate action when the deck has cards", () => {
+    const { state, analyzer } = setupAnalyzeScenario({ reveal: 3, pick: 1 });
+    const actions = getValidActions(state, ACTIVE);
+    const ada = actions.filter(
+      (a) => a.type === "activate" && a.cardId === analyzer.id,
+    );
+    expect(ada.length).toBeGreaterThan(0);
   });
 });

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -411,9 +411,13 @@ function handleMove(
     );
   }
 
-  const apCost = unit.injured
+  const baseApCost = unit.injured
     ? 1 + getConfigNumber(draft, "injury_move_penalty", 1)
     : 1;
+  const apCost = getModifiedAPCost(
+    draft as MainGameState, queries,
+    { type: "move", playerId, unitId, row: toRow, col: toCol }, baseApCost,
+  );
   spendAP(draft, apCost);
 
   const fromCell = draft.grid[fromRow][fromCol];
@@ -884,6 +888,53 @@ function handleActivate(
   draft.rngState = extractRngState(result.rng) as number[];
 }
 
+function handleResolvePick(
+  draft: Draft<MainGameState>,
+  playerId: string,
+  pickedCardIds: string[],
+  emit: EmitFn,
+): void {
+  const pending = draft.pendingPick;
+  if (!pending) throw new Error("resolve_pick rejected: no pending pick");
+  if (pending.playerId !== playerId) {
+    throw new Error(
+      `resolve_pick rejected: pending pick is for "${pending.playerId}", not "${playerId}"`,
+    );
+  }
+  if (pickedCardIds.length !== pending.pickCount) {
+    throw new Error(
+      `resolve_pick rejected: expected ${pending.pickCount} cards, got ${pickedCardIds.length}`,
+    );
+  }
+  const unique = new Set(pickedCardIds);
+  if (unique.size !== pickedCardIds.length) {
+    throw new Error("resolve_pick rejected: duplicate card ids");
+  }
+  const candidates = new Set(pending.revealedCardIds);
+  for (const id of pickedCardIds) {
+    if (!candidates.has(id)) {
+      throw new Error(`resolve_pick rejected: card "${id}" was not revealed`);
+    }
+  }
+
+  const player = getPlayerById(draft, playerId);
+  for (const id of pickedCardIds) {
+    const idx = player.mainDeck.findIndex((c) => c.id === id);
+    if (idx === -1) {
+      throw new Error(`resolve_pick rejected: card "${id}" no longer in deck`);
+    }
+    const [card] = player.mainDeck.splice(idx, 1);
+    player.hand.push(card);
+  }
+  emit({
+    type: "cards_picked",
+    playerId,
+    cardIds: pickedCardIds,
+    source: pending.source,
+  });
+  draft.pendingPick = undefined;
+}
+
 // ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
@@ -894,6 +945,12 @@ export function applyMainAction(
 ): ApplyResult {
   const events: GameEvent[] = [];
   let roundIncremented = false;
+
+  if (state.pendingPick && action.type !== "resolve_pick") {
+    throw new Error(
+      `Action "${action.type}" rejected: pending pick must be resolved first`,
+    );
+  }
 
   const nextState = produce(state, (draft) => {
     const { listeners, queries } = rebuildListeners(draft as MainGameState);
@@ -958,6 +1015,10 @@ export function applyMainAction(
 
       case "attempt_mission":
         handleAttemptMission(draft, action.playerId, action.row, action.col, emit, events, queries);
+        break;
+
+      case "resolve_pick":
+        handleResolvePick(draft, action.playerId, action.pickedCardIds, emit);
         break;
 
       default: {

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -894,26 +894,38 @@ function handleResolvePick(
   pickedCardIds: string[],
   emit: EmitFn,
 ): void {
-  const pending = draft.pendingPick;
-  if (!pending) throw new Error("resolve_pick rejected: no pending pick");
-  if (pending.playerId !== playerId) {
+  const submitted = `submitted ids=[${pickedCardIds.join(",")}] by player "${playerId}"`;
+  const prompt = draft.pickPrompt;
+  if (!prompt) {
+    throw new Error(`resolve_pick rejected: no pending pick (${submitted})`);
+  }
+  if (prompt.playerId !== playerId) {
     throw new Error(
-      `resolve_pick rejected: pending pick is for "${pending.playerId}", not "${playerId}"`,
+      `resolve_pick rejected: pending pick is for "${prompt.playerId}", not "${playerId}" (${submitted})`,
     );
   }
-  if (pickedCardIds.length !== pending.pickCount) {
+  if (pickedCardIds.length !== prompt.count) {
     throw new Error(
-      `resolve_pick rejected: expected ${pending.pickCount} cards, got ${pickedCardIds.length}`,
+      `resolve_pick rejected: expected ${prompt.count} cards, got ${pickedCardIds.length} (${submitted})`,
     );
   }
-  const unique = new Set(pickedCardIds);
-  if (unique.size !== pickedCardIds.length) {
-    throw new Error("resolve_pick rejected: duplicate card ids");
+  const seen = new Set<string>();
+  const dupes: string[] = [];
+  for (const id of pickedCardIds) {
+    if (seen.has(id)) dupes.push(id);
+    seen.add(id);
   }
-  const candidates = new Set(pending.revealedCardIds);
+  if (dupes.length > 0) {
+    throw new Error(
+      `resolve_pick rejected: duplicate card ids [${dupes.join(",")}] (${submitted})`,
+    );
+  }
+  const candidates = new Set(prompt.options);
   for (const id of pickedCardIds) {
     if (!candidates.has(id)) {
-      throw new Error(`resolve_pick rejected: card "${id}" was not revealed`);
+      throw new Error(
+        `resolve_pick rejected: card "${id}" was not revealed (${submitted}, options=[${prompt.options.join(",")}])`,
+      );
     }
   }
 
@@ -921,7 +933,9 @@ function handleResolvePick(
   for (const id of pickedCardIds) {
     const idx = player.mainDeck.findIndex((c) => c.id === id);
     if (idx === -1) {
-      throw new Error(`resolve_pick rejected: card "${id}" no longer in deck`);
+      throw new Error(
+        `resolve_pick: card "${id}" no longer in deck — invariant broken (${submitted})`,
+      );
     }
     const [card] = player.mainDeck.splice(idx, 1);
     player.hand.push(card);
@@ -930,9 +944,9 @@ function handleResolvePick(
     type: "cards_picked",
     playerId,
     cardIds: pickedCardIds,
-    source: pending.source,
+    source: prompt.source,
   });
-  draft.pendingPick = undefined;
+  draft.pickPrompt = undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -946,9 +960,12 @@ export function applyMainAction(
   const events: GameEvent[] = [];
   let roundIncremented = false;
 
-  if (state.pendingPick && action.type !== "resolve_pick") {
+  if (state.pickPrompt && action.type !== "resolve_pick") {
     throw new Error(
-      `Action "${action.type}" rejected: pending pick must be resolved first`,
+      `Action "${action.type}" by "${action.playerId}" rejected: ` +
+        `pending pick must be resolved first ` +
+        `(picker="${state.pickPrompt.playerId}", count=${state.pickPrompt.count}, ` +
+        `options=[${state.pickPrompt.options.join(",")}])`,
     );
   }
 

--- a/engine/src/effect-dsl/executor.ts
+++ b/engine/src/effect-dsl/executor.ts
@@ -30,6 +30,8 @@ export interface ExecutionContext {
   _revealedCards?: Draft<Card>[];
   /** Location removed by a `raze` verb, consumed by a subsequent `to`. */
   _razedLocation?: Draft<LocationCard>;
+  /** Set true when a verb (e.g. `pick`) needs to suspend the chain for player input. */
+  aborted?: boolean;
 }
 
 /** Resolve the acting unit's current position from the grid (lazy, always fresh). */
@@ -58,12 +60,14 @@ export function executeEffect(
 
 function executeExpression(expr: Expression, ctx: ExecutionContext): void {
   for (const effect of expr) {
+    if (ctx.aborted) return;
     executeEffectChain(effect, ctx);
   }
 }
 
 function executeEffectChain(effect: Effect, ctx: ExecutionContext): void {
   for (const step of effect) {
+    if (ctx.aborted) return;
     executeStep(step, ctx);
   }
 }
@@ -320,19 +324,38 @@ function execReveal(p: Primitive, ctx: ExecutionContext): void {
 
 function execPick(p: Primitive, ctx: ExecutionContext): void {
   const count = p.value ?? 1;
-  if (!ctx._revealedCards || ctx._revealedCards.length === 0) return;
+  const revealed = ctx._revealedCards;
+  if (!revealed || revealed.length === 0) return;
 
-  const player = getPlayerById(ctx.draft, ctx.playerId);
-  // Auto-pick first N cards for v0.1 (player choice refinement: #101)
-  const picked = ctx._revealedCards.slice(0, count);
-  for (const card of picked) {
-    const idx = player.mainDeck.findIndex((c) => c.id === card.id);
-    if (idx !== -1) {
-      player.mainDeck.splice(idx, 1);
-      player.hand.push(card);
+  // Forced pick (count >= revealed) leaves nothing to choose — auto-take all
+  // and continue the chain without pausing.
+  if (count >= revealed.length) {
+    const player = getPlayerById(ctx.draft, ctx.playerId);
+    for (const card of revealed) {
+      const idx = player.mainDeck.findIndex((c) => c.id === card.id);
+      if (idx !== -1) {
+        player.mainDeck.splice(idx, 1);
+        player.hand.push(card);
+      }
     }
+    ctx.emit({
+      type: "cards_picked",
+      playerId: ctx.playerId,
+      cardIds: revealed.map((c) => c.id),
+      source: "main_deck",
+    });
+    ctx._revealedCards = undefined;
+    return;
   }
+
+  ctx.draft.pendingPick = {
+    playerId: ctx.playerId,
+    revealedCardIds: revealed.map((c) => c.id),
+    pickCount: count,
+    source: "main_deck",
+  };
   ctx._revealedCards = undefined;
+  ctx.aborted = true;
 }
 
 function execControl(p: Primitive, ctx: ExecutionContext): void {

--- a/engine/src/effect-dsl/executor.ts
+++ b/engine/src/effect-dsl/executor.ts
@@ -26,12 +26,10 @@ export interface ExecutionContext {
   rng: prand.RandomGenerator;
   /** Back-reference to last resolved target (for chains). */
   _lastTarget?: Draft<UnitCard>;
-  /** Cards revealed by a `reveal` verb, consumed by a subsequent `pick`. */
-  _revealedCards?: Draft<Card>[];
+  /** Cards privately peeked by a `peek` verb, consumed by a subsequent `pick`. */
+  _peekedCards?: Draft<Card>[];
   /** Location removed by a `raze` verb, consumed by a subsequent `to`. */
   _razedLocation?: Draft<LocationCard>;
-  /** Set true when a verb (e.g. `pick`) needs to suspend the chain for player input. */
-  aborted?: boolean;
 }
 
 /** Resolve the acting unit's current position from the grid (lazy, always fresh). */
@@ -60,14 +58,14 @@ export function executeEffect(
 
 function executeExpression(expr: Expression, ctx: ExecutionContext): void {
   for (const effect of expr) {
-    if (ctx.aborted) return;
+    if (ctx.draft.pickPrompt) return;
     executeEffectChain(effect, ctx);
   }
 }
 
 function executeEffectChain(effect: Effect, ctx: ExecutionContext): void {
   for (const step of effect) {
-    if (ctx.aborted) return;
+    if (ctx.draft.pickPrompt) return;
     executeStep(step, ctx);
   }
 }
@@ -105,6 +103,8 @@ function executePrimitive(p: Primitive, ctx: ExecutionContext): void {
       return execMove(p, ctx);
     case "reveal":
       return execReveal(p, ctx);
+    case "peek":
+      return execPeek(p, ctx);
     case "pick":
       return execPick(p, ctx);
     case "control":
@@ -306,56 +306,87 @@ function execMove(p: Primitive, ctx: ExecutionContext): void {
 
 function execReveal(p: Primitive, ctx: ExecutionContext): void {
   const tokenNames = p.target?.tokens.map((t) => t.name) ?? [];
-  const count = p.value ?? 0;
 
   if (tokenNames.includes("opponent") && tokenNames.includes("hand")) {
     const opponent = ctx.draft.players.find((pl) => pl.id !== ctx.playerId);
     if (!opponent) return;
     const cardIds = opponent.hand.map((c) => c.id);
-    ctx.emit({ type: "cards_revealed", playerId: ctx.playerId, cardIds, source: "reveal" });
-  } else if (tokenNames.includes("deck")) {
-    const player = getPlayerById(ctx.draft, ctx.playerId);
-    const revealed = player.mainDeck.slice(0, count);
-    const cardIds = revealed.map((c) => c.id);
-    ctx.emit({ type: "cards_revealed", playerId: ctx.playerId, cardIds, source: "reveal-deck" });
-    ctx._revealedCards = revealed as Draft<Card>[];
+    ctx.emit({ type: "cards_revealed", playerId: ctx.playerId, cardIds, source: "opponent_hand" });
   }
+}
+
+// Private peek: look at top N of own deck, store for a chained `pick`.
+// Emits `cards_peeked` for engine record-keeping (replay, listeners, debug).
+// Privacy filtering of the event log is tracked separately.
+function execPeek(p: Primitive, ctx: ExecutionContext): void {
+  const tokenNames = p.target?.tokens.map((t) => t.name) ?? [];
+  if (!tokenNames.includes("deck")) return;
+
+  const count = p.value ?? 0;
+  const player = getPlayerById(ctx.draft, ctx.playerId);
+  const peeked = player.mainDeck.slice(0, count);
+  ctx.emit({
+    type: "cards_peeked",
+    playerId: ctx.playerId,
+    cardIds: peeked.map((c) => c.id),
+    source: "main_deck",
+  });
+  ctx._peekedCards = peeked as Draft<Card>[];
 }
 
 function execPick(p: Primitive, ctx: ExecutionContext): void {
   const count = p.value ?? 1;
-  const revealed = ctx._revealedCards;
-  if (!revealed || revealed.length === 0) return;
+  const peeked = ctx._peekedCards;
+  if (peeked === undefined) {
+    // Validator (`validateEffectChain`) guarantees a `peek` precedes any
+    // `pick` in the same chain. If this fires, something has bypassed it.
+    throw new Error(
+      "execPick: no peeked cards — validator should have rejected this effect at parse time",
+    );
+  }
+  // Empty deck at runtime: `cards_peeked` event already recorded the empty
+  // attempt; no further action.
+  if (peeked.length === 0) return;
 
-  // Forced pick (count >= revealed) leaves nothing to choose — auto-take all
+  // Forced pick (count >= peeked) leaves nothing to choose — auto-take all
   // and continue the chain without pausing.
-  if (count >= revealed.length) {
+  // NB: this is one of two `cards_picked` emit sites. The other is
+  // handleResolvePick (apply-main.ts), which fires when a player resolves
+  // a paused PickPrompt. Keep both sites in sync.
+  if (count >= peeked.length) {
     const player = getPlayerById(ctx.draft, ctx.playerId);
-    for (const card of revealed) {
+    for (const card of peeked) {
       const idx = player.mainDeck.findIndex((c) => c.id === card.id);
-      if (idx !== -1) {
-        player.mainDeck.splice(idx, 1);
-        player.hand.push(card);
+      // Defensive: in valid DSL today the cards are guaranteed to still be
+      // in mainDeck (peek slices without mutating; nothing runs between
+      // peek and pick). If a future verb or listener side-effect mutates
+      // the deck mid-execution, fail loud rather than silently emit a
+      // lying event. Mirrors handleResolvePick's behavior.
+      if (idx === -1) {
+        throw new Error(
+          `execPick: peeked card "${card.id}" no longer in mainDeck — invariant broken`,
+        );
       }
+      player.mainDeck.splice(idx, 1);
+      player.hand.push(card);
     }
     ctx.emit({
       type: "cards_picked",
       playerId: ctx.playerId,
-      cardIds: revealed.map((c) => c.id),
+      cardIds: peeked.map((c) => c.id),
       source: "main_deck",
     });
-    ctx._revealedCards = undefined;
+    ctx._peekedCards = undefined;
     return;
   }
 
-  ctx.draft.pendingPick = {
+  ctx.draft.pickPrompt = {
     playerId: ctx.playerId,
-    revealedCardIds: revealed.map((c) => c.id),
-    pickCount: count,
+    options: peeked.map((c) => c.id),
+    count,
     source: "main_deck",
   };
-  ctx._revealedCards = undefined;
-  ctx.aborted = true;
+  ctx._peekedCards = undefined;
 }
 
 function execControl(p: Primitive, ctx: ExecutionContext): void {

--- a/engine/src/effect-dsl/index.ts
+++ b/engine/src/effect-dsl/index.ts
@@ -1,4 +1,5 @@
 export { parse, DSLParseError } from "./parser";
+export { DSLValidationError } from "./validate";
 export type {
   Expression,
   Effect,

--- a/engine/src/effect-dsl/parser.ts
+++ b/engine/src/effect-dsl/parser.ts
@@ -2,6 +2,7 @@ import { EmbeddedActionsParser } from "chevrotain";
 import { allTokens, Ident, Int, LParen, RParen, LBrack, RBrack, Plus, Dot, Gt, Tilde, Colon } from "./tokens";
 import { lexer } from "./tokens";
 import type { Expression, Effect, Step, Primitive, Selector, Token } from "./types";
+import { validateEffectChain } from "./validate";
 
 // ---------------------------------------------------------------------------
 // Post-processing: raw chain segments → proper AST with consequences
@@ -151,5 +152,6 @@ export function parse(input: string): Expression {
   if (parserInstance.errors.length > 0) {
     throw new DSLParseError(`Parse error in "${input}": ${parserInstance.errors[0].message}`);
   }
+  validateEffectChain(ast);
   return ast;
 }

--- a/engine/src/effect-dsl/validate.ts
+++ b/engine/src/effect-dsl/validate.ts
@@ -7,17 +7,56 @@ export class DSLValidationError extends Error {
   }
 }
 
-// `pick` pauses the executor for player input (see #101). Until #103 lands,
-// the executor can't resume the rest of a chain after the pause, so any chain
-// containing `pick` must end with it.
+// Static rules for `peek` and `pick`:
+//
+//   peek:
+//     - count >= 1 (zero or negative makes no sense; the executor stores []
+//       which then no-ops on pick).
+//
+//   pick:
+//     - count >= 1 (default 1 if omitted).
+//     - Must be preceded by a producer (`peek`) in the same chain. Without
+//       one, `_peekedCards` is undefined and the executor would silently
+//       no-op.
+//     - Must be the terminal step of the LAST effect chain in the expression.
+//       Anything after it (later steps in the same chain, or later chains
+//       joined by `+`) would be silently dropped, because the suspend check
+//       bubbles out of both executor loops.
+//
+// Delete the terminal-pick rule once #103 lands (chain resumption past pick).
 export function validateEffectChain(ast: Expression): void {
   ast.forEach((effect: Effect, effectIdx: number) => {
+    let sawProducer = false;
     effect.forEach((step, stepIdx) => {
+      if (step.primitive.verb === "peek") {
+        sawProducer = true;
+        const value = step.primitive.value ?? 0;
+        if (value < 1) {
+          throw new DSLValidationError(
+            `'peek' requires a positive count (got ${value})`,
+          );
+        }
+      }
       if (step.primitive.verb !== "pick") return;
-      if (stepIdx !== effect.length - 1) {
+
+      const pickCount = step.primitive.value ?? 1;
+      if (pickCount < 1) {
         throw new DSLValidationError(
-          `'pick' must be the terminal step of an effect chain ` +
-            `(chain #${effectIdx}: pick at step ${stepIdx} of ${effect.length - 1})`,
+          `'pick' requires a positive count (got ${pickCount})`,
+        );
+      }
+      if (!sawProducer) {
+        throw new DSLValidationError(
+          `'pick' requires a preceding producer (e.g. 'peek') in the same chain ` +
+            `(chain #${effectIdx}, step ${stepIdx})`,
+        );
+      }
+      const isLastStep = stepIdx === effect.length - 1;
+      const isLastEffect = effectIdx === ast.length - 1;
+      if (!isLastStep || !isLastEffect) {
+        throw new DSLValidationError(
+          `'pick' must be the terminal primitive of the last effect chain in an expression ` +
+            `(chain #${effectIdx} of ${ast.length - 1}, step ${stepIdx} of ${effect.length - 1})`,
         );
       }
     });

--- a/engine/src/effect-dsl/validate.ts
+++ b/engine/src/effect-dsl/validate.ts
@@ -1,0 +1,25 @@
+import type { Expression, Effect } from "./types";
+
+export class DSLValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DSLValidationError";
+  }
+}
+
+// `pick` pauses the executor for player input (see #101). Until #103 lands,
+// the executor can't resume the rest of a chain after the pause, so any chain
+// containing `pick` must end with it.
+export function validateEffectChain(ast: Expression): void {
+  ast.forEach((effect: Effect, effectIdx: number) => {
+    effect.forEach((step, stepIdx) => {
+      if (step.primitive.verb !== "pick") return;
+      if (stepIdx !== effect.length - 1) {
+        throw new DSLValidationError(
+          `'pick' must be the terminal step of an effect chain ` +
+            `(chain #${effectIdx}: pick at step ${stepIdx} of ${effect.length - 1})`,
+        );
+      }
+    });
+  });
+}

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -234,13 +234,14 @@ export interface SeedingGameState extends GameStateBase {
   seedingState: SeedingState;
 }
 
-export interface PendingPick {
+/** A prompt asking the player to pick from a set of revealed cards. */
+export interface PickPrompt {
   playerId: string;
-  /** Candidate card instance IDs sitting at the top of mainDeck in revealed order. */
-  revealedCardIds: string[];
-  /** How many of the revealed cards the player must keep. */
-  pickCount: number;
-  /** Where the candidates came from. Only `main_deck` is used today. */
+  /** Card instance IDs the player may pick from, in revealed order. */
+  options: string[];
+  /** How many of the options the player must pick. Always >= 1 (validator enforces). */
+  count: number;
+  /** Where the options came from. */
   source: "main_deck";
 }
 
@@ -248,7 +249,7 @@ export interface MainGameState extends GameStateBase {
   phase: "main";
   turn: TurnState;
   /** Set mid-effect when a `pick` verb needs player input. Cleared by `resolve_pick`. */
-  pendingPick?: PendingPick;
+  pickPrompt?: PickPrompt;
 }
 
 export interface EndedGameState extends GameStateBase {
@@ -346,7 +347,7 @@ export type MainAction =
     }
   | { type: "attempt_mission"; playerId: string; row: number; col: number }
   | { type: "pass"; playerId: string }
-  | { type: "resolve_pick"; playerId: string; pickedCardIds: string[] };
+  | { type: "resolve_pick"; playerId: string; pickedCardIds: [string, ...string[]] };
 
 export type Action = SeedingAction | MainAction;
 
@@ -475,8 +476,9 @@ export type GameEvent =
     }
   | { type: "card_discarded"; playerId: string; cardId: string; reason: string }
   | { type: "unit_buffed"; unitId: string; stat: StatName; delta: number; source: string }
-  | { type: "cards_revealed"; playerId: string; cardIds: string[]; source: string }
-  | { type: "cards_picked"; playerId: string; cardIds: string[]; source: string }
+  | { type: "cards_revealed"; playerId: string; cardIds: string[]; source: "opponent_hand" }
+  | { type: "cards_peeked"; playerId: string; cardIds: string[]; source: "main_deck" }
+  | { type: "cards_picked"; playerId: string; cardIds: string[]; source: "main_deck" }
   | { type: "unit_controlled"; unitId: string; controllerId: string; previousOwnerId: string; duration: number }
   | { type: "contest_resolved"; stat: StatName; attackerId: string; defenderId: string; attackerPower: number; defenderPower: number; winnerId: string }
   | { type: "passive_expired"; playerId: string; cardId: string }
@@ -534,7 +536,7 @@ export interface VisibleState {
   /** Current seeding step, if in seeding phase. */
   seedingStep?: SeedingStep;
   /** Set during main phase when the active player must resolve a `pick`. */
-  pendingPick?: PendingPick;
+  pickPrompt?: PickPrompt;
   winner?: string;
   scores?: Record<string, number>;
 }

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -234,9 +234,21 @@ export interface SeedingGameState extends GameStateBase {
   seedingState: SeedingState;
 }
 
+export interface PendingPick {
+  playerId: string;
+  /** Candidate card instance IDs sitting at the top of mainDeck in revealed order. */
+  revealedCardIds: string[];
+  /** How many of the revealed cards the player must keep. */
+  pickCount: number;
+  /** Where the candidates came from. Only `main_deck` is used today. */
+  source: "main_deck";
+}
+
 export interface MainGameState extends GameStateBase {
   phase: "main";
   turn: TurnState;
+  /** Set mid-effect when a `pick` verb needs player input. Cleared by `resolve_pick`. */
+  pendingPick?: PendingPick;
 }
 
 export interface EndedGameState extends GameStateBase {
@@ -333,7 +345,8 @@ export type MainAction =
       col: number;
     }
   | { type: "attempt_mission"; playerId: string; row: number; col: number }
-  | { type: "pass"; playerId: string };
+  | { type: "pass"; playerId: string }
+  | { type: "resolve_pick"; playerId: string; pickedCardIds: string[] };
 
 export type Action = SeedingAction | MainAction;
 
@@ -463,6 +476,7 @@ export type GameEvent =
   | { type: "card_discarded"; playerId: string; cardId: string; reason: string }
   | { type: "unit_buffed"; unitId: string; stat: StatName; delta: number; source: string }
   | { type: "cards_revealed"; playerId: string; cardIds: string[]; source: string }
+  | { type: "cards_picked"; playerId: string; cardIds: string[]; source: string }
   | { type: "unit_controlled"; unitId: string; controllerId: string; previousOwnerId: string; duration: number }
   | { type: "contest_resolved"; stat: StatName; attackerId: string; defenderId: string; attackerPower: number; defenderPower: number; winnerId: string }
   | { type: "passive_expired"; playerId: string; cardId: string }
@@ -519,6 +533,8 @@ export interface VisibleState {
   middleArea: Card[];
   /** Current seeding step, if in seeding phase. */
   seedingStep?: SeedingStep;
+  /** Set during main phase when the active player must resolve a `pick`. */
+  pendingPick?: PendingPick;
   winner?: string;
   scores?: Record<string, number>;
 }

--- a/engine/src/valid-actions.ts
+++ b/engine/src/valid-actions.ts
@@ -1,4 +1,5 @@
-import { parse, DSLParseError } from "./effect-dsl";
+import { parse, DSLParseError, DSLValidationError } from "./effect-dsl";
+import type { Primitive } from "./effect-dsl/types";
 import { tryParseCost } from "./cost-helpers";
 import { checkMissionRequirements, parseRequirements } from "./mission-helpers";
 import type { BoardPosition } from "./position-helpers";
@@ -18,7 +19,7 @@ import type {
   GameState,
   MainAction,
   MainGameState,
-  PendingPick,
+  PickPrompt,
   SeedingAction,
   SeedingGameState,
 } from "./types";
@@ -119,8 +120,8 @@ function getMainValidActions(
   state: MainGameState,
   playerId: string,
 ): MainAction[] {
-  if (state.pendingPick && state.pendingPick.playerId === playerId) {
-    return getResolvePickActions(state.pendingPick, playerId);
+  if (state.pickPrompt && state.pickPrompt.playerId === playerId) {
+    return getResolvePickActions(state.pickPrompt, playerId);
   }
 
   const actions: MainAction[] = [];
@@ -370,11 +371,17 @@ function getMainValidActions(
 // ---------------------------------------------------------------------------
 
 function getResolvePickActions(
-  pending: PendingPick,
+  prompt: PickPrompt,
   playerId: string,
 ): MainAction[] {
-  return subsetsOfSize(pending.revealedCardIds, pending.pickCount).map(
-    (pickedCardIds) => ({ type: "resolve_pick", playerId, pickedCardIds }),
+  // PickPrompt.count is validated >= 1 (validator rejects peek[0]/pick[0]),
+  // so every subset is non-empty — safe to assert the non-empty-tuple shape.
+  return subsetsOfSize(prompt.options, prompt.count).map(
+    (pickedCardIds) => ({
+      type: "resolve_pick" as const,
+      playerId,
+      pickedCardIds: pickedCardIds as [string, ...string[]],
+    }),
   );
 }
 
@@ -400,6 +407,45 @@ function subsetsOfSize<T>(items: readonly T[], size: number): T[][] {
 }
 
 // ---------------------------------------------------------------------------
+// Activate preconditions
+// ---------------------------------------------------------------------------
+
+// Verb-level runtime preconditions for activate effects. When a precondition
+// fails for any primitive in the AST, the activate action is filtered out of
+// getValidActions so the player never sees a button that would no-op.
+//
+// To add a new precondition: append an entry. `matches` identifies the
+// primitive shape; `passes` returns true if the precondition holds. Keep
+// each entry narrow (verb + token combo) to avoid over-rejection.
+const ACTIVATE_PRECONDITIONS: Array<{
+  description: string;
+  matches: (p: Primitive) => boolean;
+  passes: (state: MainGameState, playerId: string) => boolean;
+}> = [
+  {
+    description: "peek(deck) requires at least 1 card in mainDeck",
+    matches: (p) =>
+      p.verb === "peek" &&
+      (p.target?.tokens.map((t) => t.name) ?? []).includes("deck"),
+    passes: (state, playerId) =>
+      getPlayerById(state, playerId).mainDeck.length > 0,
+  },
+];
+
+function activatePreconditionsPass(
+  primitives: readonly Primitive[],
+  state: MainGameState,
+  playerId: string,
+): boolean {
+  for (const p of primitives) {
+    for (const check of ACTIVATE_PRECONDITIONS) {
+      if (check.matches(p) && !check.passes(state, playerId)) return false;
+    }
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
 // Activate target inference
 // ---------------------------------------------------------------------------
 
@@ -420,15 +466,25 @@ function inferActivateTargets(
   unitCol: number,
   playerId: string,
 ): ActivateTarget[] {
+  // Library build (library/build.ts) parses and validates every card effect,
+  // so reaching either error class here means the runtime got out of sync
+  // with the library. Log + skip rather than crash the player's turn.
   let ast;
   try {
     ast = parse(effectStr);
   } catch (err) {
-    if (err instanceof DSLParseError) {
-      console.warn(`Unparseable effect "${effectStr}": ${err.message}`);
-      return [{}];
+    if (err instanceof DSLParseError || err instanceof DSLValidationError) {
+      console.warn(`Invalid DSL effect "${effectStr}": ${err.message}`);
+      return [];
     }
     throw err;
+  }
+
+  // Filter out activations whose effects would no-op due to missing runtime
+  // preconditions (e.g. peek(deck) with an empty deck).
+  const allPrimitives = ast.flatMap((effect) => effect.map((step) => step.primitive));
+  if (!activatePreconditionsPass(allPrimitives, state, playerId)) {
+    return [];
   }
 
   // Scan the first verb in each compound member to determine targeting needs

--- a/engine/src/valid-actions.ts
+++ b/engine/src/valid-actions.ts
@@ -18,6 +18,7 @@ import type {
   GameState,
   MainAction,
   MainGameState,
+  PendingPick,
   SeedingAction,
   SeedingGameState,
 } from "./types";
@@ -118,6 +119,10 @@ function getMainValidActions(
   state: MainGameState,
   playerId: string,
 ): MainAction[] {
+  if (state.pendingPick && state.pendingPick.playerId === playerId) {
+    return getResolvePickActions(state.pendingPick, playerId);
+  }
+
   const actions: MainAction[] = [];
   const player = getPlayerById(state, playerId);
   const ap = state.turn.actionPointsRemaining;
@@ -358,6 +363,40 @@ function getMainValidActions(
   }
 
   return actions;
+}
+
+// ---------------------------------------------------------------------------
+// Pending pick resolution
+// ---------------------------------------------------------------------------
+
+function getResolvePickActions(
+  pending: PendingPick,
+  playerId: string,
+): MainAction[] {
+  return subsetsOfSize(pending.revealedCardIds, pending.pickCount).map(
+    (pickedCardIds) => ({ type: "resolve_pick", playerId, pickedCardIds }),
+  );
+}
+
+function subsetsOfSize<T>(items: readonly T[], size: number): T[][] {
+  if (size < 0 || size > items.length) return [];
+  if (size === 0) return [[]];
+  if (size === items.length) return [[...items]];
+  const result: T[][] = [];
+  const buf: T[] = new Array(size);
+  const choose = (start: number, depth: number): void => {
+    if (depth === size) {
+      result.push([...buf]);
+      return;
+    }
+    const remaining = size - depth;
+    for (let i = start; i <= items.length - remaining; i++) {
+      buf[depth] = items[i];
+      choose(i + 1, depth + 1);
+    }
+  };
+  choose(0, 0);
+  return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/src/visible-state.ts
+++ b/engine/src/visible-state.ts
@@ -55,7 +55,11 @@ export function getVisibleState(
     middleArea: state.phase === "seeding" ? state.seedingState.middleArea : [],
     seedingStep:
       state.phase === "seeding" ? state.seedingState.step : undefined,
-    pendingPick: state.phase === "main" ? state.pendingPick : undefined,
+    // pickPrompt is private to the picker — peek() options must not leak to opponents.
+    pickPrompt:
+      state.phase === "main" && state.pickPrompt?.playerId === playerId
+        ? state.pickPrompt
+        : undefined,
     winner: state.phase === "ended" ? state.winner : undefined,
     scores: state.phase === "ended" ? state.scores : undefined,
   };

--- a/engine/src/visible-state.ts
+++ b/engine/src/visible-state.ts
@@ -55,6 +55,7 @@ export function getVisibleState(
     middleArea: state.phase === "seeding" ? state.seedingState.middleArea : [],
     seedingStep:
       state.phase === "seeding" ? state.seedingState.step : undefined,
+    pendingPick: state.phase === "main" ? state.pendingPick : undefined,
     winner: state.phase === "ended" ? state.winner : undefined,
     scores: state.phase === "ended" ? state.scores : undefined,
   };

--- a/library/build.ts
+++ b/library/build.ts
@@ -11,7 +11,7 @@
 
 import { readdirSync, readFileSync, mkdirSync, writeFileSync, existsSync } from "fs";
 import { join } from "path";
-import { parse as parseDSL, DSLParseError } from "../engine/src/effect-dsl";
+import { parse as parseDSL, DSLParseError, DSLValidationError } from "../engine/src/effect-dsl";
 
 const LIBRARY_DIR = join(import.meta.dir);
 const SETS_DIR = join(LIBRARY_DIR, "sets");
@@ -179,7 +179,7 @@ function validate(type: CardType, card: Record<string, unknown>): ValidationErro
       try {
         parseDSL(action.effect);
       } catch (e) {
-        const msg = e instanceof DSLParseError ? e.message : String(e);
+        const msg = (e instanceof DSLParseError || e instanceof DSLValidationError) ? e.message : String(e);
         errors.push({ card: id, field: "actions", message: `invalid DSL in action "${action.name}": ${msg}` });
       }
     }
@@ -188,7 +188,7 @@ function validate(type: CardType, card: Record<string, unknown>): ValidationErro
     try {
       parseDSL(card.effect as string);
     } catch (e) {
-      const msg = e instanceof DSLParseError ? e.message : String(e);
+      const msg = (e instanceof DSLParseError || e instanceof DSLValidationError) ? e.message : String(e);
       errors.push({ card: id, field: "effect", message: `invalid DSL: ${msg}` });
     }
   }

--- a/library/schema.md
+++ b/library/schema.md
@@ -114,7 +114,7 @@ consequence = ">" effect ( ":" effect )?      -- ternary: win_effect : lose_effe
 | `+` inside `()` | target | Composable filter. Each token narrows the selection: `(all + friendly + here)` |
 | `+` outside `()` | effect | Compound — both effects happen in parallel. `gold[1] + move(self)` |
 | `[]`     | value   | Numeric parameter. Inside `()` = target count. Outside = effect value. |
-| `>`      | chain   | Pipe/sequence — output of left feeds into right. `reveal(deck)[3] > pick[1]` |
+| `>`      | chain   | Pipe/sequence — output of left feeds into right. `peek(deck)[3] > pick[1]` |
 | `~`      | modifier | Modifies preceding effect. Duration (`~turn`, `~round`) or rule flag (`~ignore_blocked`). |
 | `:`      | consequence | Separates win/lose effects (ternary). `> win_effect : lose_effect` |
 
@@ -129,8 +129,9 @@ Core primitives the engine implements. New cards compose these — no per-card c
 | `draw` | count | Draw cards from your deck. `draw[2]`. Implicit `[1]`. |
 | `buy` | cost override | Buy a card from market. `buy(item)[0]` = buy item for free. `buy[-1]` = 1 gold discount on anything. |
 | `move` | distance | Move a unit. `move(self)[2]` = 2 spaces. Implicit `[1]`. |
-| `reveal` | count | Reveal cards from a zone. `reveal(deck)[3]`, `reveal(opponent + hand)` |
-| `pick` | count | Player picks N from previously revealed cards (used after `>` pipe from `reveal`). `reveal(deck)[3] > pick[1]` |
+| `reveal` | — | Publicly reveal cards (visible to all players). `reveal(opponent + hand)` |
+| `peek` | count | Privately look at the top N of your own deck. Feeds into `pick`. `peek(deck)[3]` |
+| `pick` | count | Player picks N from previously peeked cards (used after `>` pipe from `peek`). `peek(deck)[3] > pick[1]` |
 | `buff.STAT` | amount | Temporary stat increase. Requires `~duration`. `buff.strength(all + friendly)[2]~turn` |
 | `contest.STAT` | bonus | Stat contest using named stat. Value = attacker bonus. `contest.strength[3]` = +3 bonus. |
 | `injure` | — | Injure target unit. `injure(enemy)` |
@@ -237,7 +238,7 @@ Complete action definitions (`name:ap_cost:effect`):
 | Sun Tzu | `stratagem:1:move(enemy)` |
 | Harriet Tubman | `underground:1:move(friendly)~ignore_blocked` |
 | Alexander the Great | `march:1:move(self) + contest.strength(enemy)` |
-| Ada Lovelace | `analyze:1:reveal(deck)[3] > pick[1]` |
+| Ada Lovelace | `analyze:1:peek(deck)[3] > pick[1]` |
 | Galileo Galilei | `observe:1:reveal(opponent + hand)` |
 | Nikola Tesla | `invent:2:buy(item)[0]` |
 | Genghis Khan | `conquer:3:raze(location) > to(hq)` |

--- a/library/sets/alpha-1/units.csv
+++ b/library/sets/alpha-1/units.csv
@@ -2,7 +2,7 @@ id,name,set,rarity,cost,strength,cunning,charisma,attributes,keywords,actions,te
 cleopatra,Cleopatra,alpha-1,legendary,6,4,8,9,Politician;Diplomat,,diplomacy:1:contest.charisma(enemy + adjacent) > control(target)~round,Target 1 adjacent unit. Move it to Cleopatra's location. Charisma contest: on win take control of target unit for this round.,The last pharaoh played Rome like a harp.
 nikola-tesla,Nikola Tesla,alpha-1,epic,4,3,9,5,Scientist;Engineer,,invent:2:buy(item)[0],Buy an item from the market for free.,The man who lit the world — then vanished from it.
 miyamoto-musashi,Miyamoto Musashi,alpha-1,epic,5,9,7,4,Warrior,,duel:1:contest.strength(enemy),Strength contest: injure target unit at same location.,Undefeated in sixty duels.
-ada-lovelace,Ada Lovelace,alpha-1,epic,3,3,8,5,Scientist,,analyze:1:reveal(deck)[3] > pick[1],Look at the top 3 cards of your main deck. Keep one.,The first programmer — before the first computer.
+ada-lovelace,Ada Lovelace,alpha-1,epic,3,3,8,5,Scientist,,analyze:1:peek(deck)[3] > pick[1],Look at the top 3 cards of your main deck. Keep one.,The first programmer — before the first computer.
 genghis-khan,Genghis Khan,alpha-1,legendary,7,8,7,6,Warrior;Politician,Military,conquer:3:raze(location) > to(hq),Raze target location. Place it in your HQ instead of discarding. Mission VP is not awarded. Your Equip actions involving a Mount cost 0 AP.,He did not build. He took.
 leonardo-da-vinci,Leonardo da Vinci,alpha-1,legendary,7,5,10,7,Scientist;Engineer,,design:1:draw[2],Draw 2 cards from your main deck.,The universal man needed no specialization.
 mansa-musa,Mansa Musa,alpha-1,legendary,8,4,6,10,Politician;Diplomat,,pilgrimage:2:gold[5],Gain 5 gold.,His generosity crashed an economy.

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -114,9 +114,11 @@ async function runFullGame(opts: {
 
 describe("full game flow", () => {
   // seed-3 is known to produce a decisive winner across 2/3/4 player counts
-  // with the current alpha-1 card library and greedy bots. If the card set
-  // changes, this seed may need updating — pick one where scores differ at
-  // the turn limit.
+  // with the current card library and greedy bots. If card behavior changes
+  // (new effects, bot tweaks), this seed may need updating — pick one where
+  // scores differ at the turn limit and games terminate cleanly.
+  // The `determinism` block below uses the same seed value as DET_SEED;
+  // keep them in sync when rotating.
   const DECISIVE_SEED = "seed-3";
 
   it("runs a 1v1 game to completion (seeding → main → ended)", async () => {
@@ -175,6 +177,7 @@ describe("full game flow", () => {
 // ---------------------------------------------------------------------------
 
 describe("determinism", () => {
+  // Same value as DECISIVE_SEED above — when rotating, update both.
   const DET_SEED = "seed-3";
 
   it("same seed produces identical final state", async () => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -113,10 +113,11 @@ async function runFullGame(opts: {
 // ---------------------------------------------------------------------------
 
 describe("full game flow", () => {
-  // seed-2 is known to produce a decisive winner with the current alpha-1
-  // card library and greedy bots. If the card set changes, this seed may
-  // need updating — pick one where scores differ at the turn limit.
-  const DECISIVE_SEED = "seed-2";
+  // seed-3 is known to produce a decisive winner across 2/3/4 player counts
+  // with the current alpha-1 card library and greedy bots. If the card set
+  // changes, this seed may need updating — pick one where scores differ at
+  // the turn limit.
+  const DECISIVE_SEED = "seed-3";
 
   it("runs a 1v1 game to completion (seeding → main → ended)", async () => {
     const controller = await runFullGame({ seed: DECISIVE_SEED });
@@ -192,8 +193,8 @@ describe("determinism", () => {
   });
 
   it("different seeds produce different games", async () => {
-    const c1 = await runFullGame({ seed: "seed-2" });
-    const c2 = await runFullGame({ seed: "seed-4" });
+    const c1 = await runFullGame({ seed: "seed-3" });
+    const c2 = await runFullGame({ seed: "seed-8" });
 
     const s1 = c1.getState() as EndedGameState;
     const s2 = c2.getState() as EndedGameState;


### PR DESCRIPTION
## Summary

**Engine half of #101.** Effects shaped `reveal(deck)[N] > pick[M]` (today only Ada Lovelace's `analyze:1:reveal(deck)[3] > pick[1]`) previously auto-picked the first M revealed cards. They now pause the effect chain and expose the candidates as game state for the player to resolve via a new `resolve_pick` action.

The web-client UI lands in a follow-up PR that will close #101.

## Engine changes

- `PendingPick` state on `MainGameState`, plus `resolve_pick` action and `cards_picked` event.
- DSL validator asserting `pick` is the terminal primitive in any chain. Post-pick continuation tracked in #103 (not v0.1).
- `execPick` pauses + aborts the chain when player choice is required; auto-takes all when `pickCount >= revealedCount`.
- Pre-produce guard in `applyMainAction` rejects non-`resolve_pick` actions while pending.
- `getValidActions` enumerates `resolve_pick` subsets; `VisibleState` exposes `pendingPick`.
- 11 new tests in `engine/src/__tests__/reveal-pick.test.ts`.

## Hitchhikers (justified by the behavior change)

- **`handleMove` AP fix**: regular branch now uses `getModifiedAPCost`, matching the retreat branch and `getValidActions`. Pre-existing mismatch was masked until the new action sequence tripped the `pioneer` policy's free-first-move discount.
- **Integration test seed bump**: `DECISIVE_SEED` `seed-2` -> `seed-3`; \"different seeds\" test `seed-2`/`seed-4` -> `seed-3`/`seed-8`. The test file already documented this seed would need bumping when card behavior changes.

## Also in this PR

- `clients/web/vite.config.ts`: fail dev fast with a single-line hint when the card library isn't built (previously a cryptic Vite import error).

## Related

- Refs #101 (this PR is the engine half — does not close)
- Spun off from #97 (v0.1 playtest bugs)
- Follow-up: #103 — engine support for post-pick chain steps (not v0.1)

## Test plan

- [x] Engine tests pass (`bun test` — 360 pass, 0 fail)
- [x] Library still builds (`bun library/build.ts` — 66 cards)
- [ ] Client PR consumes `pendingPick` from `VisibleState` and submits `resolve_pick`