### PR TITLE
#108 — Engine: allow HQ units to activate non-positional abilities

### DIFF
--- a/engine/src/__tests__/activate-hq.test.ts
+++ b/engine/src/__tests__/activate-hq.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { produce } from "immer";
+import { applyAction } from "../apply-action";
+import { getValidActions } from "../valid-actions";
+import type { MainAction, MainGameState, UnitCard } from "../types";
+import { createTestGame, makeItem, makeUnit, resetIds } from "./helpers";
+
+beforeEach(() => resetIds());
+
+// Same active-player assumption as reveal-pick.test.ts — the SEED="test-seed"
+// shuffle puts p2 first, so player index 0 is the active player after
+// createTestGame() reorders.
+const ACTIVE = "p2";
+const ACTIVE_IDX = 0;
+
+function gameWith(fn: (draft: MainGameState) => void): MainGameState {
+  return produce(createTestGame(), fn);
+}
+
+function makeHqUnit(name: string, effect: string, apCost = 1): UnitCard {
+  return makeUnit({
+    ownerId: ACTIVE,
+    name,
+    actions: [{ name: "act", apCost, effect }],
+  });
+}
+
+describe("HQ activate — non-positional verbs", () => {
+  it("HQ Ada offers analyze (peek+pick) and pauses with pickPrompt", () => {
+    const ada = makeHqUnit("Ada", "peek(deck)[3] > pick[1]");
+    const top1 = makeUnit({ ownerId: ACTIVE, name: "Top1" });
+    const top2 = makeUnit({ ownerId: ACTIVE, name: "Top2" });
+    const top3 = makeUnit({ ownerId: ACTIVE, name: "Top3" });
+    const state = gameWith((d) => {
+      d.players[ACTIVE_IDX].hq.push(ada);
+      d.players[ACTIVE_IDX].mainDeck.push(top1, top2, top3);
+    });
+
+    const validActions = getValidActions(state, ACTIVE);
+    const activate = validActions.find(
+      (a) => a.type === "activate" && a.cardId === ada.id,
+    );
+    expect(activate).toBeDefined();
+
+    const { state: next } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: ada.id,
+      actionName: "act",
+    });
+    const ns = next as MainGameState;
+    expect(ns.pickPrompt).toEqual({
+      playerId: ACTIVE,
+      options: [top1.id, top2.id, top3.id],
+      count: 1,
+      source: "main_deck",
+    });
+  });
+
+  it("HQ Tesla offers invent (buy item from market for free)", () => {
+    const tesla = makeHqUnit("Tesla", "buy(item)[0]");
+    const marketItem = makeItem({ ownerId: ACTIVE, name: "Wrench" });
+    const state = gameWith((d) => {
+      d.players[ACTIVE_IDX].hq.push(tesla);
+      d.market.push(marketItem);
+    });
+
+    const validActions = getValidActions(state, ACTIVE);
+    expect(
+      validActions.some((a) => a.type === "activate" && a.cardId === tesla.id),
+    ).toBe(true);
+
+    const { state: next } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: tesla.id,
+      actionName: "act",
+    });
+    const ns = next as MainGameState;
+    expect(ns.players[ACTIVE_IDX].hand.some((c) => c.id === marketItem.id)).toBe(true);
+    expect(ns.market.some((c) => c.id === marketItem.id)).toBe(false);
+  });
+
+  it("HQ Mansa Musa offers pilgrimage (+5 gold)", () => {
+    const mansa = makeHqUnit("Mansa Musa", "gold[5]", 2);
+    const state = gameWith((d) => {
+      d.players[ACTIVE_IDX].hq.push(mansa);
+    });
+    const goldBefore = state.players[ACTIVE_IDX].gold;
+
+    const validActions = getValidActions(state, ACTIVE);
+    expect(
+      validActions.some((a) => a.type === "activate" && a.cardId === mansa.id),
+    ).toBe(true);
+
+    const { state: next } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: mansa.id,
+      actionName: "act",
+    });
+    expect((next as MainGameState).players[ACTIVE_IDX].gold).toBe(goldBefore + 5);
+  });
+
+  it("HQ Marco Polo does NOT offer trade-route (compound contains move)", () => {
+    const marco = makeHqUnit("Marco Polo", "move(self) + gold[1]");
+    const state = gameWith((d) => {
+      d.players[ACTIVE_IDX].hq.push(marco);
+    });
+    const activates = getValidActions(state, ACTIVE).filter(
+      (a) => a.type === "activate" && a.cardId === marco.id,
+    );
+    expect(activates).toHaveLength(0);
+  });
+
+  it("HQ Ramesses II does NOT offer monument (compound contains kill)", () => {
+    const ramesses = makeHqUnit("Ramesses II", "vp[1] + kill(self)", 2);
+    const state = gameWith((d) => {
+      d.players[ACTIVE_IDX].hq.push(ramesses);
+    });
+    const activates = getValidActions(state, ACTIVE).filter(
+      (a) => a.type === "activate" && a.cardId === ramesses.id,
+    );
+    expect(activates).toHaveLength(0);
+  });
+
+  it("HQ Ada does NOT offer analyze when mainDeck is empty (precondition)", () => {
+    const ada = makeHqUnit("Ada", "peek(deck)[3] > pick[1]");
+    const state = gameWith((d) => {
+      d.players[ACTIVE_IDX].hq.push(ada);
+      d.players[ACTIVE_IDX].mainDeck = [];
+    });
+    const activates = getValidActions(state, ACTIVE).filter(
+      (a) => a.type === "activate" && a.cardId === ada.id,
+    );
+    expect(activates).toHaveLength(0);
+  });
+
+  it("Grid Marco Polo regression — trade-route IS offered with an adjacent open cell", () => {
+    const marco = makeHqUnit("Marco Polo", "move(self) + gold[1]");
+    const state = gameWith((d) => {
+      // Place Marco at (0,0); ensure (0,1) has a location reachable via open edges.
+      // createTestGame seeds a fresh main-phase game without grid locations, so we
+      // need both cells to have locations whose facing edges are open.
+      const fromLoc = {
+        id: "loc-from",
+        definitionId: "test-loc-from",
+        type: "location" as const,
+        name: "From",
+        cost: "0",
+        rarity: "common" as const,
+        edges: { n: true, e: true, s: true, w: true },
+        ownerId: ACTIVE,
+      };
+      const toLoc = {
+        id: "loc-to",
+        definitionId: "test-loc-to",
+        type: "location" as const,
+        name: "To",
+        cost: "0",
+        rarity: "common" as const,
+        edges: { n: true, e: true, s: true, w: true },
+        ownerId: ACTIVE,
+      };
+      d.grid[0][0].location = fromLoc;
+      d.grid[0][1].location = toLoc;
+      d.grid[0][0].units.push(marco);
+    });
+    const activates: MainAction[] = getValidActions(state, ACTIVE).filter(
+      (a): a is MainAction => a.type === "activate" && a.cardId === marco.id,
+    );
+    expect(activates.length).toBeGreaterThan(0);
+  });
+});

