### PR TITLE
#101 — Client: card selection dialog for reveal > pick effects

### DIFF
--- a/clients/web/src/App.svelte
+++ b/clients/web/src/App.svelte
@@ -16,6 +16,7 @@
   import EndedScreen from "./components/EndedScreen.svelte";
   import EventLog from "./components/EventLog.svelte";
   import CombatResultPopup from "./components/CombatResultPopup.svelte";
+  import PickPromptOverlay from "./components/PickPromptOverlay.svelte";
   // TODO: Remove DevPreview import and /#dev route once quick-start variant (#82) lands
   import DevPreview from "./DevPreview.svelte";
 
@@ -69,6 +70,10 @@
     {/if}
 
     <CombatResultPopup />
+
+    {#if vs?.pickPrompt}
+      <PickPromptOverlay />
+    {/if}
 
     {#if vs}
       {#if phase === "ended"}

--- a/clients/web/src/components/CombatResultPopup.svelte
+++ b/clients/web/src/components/CombatResultPopup.svelte
@@ -1,68 +1,67 @@
 <script lang="ts">
   import { getCombatResult, dismissCombat, type CombatResult } from "../lib/gameStore.svelte";
+  import Modal from "./Modal.svelte";
 
   const result: CombatResult | null = $derived(getCombatResult());
 </script>
 
 {#if result}
-  <div class="fixed inset-0 z-40 flex items-center justify-center bg-black/60">
-    <div class="w-96 rounded-lg bg-surface p-5">
-      <h3 class="mb-3 text-center text-lg font-bold text-text-primary">
-        Combat at {result.locationName}
-      </h3>
+  <Modal>
+    <h3 class="mb-3 text-center text-lg font-bold text-text-primary">
+      Combat at {result.locationName}
+    </h3>
 
-      <div class="mb-4 flex items-center justify-center gap-3 text-sm">
-        <span class="font-semibold text-self">
-          {result.attackerName}
-        </span>
-        <span class="text-text-faint">vs</span>
-        <span class="font-semibold text-opponent">
-          {result.defenderName}
-        </span>
-      </div>
-
-      {#if result.outcomes.length > 0}
-        <div class="mb-4 space-y-1">
-          {#each result.outcomes as outcome}
-            <div class="flex items-center gap-2 rounded bg-surface-raised px-3 py-1.5 text-sm">
-              {#if outcome.type === "injured"}
-                <span>🩸</span>
-                <span class="text-text-secondary">
-                  {outcome.unitName}
-                  <span class="text-text-muted">({outcome.ownerName})</span>
-                  injured
-                </span>
-              {:else}
-                <span>💀</span>
-                <span class="text-text-secondary">
-                  {outcome.unitName}
-                  <span class="text-text-muted">({outcome.ownerName})</span>
-                  killed
-                </span>
-              {/if}
-            </div>
-          {/each}
-        </div>
-      {:else}
-        <p class="mb-4 text-center text-sm text-text-muted">No casualties — draw!</p>
-      {/if}
-
-      <div class="mb-4 text-center text-sm font-semibold">
-        {#if result.winnerName}
-          <span class="text-highlight">
-            {result.winnerName} wins!
-          </span>
-        {:else}
-          <span class="text-text-muted">Draw — no clear winner</span>
-        {/if}
-      </div>
-
-      <button
-        onclick={dismissCombat}
-        class="w-full rounded bg-amber-600 py-2 font-semibold text-white hover:bg-amber-500"
-      >
-        Continue
-      </button>
+    <div class="mb-4 flex items-center justify-center gap-3 text-sm">
+      <span class="font-semibold text-self">
+        {result.attackerName}
+      </span>
+      <span class="text-text-faint">vs</span>
+      <span class="font-semibold text-opponent">
+        {result.defenderName}
+      </span>
     </div>
-  </div>
+
+    {#if result.outcomes.length > 0}
+      <div class="mb-4 space-y-1">
+        {#each result.outcomes as outcome}
+          <div class="flex items-center gap-2 rounded bg-surface-raised px-3 py-1.5 text-sm">
+            {#if outcome.type === "injured"}
+              <span>🩸</span>
+              <span class="text-text-secondary">
+                {outcome.unitName}
+                <span class="text-text-muted">({outcome.ownerName})</span>
+                injured
+              </span>
+            {:else}
+              <span>💀</span>
+              <span class="text-text-secondary">
+                {outcome.unitName}
+                <span class="text-text-muted">({outcome.ownerName})</span>
+                killed
+              </span>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {:else}
+      <p class="mb-4 text-center text-sm text-text-muted">No casualties — draw!</p>
+    {/if}
+
+    <div class="mb-4 text-center text-sm font-semibold">
+      {#if result.winnerName}
+        <span class="text-highlight">
+          {result.winnerName} wins!
+        </span>
+      {:else}
+        <span class="text-text-muted">Draw — no clear winner</span>
+      {/if}
+    </div>
+
+    <button
+      onclick={dismissCombat}
+      class="w-full rounded bg-amber-600 py-2 font-semibold text-white hover:bg-amber-500"
+    >
+      Continue
+    </button>
+  </Modal>
 {/if}

--- a/clients/web/src/components/Modal.svelte
+++ b/clients/web/src/components/Modal.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
 
+  // Centered-card modal over a darkened backdrop. Intentionally NOT
+  // dismissable via Escape or click-outside — current callers
+  // (PickPromptOverlay, CombatResultPopup) require explicit interaction
+  // via their inner buttons. If a future modal needs dismissability, add
+  // a `dismissable` prop here rather than introducing a parallel
+  // primitive. ARIA dialog attributes set so assistive tech announces
+  // the modal; focus trap is not implemented (separate a11y concern).
   interface Props {
-    /** Tailwind width class for the card. Default w-96. */
     width?: string;
     children: Snippet;
   }
@@ -10,7 +16,11 @@
   const { width = "w-96", children }: Props = $props();
 </script>
 
-<div class="fixed inset-0 z-40 flex items-center justify-center bg-black/60">
+<div
+  class="fixed inset-0 z-40 flex items-center justify-center bg-black/60"
+  role="dialog"
+  aria-modal="true"
+>
   <div class={`${width} rounded-lg bg-surface p-5`}>
     {@render children()}
   </div>

--- a/clients/web/src/components/Modal.svelte
+++ b/clients/web/src/components/Modal.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    /** Tailwind width class for the card. Default w-96. */
+    width?: string;
+    children: Snippet;
+  }
+
+  const { width = "w-96", children }: Props = $props();
+</script>
+
+<div class="fixed inset-0 z-40 flex items-center justify-center bg-black/60">
+  <div class={`${width} rounded-lg bg-surface p-5`}>
+    {@render children()}
+  </div>
+</div>

--- a/clients/web/src/components/PickPromptOverlay.svelte
+++ b/clients/web/src/components/PickPromptOverlay.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getVisibleState, selectAction } from "../lib/gameStore.svelte";
+  import { getError, getVisibleState, selectAction, setError } from "../lib/gameStore.svelte";
   import CardView from "./CardView.svelte";
   import Modal from "./Modal.svelte";
 
@@ -12,34 +12,90 @@
           .filter((c): c is NonNullable<typeof c> => c !== undefined)
       : [],
   );
+  // Engine invariant: every option id is findable in mainDeck while the prompt
+  // is set (peek slices non-destructively; the pre-produce guard rejects any
+  // action but resolve_pick). If we find fewer cards than ids, something
+  // out-of-band has mutated the deck — fail loud via the global error banner.
+  const invariantBroken = $derived(
+    !!prompt && optionCards.length !== prompt.options.length,
+  );
+
+  $effect(() => {
+    if (invariantBroken && prompt && vs) {
+      const missing = prompt.options.filter(
+        (id) => !vs.self.mainDeck.some((c) => c.id === id),
+      );
+      console.error(
+        "PickPromptOverlay: option ids missing from mainDeck — engine/client invariant broken",
+        { missing, promptOptions: prompt.options },
+      );
+      setError(
+        "Engine state is inconsistent (pick options missing from deck). " +
+          "Return to menu and reload — your save may be corrupt.",
+      );
+    }
+  });
 
   let selected = $state(new Set<string>());
+  let submitted = $state(false);
+
+  // If the engine surfaces an error while we're mid-submit, unlock the
+  // button so the user can try again (retry may or may not succeed
+  // depending on whether the controller is recoverable, but the button
+  // shouldn't be permanently stuck).
+  const error = $derived(getError());
+  $effect(() => {
+    if (error && submitted) submitted = false;
+  });
+
+  // Reset local picker state when the prompt changes content. Today the
+  // outer `{#if vs?.pickPrompt}` unmounts and remounts the component on
+  // every prompt transition, so this is defensive — protects against a
+  // future refactor that keeps the component mounted across prompts.
+  $effect(() => {
+    void prompt?.options.join(",");
+    selected = new Set();
+    submitted = false;
+  });
 
   function toggle(cardId: string): void {
+    if (!prompt) return;
     const next = new Set(selected);
-    if (next.has(cardId)) next.delete(cardId);
-    else next.add(cardId);
+    if (next.has(cardId)) {
+      next.delete(cardId);
+    } else {
+      // At the cap — drop the oldest selection FIFO so the user can
+      // re-pick freely without manually deselecting first.
+      if (next.size >= prompt.count) {
+        const oldest = next.values().next().value;
+        if (oldest !== undefined) next.delete(oldest);
+      }
+      next.add(cardId);
+    }
     selected = next;
   }
 
   function confirm(): void {
-    if (!prompt || selected.size !== prompt.count) return;
+    if (!prompt || selected.size !== prompt.count || submitted) return;
+    submitted = true;
     selectAction({
       type: "resolve_pick",
       playerId: prompt.playerId,
       pickedCardIds: [...selected] as [string, ...string[]],
     });
-    selected = new Set();
+    // Don't clear `selected` here — the component unmounts when the engine
+    // clears pickPrompt on success, and on failure we preserve the user's
+    // selection so they can retry without re-picking from scratch.
   }
 </script>
 
-{#if prompt}
+{#if prompt && !invariantBroken}
   <Modal width="w-auto max-w-3xl">
     <h3 class="mb-2 text-center text-lg font-bold text-text-primary">
       Choose {prompt.count} card{prompt.count === 1 ? "" : "s"} to keep
     </h3>
     <p class="mb-4 text-center text-sm text-text-muted">
-      Looked at the top {optionCards.length} of your main deck.
+      Looked at the top {prompt.options.length} of your main deck.
     </p>
 
     <div class="mb-4 flex flex-wrap justify-center gap-3">
@@ -54,10 +110,10 @@
 
     <button
       onclick={confirm}
-      disabled={selected.size !== prompt.count}
+      disabled={selected.size !== prompt.count || submitted}
       class="w-full rounded bg-amber-600 py-2 font-semibold text-white hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-50"
     >
-      Confirm ({selected.size} / {prompt.count})
+      {submitted ? "Submitting…" : `Confirm (${selected.size} / ${prompt.count})`}
     </button>
   </Modal>
 {/if}

--- a/clients/web/src/components/PickPromptOverlay.svelte
+++ b/clients/web/src/components/PickPromptOverlay.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import { getVisibleState, selectAction } from "../lib/gameStore.svelte";
+  import CardView from "./CardView.svelte";
+  import Modal from "./Modal.svelte";
+
+  const vs = $derived(getVisibleState());
+  const prompt = $derived(vs?.pickPrompt);
+  const optionCards = $derived(
+    prompt && vs
+      ? prompt.options
+          .map((id) => vs.self.mainDeck.find((c) => c.id === id))
+          .filter((c): c is NonNullable<typeof c> => c !== undefined)
+      : [],
+  );
+
+  let selected = $state(new Set<string>());
+
+  function toggle(cardId: string): void {
+    const next = new Set(selected);
+    if (next.has(cardId)) next.delete(cardId);
+    else next.add(cardId);
+    selected = next;
+  }
+
+  function confirm(): void {
+    if (!prompt || selected.size !== prompt.count) return;
+    selectAction({
+      type: "resolve_pick",
+      playerId: prompt.playerId,
+      pickedCardIds: [...selected] as [string, ...string[]],
+    });
+    selected = new Set();
+  }
+</script>
+
+{#if prompt}
+  <Modal width="w-auto max-w-3xl">
+    <h3 class="mb-2 text-center text-lg font-bold text-text-primary">
+      Choose {prompt.count} card{prompt.count === 1 ? "" : "s"} to keep
+    </h3>
+    <p class="mb-4 text-center text-sm text-text-muted">
+      Looked at the top {optionCards.length} of your main deck.
+    </p>
+
+    <div class="mb-4 flex flex-wrap justify-center gap-3">
+      {#each optionCards as card (card.id)}
+        <CardView
+          {card}
+          highlighted={selected.has(card.id)}
+          onclick={() => toggle(card.id)}
+        />
+      {/each}
+    </div>
+
+    <button
+      onclick={confirm}
+      disabled={selected.size !== prompt.count}
+      class="w-full rounded bg-amber-600 py-2 font-semibold text-white hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      Confirm ({selected.size} / {prompt.count})
+    </button>
+  </Modal>
+{/if}

--- a/clients/web/src/lib/eventDescriptions.ts
+++ b/clients/web/src/lib/eventDescriptions.ts
@@ -124,7 +124,8 @@ export function describeEvent(event: GameEvent, r?: NameResolvers): string {
       return `${c(event.unitId, r)} got ${event.delta > 0 ? "+" : ""}${event.delta} ${event.stat}`;
     case "cards_revealed":
       return `${p(event.playerId, r)} revealed ${event.cardIds.length} card(s)`;
-    // TODO(#101 client PR): improve formatting + i18n; this is a stub
+    case "cards_peeked":
+      return `${p(event.playerId, r)} peeked at ${event.cardIds.length} card(s)`;
     case "cards_picked":
       return `${p(event.playerId, r)} picked ${event.cardIds.length} card(s)`;
     case "unit_controlled":

--- a/clients/web/src/lib/gameStore.svelte.ts
+++ b/clients/web/src/lib/gameStore.svelte.ts
@@ -127,6 +127,12 @@ export function getLastTurnEvents(): GameEvent[] {
 export function clearError() {
   _error = null;
 }
+// Minimal v0.1 export so components can surface engine/client invariant
+// violations via the shared banner. #110 tracks proper error-handling infra
+// (consolidated setError, structured logError helper, severity levels).
+export function setError(message: string): void {
+  _error = message;
+}
 
 // ---------------------------------------------------------------------------
 // Internal state
@@ -379,12 +385,20 @@ export async function loadGame(key: string): Promise<void> {
 }
 
 export function selectAction(action: Action): void {
-  if (resolveAction) {
-    const resolve = resolveAction;
-    resolveAction = null;
-    rejectAction = null;
-    resolve($state.snapshot(action));
+  if (!resolveAction) {
+    // No pending resolver — most likely a double-click or a click after
+    // returnToMenu cleared the slots. Drop the action loudly rather than
+    // silently. #110 tracks proper logError infrastructure.
+    console.warn(
+      "selectAction called with no pending resolver — action dropped",
+      { actionType: action.type, actionPlayerId: action.playerId },
+    );
+    return;
   }
+  const resolve = resolveAction;
+  resolveAction = null;
+  rejectAction = null;
+  resolve($state.snapshot(action));
 }
 
 export function confirmPassDevice(): void {
@@ -421,7 +435,9 @@ export async function refreshSessions(): Promise<void> {
 }
 
 export function returnToMenu(): void {
-  // Reject pending promises so the game loop terminates cleanly
+  // Reject pending promises so the game loop terminates cleanly.
+  // Any pending pickPrompt on the abandoned state is implicitly discarded:
+  // `controller = null` below GCs the entire state, including the prompt.
   const abandon = new GameAbandoned();
   if (rejectAction) {
     rejectAction(abandon);


### PR DESCRIPTION
## Summary

Client half of #101. Adds a blocking selection dialog so the active player can choose which revealed cards to keep when an effect uses \`peek(deck)[N] > pick[M]\` (today: Ada Lovelace's \`analyze\`). Engine half landed in #104.

## Components

- **\`Modal.svelte\`** (new) — shared centered-card-on-backdrop primitive. Replaces inline modal chrome that lived in CombatResultPopup.
- **\`CombatResultPopup.svelte\`** (refactor) — now wraps content in \`<Modal>\`. Pure refactor, same visual output.
- **\`PickPromptOverlay.svelte\`** (new) — driven by \`vs.pickPrompt\`. Click cards to toggle selection, Confirm submits \`resolve_pick\`.

\`PassDeviceOverlay\` intentionally not refactored (different structural shape — full-screen takeover, no centered card).

## Wiring

- \`App.svelte\` conditionally renders \`PickPromptOverlay\` next to \`CombatResultPopup\` based on \`vs?.pickPrompt\`.
- \`eventDescriptions.ts\` — real \`cards_peeked\` case, removed \`TODO(#101 client PR)\` stub on \`cards_picked\`.

## Test plan

- [x] Engine tests pass (\`bun test\` — 378 pass, no regressions)
- [x] Manual: deploy Ada Lovelace, enter her to grid, activate \`analyze\` → overlay shows top 3 of deck → click to select → Confirm moves the chosen card to hand, leaves the other two at deck top in original order.
- [x] Manual: combat between two units triggers \`CombatResultPopup\` correctly (regression check for the Modal refactor).
- [ ] Opponent view: confirm via dev tools that \`vs.pickPrompt\` is undefined for the non-picker (engine-side privacy filter already enforces this; client just reads).

## Related

- Closes #101.
- Built on engine work in #104.
- Spun off from #97 (v0.1 playtest bugs).

## Out-of-scope playtest findings (separate issues)

- #107 — engine: unwired unit passives (Mary Shelley, Spartacus).
- #108 — engine: allow HQ units to activate non-positional abilities.