--- a/engine/src/__tests__/activate-hq.test.ts
+++ b/engine/src/__tests__/activate-hq.test.ts
@@ -3,7 +3,7 @@ import { produce } from "immer";
 import { applyAction } from "../apply-action";
 import { getValidActions } from "../valid-actions";
 import type { MainAction, MainGameState, UnitCard } from "../types";
-import { createTestGame, makeItem, makeUnit, resetIds } from "./helpers";
+import { createTestGame, makeItem, makeLocation, makeUnit, resetIds } from "./helpers";
 
 beforeEach(() => resetIds());
 
@@ -139,31 +139,10 @@ describe("HQ activate — non-positional verbs", () => {
   it("Grid Marco Polo regression — trade-route IS offered with an adjacent open cell", () => {
     const marco = makeHqUnit("Marco Polo", "move(self) + gold[1]");
     const state = gameWith((d) => {
-      // Place Marco at (0,0); ensure (0,1) has a location reachable via open edges.
-      // createTestGame seeds a fresh main-phase game without grid locations, so we
-      // need both cells to have locations whose facing edges are open.
-      const fromLoc = {
-        id: "loc-from",
-        definitionId: "test-loc-from",
-        type: "location" as const,
-        name: "From",
-        cost: "0",
-        rarity: "common" as const,
-        edges: { n: true, e: true, s: true, w: true },
-        ownerId: ACTIVE,
-      };
-      const toLoc = {
-        id: "loc-to",
-        definitionId: "test-loc-to",
-        type: "location" as const,
-        name: "To",
-        cost: "0",
-        rarity: "common" as const,
-        edges: { n: true, e: true, s: true, w: true },
-        ownerId: ACTIVE,
-      };
-      d.grid[0][0].location = fromLoc;
-      d.grid[0][1].location = toLoc;
+      // Place Marco at (0,0); both cells need a location with open facing edges
+      // — createTestGame seeds an empty grid.
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE, name: "From" });
+      d.grid[0][1].location = makeLocation({ ownerId: ACTIVE, name: "To" });
       d.grid[0][0].units.push(marco);
     });
     const activates: MainAction[] = getValidActions(state, ACTIVE).filter(

--- a/engine/src/__tests__/effect-dsl-verbs.test.ts
+++ b/engine/src/__tests__/effect-dsl-verbs.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { VERBS, isHqSafeVerb, type Verb } from "../effect-dsl";
+
+// Adding a verb to VERBS without an entry here fails the suite — forces an
+// explicit HQ-safety classification on every new verb.
+const EXPECTED: Record<Verb, boolean> = {
+  gold: true,
+  vp: true,
+  draw: true,
+  peek: true,
+  pick: true,
+  buy: true,
+  reveal: true,
+  kill: false,
+  injure: false,
+  buff: false,
+  move: false,
+  control: false,
+  remove: false,
+  raze: false,
+  to: false,
+  contest: false,
+};
+
+describe("isHqSafeVerb", () => {
+  for (const verb of VERBS) {
+    it(`classifies ${verb} as ${EXPECTED[verb] ? "HQ-safe" : "grid-only"}`, () => {
+      expect(isHqSafeVerb(verb)).toBe(EXPECTED[verb]);
+    });
+  }
+
+  it("rejects unknown verbs conservatively", () => {
+    expect(isHqSafeVerb("not-a-verb")).toBe(false);
+    expect(isHqSafeVerb("")).toBe(false);
+  });
+});

--- a/engine/src/__tests__/valid-actions.test.ts
+++ b/engine/src/__tests__/valid-actions.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import { produce } from "immer";
-import type { EndedGameState } from "../types";
+import type { EndedGameState, MainGameState } from "../types";
 import { getActivePlayerId } from "../types";
-import { getValidActions } from "../valid-actions";
-import { createSeedingGame, createTestGame } from "./helpers";
+import { getValidActions, inferActivateTargets } from "../valid-actions";
+import type { BoardPosition } from "../position-helpers";
+import { createSeedingGame, createTestGame, makeUnit } from "./helpers";
 
 describe("getValidActions", () => {
   describe("main phase", () => {
@@ -86,5 +87,83 @@ describe("getValidActions", () => {
       expect(actions).toHaveLength(1);
       expect(actions[0].type).toBe("seed_keep");
     });
+  });
+});
+
+describe("inferActivateTargets — HQ origin", () => {
+  function setup(opts: { effect: string; deckTopUp?: number } = { effect: "gold[1]" }) {
+    const base = createTestGame();
+    const activeId = base.turn.activePlayerId;
+    const unit = makeUnit({
+      ownerId: activeId,
+      actions: [{ name: "act", apCost: 1, effect: opts.effect }],
+    });
+    const state = produce(base, (d) => {
+      d.players.find((p) => p.id === activeId)!.hq.push(unit);
+      if (opts.deckTopUp) {
+        const top = d.players.find((p) => p.id === activeId)!;
+        for (let i = 0; i < opts.deckTopUp; i++) {
+          top.mainDeck.push(makeUnit({ ownerId: activeId, name: `Top${i}` }));
+        }
+      }
+    });
+    const hq: BoardPosition = { type: "hq", playerId: activeId };
+    return { state: state as MainGameState, unit, activeId, hq };
+  }
+
+  it("allows gold[1] from HQ", () => {
+    const { state, unit, activeId, hq } = setup({ effect: "gold[1]" });
+    expect(inferActivateTargets(state, unit.id, "gold[1]", hq, activeId)).toEqual([{}]);
+  });
+
+  it("allows vp[1] from HQ", () => {
+    const { state, unit, activeId, hq } = setup({ effect: "vp[1]" });
+    expect(inferActivateTargets(state, unit.id, "vp[1]", hq, activeId)).toEqual([{}]);
+  });
+
+  it("allows buy(item)[0] from HQ", () => {
+    const { state, unit, activeId, hq } = setup({ effect: "buy(item)[0]" });
+    expect(inferActivateTargets(state, unit.id, "buy(item)[0]", hq, activeId)).toEqual([{}]);
+  });
+
+  it("allows peek(deck)[3] > pick[1] when deck has cards", () => {
+    const { state, unit, activeId, hq } = setup({
+      effect: "peek(deck)[3] > pick[1]",
+      deckTopUp: 3,
+    });
+    expect(
+      inferActivateTargets(state, unit.id, "peek(deck)[3] > pick[1]", hq, activeId),
+    ).toEqual([{}]);
+  });
+
+  it("rejects peek(deck)[3] > pick[1] when deck is empty (precondition gate)", () => {
+    const { state, unit, activeId, hq } = setup({ effect: "peek(deck)[3] > pick[1]" });
+    expect(
+      inferActivateTargets(state, unit.id, "peek(deck)[3] > pick[1]", hq, activeId),
+    ).toEqual([]);
+  });
+
+  it("rejects kill(self) from HQ", () => {
+    const { state, unit, activeId, hq } = setup({ effect: "kill(self)" });
+    expect(inferActivateTargets(state, unit.id, "kill(self)", hq, activeId)).toEqual([]);
+  });
+
+  it("rejects move(self) from HQ", () => {
+    const { state, unit, activeId, hq } = setup({ effect: "move(self)" });
+    expect(inferActivateTargets(state, unit.id, "move(self)", hq, activeId)).toEqual([]);
+  });
+
+  it("rejects compound vp[1] + kill(self) from HQ", () => {
+    const { state, unit, activeId, hq } = setup({ effect: "vp[1] + kill(self)" });
+    expect(
+      inferActivateTargets(state, unit.id, "vp[1] + kill(self)", hq, activeId),
+    ).toEqual([]);
+  });
+
+  it("rejects compound move(self) + gold[1] from HQ", () => {
+    const { state, unit, activeId, hq } = setup({ effect: "move(self) + gold[1]" });
+    expect(
+      inferActivateTargets(state, unit.id, "move(self) + gold[1]", hq, activeId),
+    ).toEqual([]);
   });
 });

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -850,7 +850,10 @@ function handleActivate(
   events: GameEvent[],
   queries: QueryListener[],
 ): void {
-  // Find the card with actions — search grid units
+  // Find the card with actions — search grid units, then HQ.
+  // HQ units only surface non-positional activates (see valid-actions.ts's
+  // isHqSafeVerb gate); positional verbs no-op cleanly when actingUnitId
+  // resolves to no grid position (see executor's getActingPosition).
   let card: Draft<UnitCard> | undefined;
 
   for (let r = 0; r < draft.grid.length; r++) {
@@ -864,7 +867,17 @@ function handleActivate(
     if (card) break;
   }
 
-  if (!card) throw new Error(`Card "${cardId}" not found on grid`);
+  if (!card) {
+    for (const p of draft.players) {
+      const found = p.hq.find((c) => c.id === cardId && c.type === "unit");
+      if (found) {
+        card = found as Draft<UnitCard>;
+        break;
+      }
+    }
+  }
+
+  if (!card) throw new Error(`Card "${cardId}" not found on grid or HQ`);
   if (!card.actions) throw new Error(`Card "${cardId}" has no actions`);
   if (card.ownerId !== playerId) throw new Error(`Card "${cardId}" not owned by "${playerId}"`);
 

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -850,34 +850,12 @@ function handleActivate(
   events: GameEvent[],
   queries: QueryListener[],
 ): void {
-  // Find the card with actions — search grid units, then HQ.
   // HQ units only surface non-positional activates (see valid-actions.ts's
   // isHqSafeVerb gate); positional verbs no-op cleanly when actingUnitId
   // resolves to no grid position (see executor's getActingPosition).
-  let card: Draft<UnitCard> | undefined;
-
-  for (let r = 0; r < draft.grid.length; r++) {
-    for (let c = 0; c < draft.grid[r].length; c++) {
-      const found = draft.grid[r][c].units.find((u) => u.id === cardId);
-      if (found) {
-        card = found;
-        break;
-      }
-    }
-    if (card) break;
-  }
-
-  if (!card) {
-    for (const p of draft.players) {
-      const found = p.hq.find((c) => c.id === cardId && c.type === "unit");
-      if (found) {
-        card = found as Draft<UnitCard>;
-        break;
-      }
-    }
-  }
-
-  if (!card) throw new Error(`Card "${cardId}" not found on grid or HQ`);
+  const located = findUnitPosition(draft.players, draft.grid, cardId);
+  if (!located) throw new Error(`Card "${cardId}" not found on grid or HQ`);
+  const card = located.unit as Draft<UnitCard>;
   if (!card.actions) throw new Error(`Card "${cardId}" has no actions`);
   if (card.ownerId !== playerId) throw new Error(`Card "${cardId}" not owned by "${playerId}"`);
 

--- a/engine/src/effect-dsl/index.ts
+++ b/engine/src/effect-dsl/index.ts
@@ -1,5 +1,7 @@
 export { parse, DSLParseError } from "./parser";
 export { DSLValidationError } from "./validate";
+export { VERBS, isHqSafeVerb } from "./verbs";
+export type { Verb } from "./verbs";
 export type {
   Expression,
   Effect,

--- a/engine/src/effect-dsl/verbs.ts
+++ b/engine/src/effect-dsl/verbs.ts
@@ -1,0 +1,42 @@
+/**
+ * Central registry of DSL verbs with metadata. Mirrors the dispatch in
+ * `executor.ts` — adding a verb there means adding it here too.
+ */
+
+export const VERBS = [
+  "gold",
+  "vp",
+  "draw",
+  "peek",
+  "pick",
+  "buy",
+  "reveal",
+  "kill",
+  "injure",
+  "buff",
+  "move",
+  "control",
+  "remove",
+  "raze",
+  "to",
+  "contest",
+] as const;
+
+export type Verb = (typeof VERBS)[number];
+
+// Verbs whose effect depends only on player state — safe to execute from HQ
+// where the acting unit has no grid coordinates.
+const HQ_SAFE: ReadonlySet<Verb> = new Set([
+  "gold",
+  "vp",
+  "draw",
+  "peek",
+  "pick",
+  "buy",
+  "reveal",
+]);
+
+/** True if the verb operates purely on player state (no grid context needed). */
+export function isHqSafeVerb(verb: string): boolean {
+  return HQ_SAFE.has(verb as Verb);
+}

--- a/engine/src/valid-actions.ts
+++ b/engine/src/valid-actions.ts
@@ -22,7 +22,6 @@ import type {
   PickPrompt,
   SeedingAction,
   SeedingGameState,
-  UnitCard,
 } from "./types";
 import { getActivePlayerId } from "./types";
 
@@ -341,59 +340,44 @@ function getMainValidActions(
     }
   }
 
-  // activate — unit actions from grid units and HQ units
-  for (let r = 0; r < gridRows; r++) {
-    for (let c = 0; c < gridCols; c++) {
-      for (const unit of state.grid[r][c].units) {
-        if (unit.ownerId !== playerId) continue;
-        if (!unit.actions) continue;
-        for (const actionDef of unit.actions) {
-          if (ap < actionDef.apCost) continue;
-          const targets = inferActivateTargets(
-            state,
-            unit.id,
-            actionDef.effect,
-            { type: "grid", row: r, col: c },
-            playerId,
-          );
-          for (const t of targets) {
-            actions.push({
-              type: "activate",
-              playerId,
-              cardId: unit.id,
-              actionName: actionDef.name,
-              ...t,
-            });
-          }
-        }
-      }
-    }
-  }
-
-  // HQ-origin activates: each verb is HQ-safe iff it operates purely on player
-  // state (no grid coords). inferActivateTargets enforces the all-primitives
-  // rule per AST and returns [] for any compound containing a non-HQ-safe verb.
-  for (const card of player.hq) {
-    if (card.type !== "unit") continue;
-    const unit = card as UnitCard;
-    if (!unit.actions) continue;
-    for (const actionDef of unit.actions) {
-      if (ap < actionDef.apCost) continue;
-      const targets = inferActivateTargets(
-        state,
-        unit.id,
-        actionDef.effect,
-        { type: "hq", playerId },
-        playerId,
-      );
-      for (const t of targets) {
-        actions.push({
-          type: "activate",
+  // activate — unit actions, across all positions
+  // HQ-origin activates rely on inferActivateTargets to reject any compound
+  // containing a non-HQ-safe verb (move, kill, contest, …) so positional
+  // primitives never reach the executor without grid coords.
+  const activatePositions: BoardPosition[] = [
+    { type: "hq", playerId },
+    ...Array.from({ length: gridRows * gridCols }, (_, i) => ({
+      type: "grid" as const,
+      row: Math.floor(i / gridCols),
+      col: i % gridCols,
+    })),
+  ];
+  for (const pos of activatePositions) {
+    // HQ: units belong to the player by definition. Grid: filter by ownerId
+    // since multiple players share cells.
+    const ownerFilter = pos.type === "hq";
+    const units = getUnitsAtPosition(state.players, state.grid, pos)
+      .filter((u) => ownerFilter || u.ownerId === playerId);
+    for (const unit of units) {
+      if (!unit.actions) continue;
+      for (const actionDef of unit.actions) {
+        if (ap < actionDef.apCost) continue;
+        const targets = inferActivateTargets(
+          state,
+          unit.id,
+          actionDef.effect,
+          pos,
           playerId,
-          cardId: unit.id,
-          actionName: actionDef.name,
-          ...t,
-        });
+        );
+        for (const t of targets) {
+          actions.push({
+            type: "activate",
+            playerId,
+            cardId: unit.id,
+            actionName: actionDef.name,
+            ...t,
+          });
+        }
       }
     }
   }

--- a/engine/src/valid-actions.ts
+++ b/engine/src/valid-actions.ts
@@ -1,4 +1,4 @@
-import { parse, DSLParseError, DSLValidationError } from "./effect-dsl";
+import { parse, DSLParseError, DSLValidationError, isHqSafeVerb } from "./effect-dsl";
 import type { Primitive } from "./effect-dsl/types";
 import { tryParseCost } from "./cost-helpers";
 import { checkMissionRequirements, parseRequirements } from "./mission-helpers";
@@ -22,6 +22,7 @@ import type {
   PickPrompt,
   SeedingAction,
   SeedingGameState,
+  UnitCard,
 } from "./types";
 import { getActivePlayerId } from "./types";
 
@@ -340,7 +341,7 @@ function getMainValidActions(
     }
   }
 
-  // activate — unit actions from grid units
+  // activate — unit actions from grid units and HQ units
   for (let r = 0; r < gridRows; r++) {
     for (let c = 0; c < gridCols; c++) {
       for (const unit of state.grid[r][c].units) {
@@ -348,7 +349,13 @@ function getMainValidActions(
         if (!unit.actions) continue;
         for (const actionDef of unit.actions) {
           if (ap < actionDef.apCost) continue;
-          const targets = inferActivateTargets(state, unit.id, actionDef.effect, r, c, playerId);
+          const targets = inferActivateTargets(
+            state,
+            unit.id,
+            actionDef.effect,
+            { type: "grid", row: r, col: c },
+            playerId,
+          );
           for (const t of targets) {
             actions.push({
               type: "activate",
@@ -359,6 +366,34 @@ function getMainValidActions(
             });
           }
         }
+      }
+    }
+  }
+
+  // HQ-origin activates: each verb is HQ-safe iff it operates purely on player
+  // state (no grid coords). inferActivateTargets enforces the all-primitives
+  // rule per AST and returns [] for any compound containing a non-HQ-safe verb.
+  for (const card of player.hq) {
+    if (card.type !== "unit") continue;
+    const unit = card as UnitCard;
+    if (!unit.actions) continue;
+    for (const actionDef of unit.actions) {
+      if (ap < actionDef.apCost) continue;
+      const targets = inferActivateTargets(
+        state,
+        unit.id,
+        actionDef.effect,
+        { type: "hq", playerId },
+        playerId,
+      );
+      for (const t of targets) {
+        actions.push({
+          type: "activate",
+          playerId,
+          cardId: unit.id,
+          actionName: actionDef.name,
+          ...t,
+        });
       }
     }
   }
@@ -457,13 +492,14 @@ type ActivateTarget = {
 /**
  * Infer valid targets for an activate action by doing a shallow parse of
  * the DSL effect string. Returns one entry per valid target combination.
+ *
+ * Exported for direct testing (see valid-actions.test.ts).
  */
-function inferActivateTargets(
+export function inferActivateTargets(
   state: MainGameState,
   _unitId: string,
   effectStr: string,
-  unitRow: number,
-  unitCol: number,
+  origin: BoardPosition,
   playerId: string,
 ): ActivateTarget[] {
   // Library build (library/build.ts) parses and validates every card effect,
@@ -486,6 +522,16 @@ function inferActivateTargets(
   if (!activatePreconditionsPass(allPrimitives, state, playerId)) {
     return [];
   }
+
+  // HQ origin: every primitive must be HQ-safe (player-state-only). Reject
+  // compounds that mix positional verbs (move, kill, etc.) with safe ones —
+  // partial execution would silently drop the positional half.
+  if (origin.type === "hq") {
+    if (allPrimitives.some((p) => !isHqSafeVerb(p.verb))) return [];
+    return [{}];
+  }
+
+  const { row: unitRow, col: unitCol } = origin;
 
   // Scan the first verb in each compound member to determine targeting needs
   const targetSets: ActivateTarget[][] = [];


### PR DESCRIPTION
## Summary

Allow HQ units to surface state-mutating activate actions that don't need grid context (e.g. Ada's `analyze`, Tesla's `invent`, Mansa Musa's `pilgrimage`), while continuing to filter out positional verbs (`move(self)`, `adjacent`/`here`/`enemy`/`friendly`).

The HQ-safety rule lives in a new central verb registry (`effect-dsl/verbs.ts`) so future verbs must classify themselves explicitly — the verb-classification test will fail if a new verb is added to `VERBS` without a matching entry.

## Changes

- `engine/src/effect-dsl/verbs.ts` (new) — `VERBS`, `Verb` type, and `isHqSafeVerb`
- `engine/src/effect-dsl/index.ts` — re-export the new symbols
- `engine/src/valid-actions.ts` — activate scan now iterates HQ units; `inferActivateTargets` takes `BoardPosition` and returns `[]` for HQ origin if any primitive is not HQ-safe (rejects compound effects like Ramesses' `vp[1] + kill(self)` and Marco Polo's `move(self) + gold[1]`)
- `engine/src/apply-main.ts` — `handleActivate` searches HQ as well as the grid
- Engine tests in three layers: verb classification (`effect-dsl-verbs.test.ts`), `inferActivateTargets` direct cases (added to `valid-actions.test.ts`), and end-to-end card scenarios (`activate-hq.test.ts`)

## Related

- Closes #108
- Stepping stone toward #59 (HQ-on-grid refactor, post-v0.1)
- Composes with `ACTIVATE_PRECONDITIONS` from #104

## Test plan
- [x] HQ-Ada's analyze appears in valid actions and resolves correctly (pickPrompt set)
- [x] HQ-Tesla's invent appears and resolves (market item to hand)
- [x] HQ-Mansa Musa's pilgrimage appears and resolves (+5 gold)
- [x] HQ-Marco Polo's trade-route (compound w/ move) does NOT appear
- [x] HQ-Ramesses II's monument (compound w/ kill) does NOT appear
- [x] HQ-Ada's analyze gated when mainDeck empty (existing `ACTIVATE_PRECONDITIONS` still applies)
- [x] Grid Marco Polo regression: trade-route IS still offered from grid
- [x] `bun test` — 406 tests passing
- [x] `bun run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)