### PR TITLE
#107 — Engine: unwired card abilities (playtest gaps)

### DIFF
--- a/clients/web/src/DevPreview.svelte
+++ b/clients/web/src/DevPreview.svelte
@@ -128,7 +128,7 @@
     prospectDeckSize: 5, discardPileSize: 2,
     hq: [p2Units[2]],
     activePolicies: p2Policies,
-    activeTraps: [{ targetId: locations[1]?.id }],
+    activeTraps: [{ targetId: locations[1]?.id, cardId: "preview-trap-1" }],
   };
 
   const turn: TurnState = { activePlayerId: p1, actionPointsRemaining: 2, round: 3 };
@@ -142,6 +142,7 @@
     self: selfState, teammates: [], opponents: [opponentView],
     grid, market: marketCards,
     turnOrder: [p1, p2], middleArea: [],
+    reveals: { revealedTrapIds: [] },
   };
 
   const mockActions = [

--- a/engine/src/__tests__/activate-hq.test.ts
+++ b/engine/src/__tests__/activate-hq.test.ts
@@ -50,6 +50,7 @@ describe("HQ activate — non-positional verbs", () => {
     });
     const ns = next as MainGameState;
     expect(ns.pickPrompt).toEqual({
+      kind: "deck_pick",
       playerId: ACTIVE,
       options: [top1.id, top2.id, top3.id],
       count: 1,

--- a/engine/src/__tests__/listeners.test.ts
+++ b/engine/src/__tests__/listeners.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it, beforeEach } from "bun:test";
 import { produce } from "immer";
 import type { Draft } from "immer";
 import { applyAction } from "../apply-action";
-import type { GameEvent, MainGameState } from "../types";
+import { getValidActions } from "../valid-actions";
+import type { Action, GameEvent, MainGameState } from "../types";
 import { emit } from "../listeners/emit";
 import { rebuildListeners } from "../listeners/rebuild";
 import { getModifiedStat, getModifiedCost, isUnitProtected, getModifiedAPCost } from "../listeners/query";
@@ -1078,6 +1079,70 @@ describe("AP modifier queries", () => {
     expect(revealed).toBeDefined();
     expect((revealed as any).playerId).toBe(active);
     expect((revealed as any).cardIds.length).toBe(2);
+  });
+
+  it("Mary Shelley on the grid: first play_event still 0 AP (grid factory branch)", () => {
+    const state = gameWith((d, p) => {
+      d.grid[0][0].units.push(
+        makeUnit({ ownerId: p.active, definitionId: "mary-shelley" }),
+      );
+    });
+    const { active } = getPlayers(state);
+    const { queries } = rebuildListeners(state);
+    const playEventAction = { type: "play_event" as const, playerId: active, cardId: "e1" };
+    expect(getModifiedAPCost(state, queries, playEventAction, 1)).toBe(0);
+  });
+
+  it("Spymaster Infiltrate: not surfaced as a valid action when AP is insufficient", () => {
+    const state = gameWith((d, p) => {
+      d.players[p.activeIdx].activePolicies.push(
+        makePolicy({ ownerId: p.active, definitionId: "spymaster" }),
+      );
+      d.turn.actionPointsRemaining = 0;
+    });
+    const { active } = getPlayers(state);
+    const validActions = getValidActions(state, active);
+    const infiltrateActions = validActions.filter(
+      (a: Action) => a.type === "activate" && a.actionName === "Infiltrate",
+    );
+    expect(infiltrateActions).toHaveLength(0);
+  });
+
+  it("Mary Shelley: getValidActions surfaces play_event at AP=0 (first event of turn)", () => {
+    const state = gameWith((d, p) => {
+      d.players[p.activeIdx].hq.push(
+        makeUnit({ ownerId: p.active, definitionId: "mary-shelley" }),
+      );
+      d.players[p.activeIdx].hand.push(
+        makeInstantEvent({ ownerId: p.active, cost: "0" }),
+      );
+      d.turn.actionPointsRemaining = 0;
+    });
+    const { active } = getPlayers(state);
+    const validActions = getValidActions(state, active);
+    const playEvent = validActions.filter((a: Action) => a.type === "play_event");
+    expect(playEvent.length).toBeGreaterThan(0);
+  });
+
+  it("Spymaster Infiltrate: empty opponent hand emits cards_revealed with empty cardIds", () => {
+    const initial = gameWith((d, p) => {
+      d.players[p.activeIdx].activePolicies.push(
+        makePolicy({ ownerId: p.active, definitionId: "spymaster" }),
+      );
+      // opponent hand intentionally empty
+    });
+    const { active } = getPlayers(initial);
+    const spymaster = initial.players.find((p) => p.id === active)!.activePolicies[0];
+    const { events } = applyAction(initial, {
+      type: "activate",
+      playerId: active,
+      cardId: spymaster.id,
+      actionName: "Infiltrate",
+    });
+    const revealed = events.find((e) => e.type === "cards_revealed");
+    expect(revealed).toBeDefined();
+    expect((revealed as any).cardIds).toEqual([]);
+    expect((revealed as any).source).toBe("opponent_hand");
   });
 
   it("Mary Shelley: applyAction(play_event) spends 0 AP for first event, 1 AP for second", () => {

--- a/engine/src/__tests__/listeners.test.ts
+++ b/engine/src/__tests__/listeners.test.ts
@@ -15,6 +15,7 @@ import {
   makePolicy,
   makePassiveEvent,
   makeTrapEvent,
+  makeInstantEvent,
   resetIds,
 } from "./helpers";
 
@@ -1014,5 +1015,90 @@ describe("AP modifier queries", () => {
     });
     const { queries: q2 } = rebuildListeners(stateWithMove);
     expect(getModifiedAPCost(stateWithMove, q2, moveAction, 1)).toBe(1);
+  });
+
+  it("Mary Shelley: first play_event 0 AP, second play_event normal", () => {
+    const state = gameWith((d, p) => {
+      d.players[p.activeIdx].hq.push(
+        makeUnit({ ownerId: p.active, definitionId: "mary-shelley" }),
+      );
+    });
+    const { active } = getPlayers(state);
+    const { queries } = rebuildListeners(state);
+    const playEventAction = { type: "play_event" as const, playerId: active, cardId: "e1" };
+
+    // First event — 0 AP
+    expect(getModifiedAPCost(state, queries, playEventAction, 1)).toBe(0);
+
+    // After a play_event in the log — normal AP
+    const stateWithEvent = produce(state, (d) => {
+      d.actionLog.push({ type: "play_event", playerId: active, cardId: "e1" } as any);
+    });
+    const { queries: q2 } = rebuildListeners(stateWithEvent);
+    expect(getModifiedAPCost(stateWithEvent, q2, playEventAction, 1)).toBe(1);
+  });
+
+  it("Mary Shelley: only affects own player's events", () => {
+    const state = gameWith((d, p) => {
+      d.players[p.activeIdx].hq.push(
+        makeUnit({ ownerId: p.active, definitionId: "mary-shelley" }),
+      );
+    });
+    const { other } = getPlayers(state);
+    const { queries } = rebuildListeners(state);
+    const opponentPlayEvent = { type: "play_event" as const, playerId: other, cardId: "e1" };
+    expect(getModifiedAPCost(state, queries, opponentPlayEvent, 1)).toBe(1);
+  });
+
+  it("Spymaster Infiltrate: activating the policy reveals an opponent's hand and spends 1 AP", () => {
+    const initial = gameWith((d, p) => {
+      d.players[p.activeIdx].activePolicies.push(
+        makePolicy({ ownerId: p.active, definitionId: "spymaster" }),
+      );
+      // Put some cards in the opponent's hand to be revealed.
+      d.players[p.otherIdx].hand.push(
+        makeInstantEvent({ ownerId: p.other }),
+        makeInstantEvent({ ownerId: p.other }),
+      );
+    });
+    const { active } = getPlayers(initial);
+    const apBefore = initial.turn.actionPointsRemaining;
+    const spymaster = initial.players.find((p) => p.id === active)!.activePolicies[0];
+
+    const { state, events } = applyAction(initial, {
+      type: "activate",
+      playerId: active,
+      cardId: spymaster.id,
+      actionName: "Infiltrate",
+    });
+    const after = state as MainGameState;
+
+    expect(after.turn.actionPointsRemaining).toBe(apBefore - 1);
+    const revealed = events.find((e) => e.type === "cards_revealed");
+    expect(revealed).toBeDefined();
+    expect((revealed as any).playerId).toBe(active);
+    expect((revealed as any).cardIds.length).toBe(2);
+  });
+
+  it("Mary Shelley: applyAction(play_event) spends 0 AP for first event, 1 AP for second", () => {
+    const initial = gameWith((d, p) => {
+      d.players[p.activeIdx].hq.push(
+        makeUnit({ ownerId: p.active, definitionId: "mary-shelley" }),
+      );
+      d.players[p.activeIdx].hand.push(
+        makeInstantEvent({ ownerId: p.active, cost: "0" }),
+        makeInstantEvent({ ownerId: p.active, cost: "0" }),
+      );
+    });
+    const { active } = getPlayers(initial);
+    const apBefore = initial.turn.actionPointsRemaining;
+
+    const e1 = initial.players.find((p) => p.id === active)!.hand[0].id;
+    const after1 = applyAction(initial, { type: "play_event", playerId: active, cardId: e1 }).state as MainGameState;
+    expect(after1.turn.actionPointsRemaining).toBe(apBefore); // 0 AP for first event
+
+    const e2 = after1.players.find((p) => p.id === active)!.hand[0].id;
+    const after2 = applyAction(after1, { type: "play_event", playerId: active, cardId: e2 }).state as MainGameState;
+    expect(after2.turn.actionPointsRemaining).toBe(apBefore - 1); // 1 AP for second event
   });
 });

--- a/engine/src/__tests__/reveal-pick.test.ts
+++ b/engine/src/__tests__/reveal-pick.test.ts
@@ -57,6 +57,7 @@ describe("reveal > pick — player choice required", () => {
     const ns = next as MainGameState;
 
     expect(ns.pickPrompt).toEqual({
+      kind: "deck_pick",
       playerId: ACTIVE,
       options: [top1.id, top2.id, top3.id],
       count: 1,
@@ -95,7 +96,8 @@ describe("reveal > pick — player choice required", () => {
     });
 
     const vs = getVisibleState(paused, ACTIVE);
-    expect(vs.pickPrompt?.count).toBe(1);
+    expect(vs.pickPrompt?.kind).toBe("deck_pick");
+    expect(vs.pickPrompt?.kind === "deck_pick" && vs.pickPrompt.count).toBe(1);
     expect(vs.pickPrompt?.options).toHaveLength(3);
   });
 

--- a/engine/src/__tests__/seeding.test.ts
+++ b/engine/src/__tests__/seeding.test.ts
@@ -604,4 +604,100 @@ describe("seeding phase", () => {
       expect(playerAfter.prospectDeck.length).toBe(prospectBefore + 1);
     });
   });
+
+  describe("Scholar post-policy reorder", () => {
+    function scholarSeed(seed = "scholar-test"): SeedingGameState {
+      // 40-card decks ensure a populated main deck after seeding completes.
+      return createSeedingGame({
+        deckSize: 40,
+        policyCount: 3,
+        seed,
+        config: { ...DEFAULT_CONFIG, grid_padding: 2 },
+      });
+    }
+
+    /** Play until reaching the policy_selection step; then force Scholar into each player's policyPool. */
+    function reachPolicySelectWithScholar(state: SeedingGameState): SeedingGameState {
+      let s: GameState = state;
+      let safety = 0;
+      while (s.phase === "seeding" && s.seedingState.step !== "policy_selection") {
+        if (++safety > 500) throw new Error("stuck advancing to policy_selection");
+        const activeId = getActivePlayerId(s);
+        const actions = getValidActions(s, activeId);
+        if (actions.length === 0) throw new Error(`no actions at ${s.seedingState.step}`);
+        s = apply(s as SeedingGameState, fillAction(s, actions[0]) as SeedingAction);
+      }
+      if (s.phase !== "seeding") throw new Error("expected seeding");
+      // Replace each player's policyPool's first two entries with Scholar + a sibling so
+      // policy_select reliably assigns Scholar to everyone.
+      return produce(s as SeedingGameState, (draft) => {
+        for (const player of draft.players) {
+          const scholar = { ...player.policyPool[0], definitionId: "scholar" };
+          const sibling = { ...player.policyPool[1], definitionId: "test-policy" };
+          player.policyPool = [scholar, sibling, ...player.policyPool.slice(2)];
+        }
+      });
+    }
+
+    it("opens a scholar_reorder pickPrompt after policy_select when Scholar is assigned", () => {
+      const seeded = reachPolicySelectWithScholar(scholarSeed("scholar-1"));
+      const next = apply(seeded, { type: "policy_select", playerId: seeded.seedingState.currentPlayerId });
+      expect(next.phase).toBe("seeding");
+      const seedingNext = next as SeedingGameState;
+      expect(seedingNext.seedingState.step).toBe("post_policy_pick");
+      expect(seedingNext.pickPrompt).toBeDefined();
+      expect(seedingNext.pickPrompt!.purpose).toBe("scholar_reorder");
+      expect(seedingNext.pickPrompt!.ordered).toBe(true);
+      // Top-5 ids (or fewer if deck shorter) match owner's main deck top.
+      const ownerId = seedingNext.pickPrompt!.playerId;
+      const owner = getPlayer(seedingNext, ownerId);
+      const topIds = owner.mainDeck.slice(0, seedingNext.pickPrompt!.options.length).map((c) => c.id);
+      expect([...seedingNext.pickPrompt!.options]).toEqual(topIds);
+    });
+
+    it("reorders the main deck according to the submitted permutation and transitions to main when queue empties", () => {
+      const seeded = reachPolicySelectWithScholar(scholarSeed("scholar-2"));
+      let s: GameState = apply(seeded, { type: "policy_select", playerId: seeded.seedingState.currentPlayerId });
+
+      // Resolve each player's reorder. Reverse the options each time so we can
+      // verify the order took effect.
+      while (s.phase === "seeding") {
+        if (s.seedingState.step !== "post_policy_pick") {
+          throw new Error(`unexpected step "${s.seedingState.step}"`);
+        }
+        const prompt = s.pickPrompt!;
+        const reversed = [...prompt.options].reverse() as [string, ...string[]];
+        const ownerId = prompt.playerId;
+        const beforeMainDeck = getPlayer(s, ownerId).mainDeck.map((c) => c.id);
+        s = apply(s as SeedingGameState, {
+          type: "resolve_pick",
+          playerId: ownerId,
+          pickedCardIds: reversed,
+        });
+        // Verify top N now matches the reversed order.
+        const owner = getPlayer(s, ownerId);
+        expect(owner.mainDeck.slice(0, reversed.length).map((c) => c.id)).toEqual(
+          [...reversed],
+        );
+        // Same set of cards, just reordered — total length unchanged.
+        expect(owner.mainDeck.length).toBe(beforeMainDeck.length);
+      }
+      expect(s.phase).toBe("main");
+      expect("pickPrompt" in s && s.pickPrompt).toBeFalsy();
+    });
+
+    it("transitions straight to main when no player has Scholar", () => {
+      // Reach policy_select without forcing Scholar.
+      let s: GameState = scholarSeed("no-scholar");
+      let safety = 0;
+      while (s.phase === "seeding" && s.seedingState.step !== "policy_selection") {
+        if (++safety > 500) throw new Error("stuck");
+        const activeId = getActivePlayerId(s);
+        const actions = getValidActions(s, activeId);
+        s = apply(s as SeedingGameState, fillAction(s, actions[0]) as SeedingAction);
+      }
+      s = apply(s as SeedingGameState, { type: "policy_select", playerId: getActivePlayerId(s) });
+      expect(s.phase).toBe("main");
+    });
+  });
 });

--- a/engine/src/__tests__/seeding.test.ts
+++ b/engine/src/__tests__/seeding.test.ts
@@ -646,8 +646,7 @@ describe("seeding phase", () => {
       const seedingNext = next as SeedingGameState;
       expect(seedingNext.seedingState.step).toBe("post_policy_pick");
       expect(seedingNext.pickPrompt).toBeDefined();
-      expect(seedingNext.pickPrompt!.purpose).toBe("scholar_reorder");
-      expect(seedingNext.pickPrompt!.ordered).toBe(true);
+      expect(seedingNext.pickPrompt!.kind).toBe("scholar_reorder");
       // Top-5 ids (or fewer if deck shorter) match owner's main deck top.
       const ownerId = seedingNext.pickPrompt!.playerId;
       const owner = getPlayer(seedingNext, ownerId);
@@ -660,28 +659,45 @@ describe("seeding phase", () => {
       let s: GameState = apply(seeded, { type: "policy_select", playerId: seeded.seedingState.currentPlayerId });
 
       // Resolve each player's reorder. Reverse the options each time so we can
-      // verify the order took effect.
+      // verify the order took effect. Also assert the queue drains in turn
+      // order, one player per resolve.
+      const initialQueueLength =
+        s.phase === "seeding" && s.seedingState.step === "post_policy_pick"
+          ? s.seedingState.pendingPostPolicyPicks.length
+          : 0;
+      let resolvedCount = 0;
+      let prevQueueHead: string | undefined;
       while (s.phase === "seeding") {
         if (s.seedingState.step !== "post_policy_pick") {
           throw new Error(`unexpected step "${s.seedingState.step}"`);
         }
+        const queueHead = s.seedingState.pendingPostPolicyPicks[0];
         const prompt = s.pickPrompt!;
+        // Prompt and queue head agree.
+        expect(prompt.playerId).toBe(queueHead);
+        // Queue advances strictly — never re-prompts the same player.
+        expect(queueHead).not.toBe(prevQueueHead);
+        prevQueueHead = queueHead;
+        const queueLenBefore = s.seedingState.pendingPostPolicyPicks.length;
         const reversed = [...prompt.options].reverse() as [string, ...string[]];
         const ownerId = prompt.playerId;
         const beforeMainDeck = getPlayer(s, ownerId).mainDeck.map((c) => c.id);
+        const expectedOrder = [...reversed];
         s = apply(s as SeedingGameState, {
           type: "resolve_pick",
           playerId: ownerId,
           pickedCardIds: reversed,
         });
-        // Verify top N now matches the reversed order.
         const owner = getPlayer(s, ownerId);
-        expect(owner.mainDeck.slice(0, reversed.length).map((c) => c.id)).toEqual(
-          [...reversed],
-        );
-        // Same set of cards, just reordered — total length unchanged.
+        expect(owner.mainDeck.slice(0, expectedOrder.length).map((c) => c.id)).toEqual(expectedOrder);
         expect(owner.mainDeck.length).toBe(beforeMainDeck.length);
+        resolvedCount++;
+        // Queue shrunk by exactly one, or empty + transitioned.
+        if (s.phase === "seeding" && s.seedingState.step === "post_policy_pick") {
+          expect(s.seedingState.pendingPostPolicyPicks.length).toBe(queueLenBefore - 1);
+        }
       }
+      expect(resolvedCount).toBe(initialQueueLength);
       expect(s.phase).toBe("main");
       expect("pickPrompt" in s && s.pickPrompt).toBeFalsy();
     });

--- a/engine/src/__tests__/visible-state.test.ts
+++ b/engine/src/__tests__/visible-state.test.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { produce } from "immer";
 import type { EndedGameState, MainGameState } from "../types";
 import { getVisibleState } from "../visible-state";
+import { UNIT_EFFECTS } from "../listeners/effects";
 import {
   createSeedingGame,
   createTestGame,
@@ -98,12 +99,14 @@ describe("getVisibleState", () => {
       expect(typeof opp.discardPileSize).toBe("number");
     });
 
-    it("redacts trap card contents", () => {
+    it("redacts trap card contents but always exposes cardId", () => {
       const state = withTrap(createTestGame(), "p2", "target-123");
       const vis = getVisibleState(state, "p1");
       const trap = vis.opponents[0].activeTraps[0];
+      const p2 = state.players.find((p) => p.id === "p2")!;
       expect(trap.targetId).toBe("target-123");
-      expect("card" in trap).toBe(false);
+      expect(trap.cardId).toBe(p2.activeTraps[0].card.id);
+      expect(trap.card).toBeUndefined();
     });
   });
 
@@ -157,7 +160,12 @@ describe("getVisibleState", () => {
   describe("ended phase", () => {
     it("does not throw for ended game", () => {
       const base = createTestGame();
-      const endedState: EndedGameState = { ...base, phase: "ended", scores: {} };
+      const endedState: EndedGameState = {
+        ...base,
+        phase: "ended",
+        scores: {},
+        pickPrompt: undefined,
+      };
       const vis = getVisibleState(endedState, "p1");
       expect(vis.phase).toBe("ended");
       expect(vis.currentPlayerId).toBe(base.turn.activePlayerId);
@@ -225,6 +233,7 @@ describe("getVisibleState", () => {
       const opp = vis.opponents.find((o) => o.id === "p2")!;
       expect(opp.activeTraps).toHaveLength(1);
       expect(opp.activeTraps[0].card).toBeDefined();
+      expect(opp.activeTraps[0].cardId).toBe(opp.activeTraps[0].card!.id);
     });
 
     it("keeps opponent traps redacted when Spy Glass is not at the trap's location", () => {
@@ -249,6 +258,58 @@ describe("getVisibleState", () => {
       expect(opp.activeTraps[0].card).toBeUndefined();
     });
 
+    it("does not fire when Spy Glass is stored in HQ (not on grid)", () => {
+      const state = produce(createTestGame(), (d) => {
+        const loc = makeLocation({ ownerId: "p1" });
+        d.grid[0][0].location = loc;
+        const p1 = d.players.find((p) => p.id === "p1")!;
+        p1.hq.push(makeItem({ ownerId: "p1", definitionId: "spy-glass" }));
+        const p2 = d.players.find((p) => p.id === "p2")!;
+        p2.activeTraps.push({
+          card: makeTrapEvent({ ownerId: "p2", trigger: "test" }),
+          targetId: loc.id,
+        });
+      });
+      const vis = getVisibleState(state, "p1");
+      expect(vis.reveals.revealedTrapIds).toHaveLength(0);
+    });
+
+    it("does not fire when equipped unit is on a cell with no location", () => {
+      const state = produce(createTestGame(), (d) => {
+        const unit = makeUnit({ ownerId: "p1" });
+        // No location on (0,0)
+        d.grid[0][0].units.push(unit);
+        d.grid[0][0].items.push(
+          makeItem({ ownerId: "p1", definitionId: "spy-glass", equippedTo: unit.id }),
+        );
+        const p2 = d.players.find((p) => p.id === "p2")!;
+        p2.activeTraps.push({
+          card: makeTrapEvent({ ownerId: "p2", trigger: "test" }),
+          targetId: "any",
+        });
+      });
+      const vis = getVisibleState(state, "p1");
+      expect(vis.reveals.revealedTrapIds).toHaveLength(0);
+    });
+
+    it("does not fire when Spy Glass is on grid but not equipped to any unit", () => {
+      const state = produce(createTestGame(), (d) => {
+        const loc = makeLocation({ ownerId: "p1" });
+        d.grid[0][0].location = loc;
+        // Spy Glass on cell with no equippedTo
+        d.grid[0][0].items.push(
+          makeItem({ ownerId: "p1", definitionId: "spy-glass" }),
+        );
+        const p2 = d.players.find((p) => p.id === "p2")!;
+        p2.activeTraps.push({
+          card: makeTrapEvent({ ownerId: "p2", trigger: "test" }),
+          targetId: loc.id,
+        });
+      });
+      const vis = getVisibleState(state, "p1");
+      expect(vis.reveals.revealedTrapIds).toHaveLength(0);
+    });
+
     it("does not surface trap reveal rights to the wrong viewer", () => {
       const state = produce(createTestGame(), (d) => {
         const loc = makeLocation({ ownerId: "p1" });
@@ -267,6 +328,49 @@ describe("getVisibleState", () => {
       // Spy Glass belongs to p1 — viewing as p2 should not grant trap reveals.
       const visP2 = getVisibleState(state, "p2");
       expect(visP2.reveals.revealedTrapIds).toHaveLength(0);
+    });
+  });
+
+  describe("reveals — UNIT_EFFECTS factory branches in computeReveals", () => {
+    // Register a fixture-only unit definitionId with a reveals provider so
+    // both the grid and HQ walker branches in computeReveals get exercised
+    // beyond the cards that ship with reveals today.
+    const STUB_DEF = "__reveals-test-unit__";
+    let stubInvocations: { viewerId: string; hasPosition: boolean }[] = [];
+
+    beforeEach(() => {
+      stubInvocations = [];
+      UNIT_EFFECTS[STUB_DEF] = (_unit, ownerId, position) => ({
+        listeners: [],
+        queries: [],
+        reveals: (_state, viewerId) => {
+          stubInvocations.push({ viewerId, hasPosition: position != null });
+          return viewerId === ownerId ? { revealedTrapIds: [`stub-${ownerId}`] } : {};
+        },
+      });
+    });
+
+    afterEach(() => {
+      delete UNIT_EFFECTS[STUB_DEF];
+    });
+
+    it("invokes a unit's reveals provider for grid-deployed units (with position)", () => {
+      const state = produce(createTestGame(), (d) => {
+        d.grid[1][1].units.push(makeUnit({ ownerId: "p1", definitionId: STUB_DEF }));
+      });
+      const vis = getVisibleState(state, "p1");
+      expect(vis.reveals.revealedTrapIds).toContain("stub-p1");
+      expect(stubInvocations.some((c) => c.hasPosition)).toBe(true);
+    });
+
+    it("invokes a unit's reveals provider for HQ-stored units (no position)", () => {
+      const state = produce(createTestGame(), (d) => {
+        const p1 = d.players.find((p) => p.id === "p1")!;
+        p1.hq.push(makeUnit({ ownerId: "p1", definitionId: STUB_DEF }));
+      });
+      const vis = getVisibleState(state, "p1");
+      expect(vis.reveals.revealedTrapIds).toContain("stub-p1");
+      expect(stubInvocations.some((c) => !c.hasPosition)).toBe(true);
     });
   });
 });

--- a/engine/src/__tests__/visible-state.test.ts
+++ b/engine/src/__tests__/visible-state.test.ts
@@ -5,6 +5,9 @@ import { getVisibleState } from "../visible-state";
 import {
   createSeedingGame,
   createTestGame,
+  makeInstantEvent,
+  makeItem,
+  makeLocation,
   makeTrapEvent,
   makeUnit,
   resetIds,
@@ -158,6 +161,112 @@ describe("getVisibleState", () => {
       const vis = getVisibleState(endedState, "p1");
       expect(vis.phase).toBe("ended");
       expect(vis.currentPlayerId).toBe(base.turn.activePlayerId);
+    });
+  });
+
+  describe("reveals — Alexandria Harbor", () => {
+    it("exposes top of own main deck to the owner", () => {
+      const state = produce(createTestGame(), (d) => {
+        const p1 = d.players.find((p) => p.id === "p1")!;
+        p1.mainDeck.unshift(makeInstantEvent({ ownerId: "p1" }));
+        d.grid[0][0].location = makeLocation({
+          ownerId: "p1",
+          definitionId: "alexandria-harbor",
+        });
+      });
+      const vis = getVisibleState(state, "p1");
+      const p1Deck = state.players.find((p) => p.id === "p1")!.mainDeck;
+      expect(vis.reveals.mainDeckTop).toBeDefined();
+      expect(vis.reveals.mainDeckTop!.id).toBe(p1Deck[0].id);
+    });
+
+    it("does not expose top of deck to non-owners", () => {
+      const state = produce(createTestGame(), (d) => {
+        const p1 = d.players.find((p) => p.id === "p1")!;
+        p1.mainDeck.unshift(makeInstantEvent({ ownerId: "p1" }));
+        d.grid[0][0].location = makeLocation({
+          ownerId: "p1",
+          definitionId: "alexandria-harbor",
+        });
+      });
+      const vis = getVisibleState(state, "p2");
+      expect(vis.reveals.mainDeckTop).toBeUndefined();
+    });
+
+    it("does not expose when deck is empty", () => {
+      const state = produce(createTestGame(), (d) => {
+        d.grid[0][0].location = makeLocation({
+          ownerId: "p1",
+          definitionId: "alexandria-harbor",
+        });
+      });
+      const vis = getVisibleState(state, "p1");
+      expect(vis.reveals.mainDeckTop).toBeUndefined();
+    });
+  });
+
+  describe("reveals — Spy Glass", () => {
+    it("un-redacts opponent traps at the equipped unit's location", () => {
+      const state = produce(createTestGame(), (d) => {
+        const loc = makeLocation({ ownerId: "p1" });
+        d.grid[0][0].location = loc;
+        const unit = makeUnit({ ownerId: "p1" });
+        d.grid[0][0].units.push(unit);
+        d.grid[0][0].items.push(
+          makeItem({ ownerId: "p1", definitionId: "spy-glass", equippedTo: unit.id }),
+        );
+        const p2 = d.players.find((p) => p.id === "p2")!;
+        p2.activeTraps.push({
+          card: makeTrapEvent({ ownerId: "p2", trigger: "test" }),
+          targetId: loc.id,
+        });
+      });
+      const vis = getVisibleState(state, "p1");
+      const opp = vis.opponents.find((o) => o.id === "p2")!;
+      expect(opp.activeTraps).toHaveLength(1);
+      expect(opp.activeTraps[0].card).toBeDefined();
+    });
+
+    it("keeps opponent traps redacted when Spy Glass is not at the trap's location", () => {
+      const state = produce(createTestGame(), (d) => {
+        const targetLoc = makeLocation({ ownerId: "p1" });
+        const otherLoc = makeLocation({ ownerId: "p1" });
+        d.grid[0][0].location = targetLoc;
+        d.grid[0][1].location = otherLoc;
+        const unit = makeUnit({ ownerId: "p1" });
+        d.grid[0][1].units.push(unit);
+        d.grid[0][1].items.push(
+          makeItem({ ownerId: "p1", definitionId: "spy-glass", equippedTo: unit.id }),
+        );
+        const p2 = d.players.find((p) => p.id === "p2")!;
+        p2.activeTraps.push({
+          card: makeTrapEvent({ ownerId: "p2", trigger: "test" }),
+          targetId: targetLoc.id,
+        });
+      });
+      const vis = getVisibleState(state, "p1");
+      const opp = vis.opponents.find((o) => o.id === "p2")!;
+      expect(opp.activeTraps[0].card).toBeUndefined();
+    });
+
+    it("does not surface trap reveal rights to the wrong viewer", () => {
+      const state = produce(createTestGame(), (d) => {
+        const loc = makeLocation({ ownerId: "p1" });
+        d.grid[0][0].location = loc;
+        const unit = makeUnit({ ownerId: "p1" });
+        d.grid[0][0].units.push(unit);
+        d.grid[0][0].items.push(
+          makeItem({ ownerId: "p1", definitionId: "spy-glass", equippedTo: unit.id }),
+        );
+        const p2 = d.players.find((p) => p.id === "p2")!;
+        p2.activeTraps.push({
+          card: makeTrapEvent({ ownerId: "p2", trigger: "test" }),
+          targetId: loc.id,
+        });
+      });
+      // Spy Glass belongs to p1 — viewing as p2 should not grant trap reveals.
+      const visP2 = getVisibleState(state, "p2");
+      expect(visP2.reveals.revealedTrapIds).toHaveLength(0);
     });
   });
 });

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -27,6 +27,7 @@ import { getModifiedStat, getModifiedCost, getModifiedAPCost } from "./listeners
 import type { EmitFn, QueryListener } from "./listeners/types";
 import { killUnit, dropEquippedItems } from "./unit-helpers";
 import type {
+  ActionDef,
   ActivePassiveEvent,
   ApplyResult,
   GameEvent,
@@ -35,6 +36,7 @@ import type {
   MainGameState,
   UnitCard,
 } from "./types";
+import { POLICY_ACTIONS } from "./listeners/effects";
 import { getActivePlayerId } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -460,7 +462,11 @@ function handlePlayEvent(
 
   const cost = parseCost(card.cost);
   spendGold(draft, player, cost, "play_event", events);
-  spendAP(draft, 1);
+  const apCost = getModifiedAPCost(
+    draft as MainGameState, queries,
+    { type: "play_event", playerId, cardId, targetId }, 1,
+  );
+  spendAP(draft, apCost);
 
   player.hand.splice(cardIdx, 1);
 
@@ -854,12 +860,25 @@ function handleActivate(
   // isHqSafeVerb gate); positional verbs no-op cleanly when actingUnitId
   // resolves to no grid position (see executor's getActingPosition).
   const located = findUnitPosition(draft.players, draft.grid, cardId);
-  if (!located) throw new Error(`Card "${cardId}" not found on grid or HQ`);
-  const card = located.unit as Draft<UnitCard>;
-  if (!card.actions) throw new Error(`Card "${cardId}" has no actions`);
-  if (card.ownerId !== playerId) throw new Error(`Card "${cardId}" not owned by "${playerId}"`);
+  let actionDef: ActionDef | undefined;
+  let actingUnitId: string | undefined = cardId;
 
-  const actionDef = card.actions.find((a) => a.name === actionName);
+  if (located) {
+    const card = located.unit as Draft<UnitCard>;
+    if (!card.actions) throw new Error(`Card "${cardId}" has no actions`);
+    if (card.ownerId !== playerId) throw new Error(`Card "${cardId}" not owned by "${playerId}"`);
+    actionDef = card.actions.find((a) => a.name === actionName);
+  } else {
+    // Not a unit — try active policies. Policy actions live in POLICY_ACTIONS
+    // keyed by definitionId (CSV-driven extraction is tracked in #68).
+    const owner = draft.players.find((p) => p.id === playerId);
+    const policy = owner?.activePolicies.find((p) => p.id === cardId);
+    if (!policy) throw new Error(`Card "${cardId}" not found on grid, HQ, or active policies`);
+    const policyActions = POLICY_ACTIONS[policy.definitionId] ?? [];
+    actionDef = policyActions.find((a) => a.name === actionName);
+    actingUnitId = undefined;
+  }
+
   if (!actionDef) throw new Error(`Action "${actionName}" not found on card "${cardId}"`);
 
   spendAP(draft, actionDef.apCost);
@@ -868,7 +887,7 @@ function handleActivate(
   const result = executeEffect(actionDef.effect, {
     draft,
     playerId,
-    actingUnitId: cardId,
+    actingUnitId,
     targetId,
     targetCell,
     emit,

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -868,18 +868,22 @@ function handleActivate(
     if (!card.actions) throw new Error(`Card "${cardId}" has no actions`);
     if (card.ownerId !== playerId) throw new Error(`Card "${cardId}" not owned by "${playerId}"`);
     actionDef = card.actions.find((a) => a.name === actionName);
+    if (!actionDef) throw new Error(`Action "${actionName}" not found on unit "${cardId}"`);
   } else {
-    // Not a unit — try active policies. Policy actions live in POLICY_ACTIONS
-    // keyed by definitionId (CSV-driven extraction is tracked in #68).
+    // Not a unit — try active policies.
     const owner = draft.players.find((p) => p.id === playerId);
     const policy = owner?.activePolicies.find((p) => p.id === cardId);
     if (!policy) throw new Error(`Card "${cardId}" not found on grid, HQ, or active policies`);
-    const policyActions = POLICY_ACTIONS[policy.definitionId] ?? [];
+    const policyActions = POLICY_ACTIONS[policy.definitionId];
+    if (!policyActions) {
+      throw new Error(
+        `Policy "${policy.definitionId}" (id="${cardId}") has no actions registered in POLICY_ACTIONS`,
+      );
+    }
     actionDef = policyActions.find((a) => a.name === actionName);
+    if (!actionDef) throw new Error(`Action "${actionName}" not found on policy "${cardId}"`);
     actingUnitId = undefined;
   }
-
-  if (!actionDef) throw new Error(`Action "${actionName}" not found on card "${cardId}"`);
 
   spendAP(draft, actionDef.apCost);
 
@@ -912,6 +916,11 @@ function handleResolvePick(
   if (prompt.playerId !== playerId) {
     throw new Error(
       `resolve_pick rejected: pending pick is for "${prompt.playerId}", not "${playerId}" (${submitted})`,
+    );
+  }
+  if (prompt.kind !== "deck_pick") {
+    throw new Error(
+      `resolve_pick rejected: main-phase handler only supports "deck_pick" prompts (got "${prompt.kind}")`,
     );
   }
   if (pickedCardIds.length !== prompt.count) {
@@ -974,7 +983,7 @@ export function applyMainAction(
     throw new Error(
       `Action "${action.type}" by "${action.playerId}" rejected: ` +
         `pending pick must be resolved first ` +
-        `(picker="${state.pickPrompt.playerId}", count=${state.pickPrompt.count}, ` +
+        `(picker="${state.pickPrompt.playerId}", kind="${state.pickPrompt.kind}", ` +
         `options=[${state.pickPrompt.options.join(",")}])`,
     );
   }

--- a/engine/src/apply-seeding.ts
+++ b/engine/src/apply-seeding.ts
@@ -51,6 +51,18 @@ export function applySeedingAction(
   state: SeedingGameState,
   action: SeedingAction,
 ): ApplyResult {
+  // Symmetric guard with applyMainAction: while a pickPrompt is set,
+  // only resolve_pick is accepted. Surfaces the actual blocker rather
+  // than relying on each per-step handler's step-mismatch throw.
+  if (state.pickPrompt && action.type !== "resolve_pick") {
+    throw new Error(
+      `Seeding action "${action.type}" by "${action.playerId}" rejected: ` +
+        `pending pick must be resolved first ` +
+        `(picker="${state.pickPrompt.playerId}", kind="${state.pickPrompt.kind}", ` +
+        `options=[${state.pickPrompt.options.join(",")}])`,
+    );
+  }
+
   // policy_select triggers a phase transition — handled separately
   // so we can construct MainGameState explicitly with full type checking.
   if (action.type === "policy_select") {
@@ -455,11 +467,20 @@ function handlePolicySelection(
     .map((p) => p.id);
 
   if (pendingPicks.length > 0) {
+    const queue = pendingPicks as [string, ...string[]];
     const withQueue = produce(afterAssign, (draft) => {
-      draft.seedingState.step = "post_policy_pick";
-      draft.seedingState.pendingPostPolicyPicks = pendingPicks;
-      draft.seedingState.currentPlayerId = pendingPicks[0];
-      openScholarReorderPrompt(draft, pendingPicks[0], events);
+      // Reassign the whole seedingState so the discriminated union narrows
+      // cleanly to the post_policy_pick variant (and the queue field is
+      // present and non-empty as required).
+      draft.seedingState = {
+        step: "post_policy_pick",
+        currentPlayerId: queue[0],
+        middleArea: draft.seedingState.middleArea,
+        stealTurnIndex: draft.seedingState.stealTurnIndex,
+        keepSubmitted: draft.seedingState.keepSubmitted,
+        pendingPostPolicyPicks: queue,
+      };
+      openScholarReorderPrompt(draft, queue[0], events);
     });
     events.push({ type: "seeding_step_changed", step: "post_policy_pick" });
     return { state: withQueue, events };
@@ -476,15 +497,20 @@ function openScholarReorderPrompt(
 ): void {
   const player = getPlayerById(draft, playerId);
   const peekCount = Math.min(5, player.mainDeck.length);
-  if (peekCount === 0) return;
+  if (peekCount === 0) {
+    // Queue construction filters empty-deck players at handlePolicySelection.
+    // Reaching here means the filter was bypassed — surface as an invariant
+    // violation rather than silently leaving the queue stuck.
+    throw new Error(
+      `openScholarReorderPrompt invariant: player "${playerId}" has empty mainDeck — handlePolicySelection should have filtered them out`,
+    );
+  }
   const topIds = player.mainDeck.slice(0, peekCount).map((c) => c.id) as [string, ...string[]];
   draft.pickPrompt = {
+    kind: "scholar_reorder",
     playerId,
     options: topIds,
-    count: peekCount,
     source: "main_deck",
-    ordered: true,
-    purpose: "scholar_reorder",
   };
   events.push({
     type: "cards_peeked",
@@ -507,9 +533,14 @@ function handleSeedingResolvePick(
       `resolve_pick during seeding rejected: pending pick is for "${prompt.playerId}", not "${action.playerId}"`,
     );
   }
-  if (prompt.purpose !== "scholar_reorder") {
+  if (prompt.kind !== "scholar_reorder") {
     throw new Error(
-      `resolve_pick during seeding only supports "scholar_reorder" prompts (got "${prompt.purpose}")`,
+      `resolve_pick during seeding only supports "scholar_reorder" prompts (got "${prompt.kind}")`,
+    );
+  }
+  if (state.seedingState.step !== "post_policy_pick") {
+    throw new Error(
+      `resolve_pick during seeding invariant: pickPrompt is set but step is "${state.seedingState.step}", not "post_policy_pick"`,
     );
   }
 
@@ -527,12 +558,24 @@ function handleSeedingResolvePick(
       `resolve_pick (scholar_reorder): submitted ids must be a permutation of [${prompt.options.join(",")}]`,
     );
   }
+  // Queue invariant: the actor must be at the head of the post-policy queue.
+  // The prompt.playerId === action.playerId check above passes any matching
+  // player; this additionally guards against the prompt being stale relative
+  // to the queue (which would silently corrupt the wrong player's deck).
+  const currentQueue = state.seedingState.pendingPostPolicyPicks;
+  if (currentQueue.indexOf(action.playerId) < 0) {
+    throw new Error(
+      `resolve_pick (scholar_reorder) invariant: actor "${action.playerId}" ` +
+      `not in pendingPostPolicyPicks queue [${currentQueue.join(",")}]`,
+    );
+  }
 
   const events: GameEvent[] = [];
   const after = produce(state, (draft) => {
     draft.actionLog.push(action);
     const player = getPlayerById(draft, action.playerId);
-    // Splice the top `count` cards out, then put them back in chosen order.
+    // Splice the top `options.length` cards out (count === options.length for
+    // ordered prompts) and put them back in the submitted order.
     const removed = player.mainDeck.splice(0, prompt.options.length);
     const lookup = new Map<string, Card>();
     for (const c of removed) lookup.set(c.id, c);
@@ -545,23 +588,37 @@ function handleSeedingResolvePick(
       source: "main_deck",
     });
 
-    // Pop this player from the queue and advance.
-    const queue = draft.seedingState.pendingPostPolicyPicks ?? [];
-    const idx = queue.indexOf(action.playerId);
-    if (idx >= 0) queue.splice(idx, 1);
+    // Pop this player from the queue. We're inside the post_policy_pick
+    // variant — narrowed via the check above — so the field is present.
+    const ds = draft.seedingState;
+    if (ds.step !== "post_policy_pick") return;
+    const queueDraft = ds.pendingPostPolicyPicks as unknown as string[];
+    const idx = queueDraft.indexOf(action.playerId);
+    queueDraft.splice(idx, 1); // guarded above; idx >= 0
     draft.pickPrompt = undefined;
 
-    if (queue.length > 0) {
-      draft.seedingState.currentPlayerId = queue[0];
-      openScholarReorderPrompt(draft, queue[0], events);
+    if (queueDraft.length > 0) {
+      ds.currentPlayerId = queueDraft[0];
+      openScholarReorderPrompt(draft, queueDraft[0], events);
     }
   });
 
   // If the queue is now empty, transition to main.
-  const queueEmpty = (after.seedingState.pendingPostPolicyPicks ?? []).length === 0;
+  const afterState = after.seedingState;
+  const queueEmpty = afterState.step !== "post_policy_pick"
+    || afterState.pendingPostPolicyPicks.length === 0;
   if (queueEmpty) {
     const cleared = produce(after, (draft) => {
-      draft.seedingState.pendingPostPolicyPicks = undefined;
+      // Collapse back to a step-only seedingState (drop the queue field) so the
+      // discriminated union narrows away from post_policy_pick before
+      // finalizeSeeding constructs MainGameState.
+      draft.seedingState = {
+        step: "policy_selection",
+        currentPlayerId: draft.seedingState.currentPlayerId,
+        middleArea: draft.seedingState.middleArea,
+        stealTurnIndex: draft.seedingState.stealTurnIndex,
+        keepSubmitted: draft.seedingState.keepSubmitted,
+      };
     });
     return finalizeSeeding(cleared, events);
   }
@@ -573,6 +630,16 @@ function finalizeSeeding(
   state: SeedingGameState,
   events: GameEvent[],
 ): ApplyResult {
+  // Invariant: any pickPrompt must be resolved before main-phase begins.
+  // The Scholar reorder flow clears its prompt explicitly; surfacing this
+  // as a throw makes it impossible for a future seeding-time prompt to
+  // silently leak into MainGameState.
+  if (state.pickPrompt) {
+    throw new Error(
+      `finalizeSeeding invariant: pickPrompt must be cleared before transitioning to main ` +
+      `(picker="${state.pickPrompt.playerId}", kind="${state.pickPrompt.kind}")`,
+    );
+  }
   const mainState: MainGameState = {
     config: state.config,
     phase: "main",

--- a/engine/src/apply-seeding.ts
+++ b/engine/src/apply-seeding.ts
@@ -57,6 +57,12 @@ export function applySeedingAction(
     return handlePolicySelection(state, action);
   }
 
+  // resolve_pick during seeding (e.g. Scholar's post-policy reorder).
+  // May itself transition to main once the queue empties.
+  if (action.type === "resolve_pick") {
+    return handleSeedingResolvePick(state, action);
+  }
+
   const events: GameEvent[] = [];
 
   const nextState = produce(state, (draft) => {
@@ -413,8 +419,8 @@ function handlePolicySelection(
 
   const events: GameEvent[] = [];
 
-  // Step 1: Apply policy assignment within seeding state (Immer)
-  const final = produce(state, (draft) => {
+  // Assign policies within seeding state (Immer)
+  const afterAssign = produce(state, (draft) => {
     draft.actionLog.push(action);
 
     let rng = fromState(draft.rngState);
@@ -441,31 +447,156 @@ function handlePolicySelection(
     draft.rngState = extractRngState(rng) as number[];
   });
 
-  // Step 2: Construct MainGameState explicitly (full type checking)
+  // Queue post-policy reorder prompts for players whose policies need them
+  // (e.g. Scholar's top-5 reorder). Players are processed in turn order.
+  const pendingPicks = afterAssign.players
+    .filter((p) => p.activePolicies.some((pol) => pol.definitionId === "scholar"))
+    .filter((p) => p.mainDeck.length > 0)
+    .map((p) => p.id);
+
+  if (pendingPicks.length > 0) {
+    const withQueue = produce(afterAssign, (draft) => {
+      draft.seedingState.step = "post_policy_pick";
+      draft.seedingState.pendingPostPolicyPicks = pendingPicks;
+      draft.seedingState.currentPlayerId = pendingPicks[0];
+      openScholarReorderPrompt(draft, pendingPicks[0], events);
+    });
+    events.push({ type: "seeding_step_changed", step: "post_policy_pick" });
+    return { state: withQueue, events };
+  }
+
+  return finalizeSeeding(afterAssign, events);
+}
+
+/** Open a Scholar-reorder pickPrompt for the given player on the seeding draft. */
+function openScholarReorderPrompt(
+  draft: Draft<SeedingGameState>,
+  playerId: string,
+  events: GameEvent[],
+): void {
+  const player = getPlayerById(draft, playerId);
+  const peekCount = Math.min(5, player.mainDeck.length);
+  if (peekCount === 0) return;
+  const topIds = player.mainDeck.slice(0, peekCount).map((c) => c.id) as [string, ...string[]];
+  draft.pickPrompt = {
+    playerId,
+    options: topIds,
+    count: peekCount,
+    source: "main_deck",
+    ordered: true,
+    purpose: "scholar_reorder",
+  };
+  events.push({
+    type: "cards_peeked",
+    playerId,
+    cardIds: [...topIds],
+    source: "main_deck",
+  });
+}
+
+function handleSeedingResolvePick(
+  state: SeedingGameState,
+  action: SeedingAction & { type: "resolve_pick" },
+): ApplyResult {
+  const prompt = state.pickPrompt;
+  if (!prompt) {
+    throw new Error("resolve_pick during seeding rejected: no pending pick");
+  }
+  if (prompt.playerId !== action.playerId) {
+    throw new Error(
+      `resolve_pick during seeding rejected: pending pick is for "${prompt.playerId}", not "${action.playerId}"`,
+    );
+  }
+  if (prompt.purpose !== "scholar_reorder") {
+    throw new Error(
+      `resolve_pick during seeding only supports "scholar_reorder" prompts (got "${prompt.purpose}")`,
+    );
+  }
+
+  // Ordered prompts: submission must be a permutation of options.
+  const submitted = action.pickedCardIds;
+  if (submitted.length !== prompt.options.length) {
+    throw new Error(
+      `resolve_pick (scholar_reorder): expected ${prompt.options.length} ids, got ${submitted.length}`,
+    );
+  }
+  const expected = new Set(prompt.options);
+  const submittedSet = new Set(submitted);
+  if (expected.size !== submittedSet.size || ![...expected].every((id) => submittedSet.has(id))) {
+    throw new Error(
+      `resolve_pick (scholar_reorder): submitted ids must be a permutation of [${prompt.options.join(",")}]`,
+    );
+  }
+
+  const events: GameEvent[] = [];
+  const after = produce(state, (draft) => {
+    draft.actionLog.push(action);
+    const player = getPlayerById(draft, action.playerId);
+    // Splice the top `count` cards out, then put them back in chosen order.
+    const removed = player.mainDeck.splice(0, prompt.options.length);
+    const lookup = new Map<string, Card>();
+    for (const c of removed) lookup.set(c.id, c);
+    const reordered = submitted.map((id) => lookup.get(id)!);
+    player.mainDeck.unshift(...reordered);
+    events.push({
+      type: "cards_picked",
+      playerId: action.playerId,
+      cardIds: [...submitted],
+      source: "main_deck",
+    });
+
+    // Pop this player from the queue and advance.
+    const queue = draft.seedingState.pendingPostPolicyPicks ?? [];
+    const idx = queue.indexOf(action.playerId);
+    if (idx >= 0) queue.splice(idx, 1);
+    draft.pickPrompt = undefined;
+
+    if (queue.length > 0) {
+      draft.seedingState.currentPlayerId = queue[0];
+      openScholarReorderPrompt(draft, queue[0], events);
+    }
+  });
+
+  // If the queue is now empty, transition to main.
+  const queueEmpty = (after.seedingState.pendingPostPolicyPicks ?? []).length === 0;
+  if (queueEmpty) {
+    const cleared = produce(after, (draft) => {
+      draft.seedingState.pendingPostPolicyPicks = undefined;
+    });
+    return finalizeSeeding(cleared, events);
+  }
+  return { state: after, events };
+}
+
+/** Build MainGameState + run first-player start-of-turn. Called when seeding completes. */
+function finalizeSeeding(
+  state: SeedingGameState,
+  events: GameEvent[],
+): ApplyResult {
   const mainState: MainGameState = {
-    config: final.config,
+    config: state.config,
     phase: "main",
     turn: {
-      activePlayerId: final.players[0].id,
+      activePlayerId: state.players[0].id,
       round: 1,
       actionPointsRemaining: getConfigNumber(
-        final,
+        state,
         "action_points_per_turn",
         3,
       ),
     },
-    players: final.players,
-    grid: final.grid,
-    market: final.market,
-    rngState: final.rngState,
-    seed: final.seed,
-    actionLog: final.actionLog,
+    players: state.players,
+    grid: state.grid,
+    market: state.market,
+    rngState: state.rngState,
+    seed: state.seed,
+    actionLog: state.actionLog,
   };
 
   events.push({ type: "phase_changed", from: "seeding", to: "main" });
   events.push({
     type: "turn_started",
-    playerId: final.players[0].id,
+    playerId: state.players[0].id,
     round: 1,
   });
 

--- a/engine/src/effect-dsl/executor.ts
+++ b/engine/src/effect-dsl/executor.ts
@@ -385,6 +385,7 @@ function execPick(p: Primitive, ctx: ExecutionContext): void {
   // peeked.length (which subsumes length 1 with the default count of 1), so
   // the mapped array is non-empty by construction.
   ctx.draft.pickPrompt = {
+    kind: "deck_pick",
     playerId: ctx.playerId,
     options: peeked.map((c) => c.id) as [string, ...string[]],
     count,

--- a/engine/src/index.ts
+++ b/engine/src/index.ts
@@ -62,6 +62,7 @@ export type {
   PickPrompt,
   PolicyCard,
   Rarity,
+  Reveals,
   SeedingGameState,
   Session,
   Trap,
@@ -75,7 +76,7 @@ export { getActivePlayerId } from "./types";
 export { getValidActions } from "./valid-actions";
 export { getVisibleState } from "./visible-state";
 // Listeners
-export type { EffectListener, EffectSource, EmitFn } from "./listeners";
+export type { EffectListener, EffectSource, EmitFn, RevealsProvider } from "./listeners";
 export { emit, rebuildListeners } from "./listeners";
 export {
   LOCATION_EFFECTS,
@@ -83,6 +84,8 @@ export {
   PASSIVE_EVENT_EFFECTS,
   TRAP_EFFECTS,
   ITEM_EFFECTS,
+  UNIT_EFFECTS,
+  POLICY_ACTIONS,
 } from "./listeners";
 // Win condition
 export { findSoleLeader, getScores, shouldEndGame, toEndedState } from "./win-condition";

--- a/engine/src/listeners/effects.ts
+++ b/engine/src/listeners/effects.ts
@@ -207,6 +207,17 @@ export const LOCATION_EFFECTS: Record<string, LocationEffectFactory> = {
         && ctx.unit.cunning >= 7,
     } satisfies ProtectionListener],
   }),
+
+  "alexandria-harbor": (_loc, ownerId) => ({
+    listeners: [],
+    queries: [],
+    reveals: (state, viewerId) => {
+      if (viewerId !== ownerId) return {};
+      const player = state.players.find((p) => p.id === viewerId);
+      const top = player?.mainDeck[0];
+      return top ? { mainDeckTop: top } : {};
+    },
+  }),
 };
 
 export const POLICY_EFFECTS: Record<string, PolicyEffectFactory> = {
@@ -406,6 +417,28 @@ export const ITEM_EFFECTS: Record<string, ItemEffectFactory> = {
       modify: (_state, ctx) =>
         ctx.stat === "cunning" && item.equippedTo === ctx.unit.id ? 2 : 0,
     } satisfies StatModifierListener],
+  }),
+
+  "spy-glass": (item, ownerId, position) => ({
+    listeners: [],
+    queries: [],
+    reveals: (state, viewerId) => {
+      // Only the Spy Glass owner gets reveal rights. Equipped + on grid required:
+      // rebuild calls this factory with `position` only when the item is at a
+      // grid cell; HQ-stored Spy Glasses don't fire.
+      if (viewerId !== ownerId || !item.equippedTo || !position) return {};
+      const cell = state.grid[position.row]?.[position.col];
+      if (!cell?.location) return {};
+      const locationId = cell.location.id;
+      const revealedTrapIds: string[] = [];
+      for (const player of state.players) {
+        if (player.id === viewerId) continue;
+        for (const trap of player.activeTraps) {
+          if (trap.targetId === locationId) revealedTrapIds.push(trap.card.id);
+        }
+      }
+      return { revealedTrapIds };
+    },
   }),
 
   "war-banner": (item, ownerId, position) => ({

--- a/engine/src/listeners/effects.ts
+++ b/engine/src/listeners/effects.ts
@@ -424,8 +424,9 @@ export const ITEM_EFFECTS: Record<string, ItemEffectFactory> = {
     queries: [],
     reveals: (state, viewerId) => {
       // Only the Spy Glass owner gets reveal rights. Equipped + on grid required:
-      // rebuild calls this factory with `position` only when the item is at a
-      // grid cell; HQ-stored Spy Glasses don't fire.
+      // computeReveals (visible-state.ts) passes `position` only for items found
+      // via the grid loop; HQ-stored items reach this factory without position
+      // so the guard below short-circuits.
       if (viewerId !== ownerId || !item.equippedTo || !position) return {};
       const cell = state.grid[position.row]?.[position.col];
       if (!cell?.location) return {};

--- a/engine/src/listeners/effects.ts
+++ b/engine/src/listeners/effects.ts
@@ -9,6 +9,7 @@ import type {
   StatModifierListener,
 } from "./types";
 import type {
+  ActionDef,
   GameEvent,
   ItemCard,
   LocationCard,
@@ -53,6 +54,12 @@ export type TrapEffectFactory = (
 
 export type ItemEffectFactory = (
   item: ItemCard,
+  ownerId: string,
+  position?: { row: number; col: number },
+) => EffectDefinition;
+
+export type UnitEffectFactory = (
+  unit: UnitCard,
   ownerId: string,
   position?: { row: number; col: number },
 ) => EffectDefinition;
@@ -497,6 +504,37 @@ export const ITEM_EFFECTS: Record<string, ItemEffectFactory> = {
       },
     }],
     queries: [],
+  }),
+};
+
+// ---------------------------------------------------------------------------
+// Policy actions — activatable actions surfaced on active policies.
+// Keyed by policy definitionId. The action shape mirrors UnitCard.actions.
+// CSV-driven extraction of policy actions is tracked in #68; until then,
+// actions live here so handleActivate can dispatch them by definitionId.
+// ---------------------------------------------------------------------------
+
+export const POLICY_ACTIONS: Record<string, ActionDef[]> = {
+  "spymaster": [
+    { name: "Infiltrate", apCost: 1, effect: "reveal(opponent + hand)" },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Unit effects — passives that fire while a unit is in play (HQ or grid).
+// ---------------------------------------------------------------------------
+
+export const UNIT_EFFECTS: Record<string, UnitEffectFactory> = {
+  "mary-shelley": (unit, ownerId) => ({
+    listeners: [],
+    queries: [{
+      source: { type: "unit", cardId: unit.id, definitionId: "mary-shelley", ownerId },
+      query: "ap",
+      modify: (state, ctx) => {
+        if (ctx.playerId !== ownerId || ctx.action.type !== "play_event") return 0;
+        return countActionsThisTurn(state, ownerId, (a) => a.type === "play_event") === 0 ? -99 : 0;
+      },
+    } satisfies APModifierListener],
   }),
 };
 

--- a/engine/src/listeners/index.ts
+++ b/engine/src/listeners/index.ts
@@ -4,6 +4,7 @@ export type {
   EmitFn,
   EffectDefinition,
   QueryListener,
+  RevealsProvider,
   StatModifierListener,
   CostModifierListener,
   ProtectionListener,
@@ -31,4 +32,6 @@ export {
   PASSIVE_EVENT_EFFECTS,
   TRAP_EFFECTS,
   ITEM_EFFECTS,
+  UNIT_EFFECTS,
+  POLICY_ACTIONS,
 } from "./effects";

--- a/engine/src/listeners/rebuild.ts
+++ b/engine/src/listeners/rebuild.ts
@@ -6,6 +6,7 @@ import {
   PASSIVE_EVENT_EFFECTS,
   TRAP_EFFECTS,
   ITEM_EFFECTS,
+  UNIT_EFFECTS,
 } from "./effects";
 
 export interface RebuildResult {
@@ -51,6 +52,16 @@ export function rebuildListeners(state: MainGameState): RebuildResult {
           queries.push(...result.queries);
         }
       }
+
+      // Unit effects (units on the grid)
+      for (const unit of cell.units) {
+        const factory = UNIT_EFFECTS[unit.definitionId];
+        if (factory) {
+          const result = factory(unit, unit.ownerId, { row: r, col: c });
+          listeners.push(...result.listeners);
+          queries.push(...result.queries);
+        }
+      }
     }
   }
 
@@ -83,10 +94,17 @@ export function rebuildListeners(state: MainGameState): RebuildResult {
       }
     }
 
-    // HQ items (stored items not on grid)
+    // HQ items + units (stored cards not yet on grid)
     for (const card of player.hq) {
       if (card.type === "item") {
         const factory = ITEM_EFFECTS[card.definitionId];
+        if (factory) {
+          const result = factory(card, player.id);
+          listeners.push(...result.listeners);
+          queries.push(...result.queries);
+        }
+      } else if (card.type === "unit") {
+        const factory = UNIT_EFFECTS[card.definitionId];
         if (factory) {
           const result = factory(card, player.id);
           listeners.push(...result.listeners);

--- a/engine/src/listeners/types.ts
+++ b/engine/src/listeners/types.ts
@@ -5,7 +5,7 @@ export type { StatName };
 
 /** Where the effect originates — enough to identify the source card. */
 export interface EffectSource {
-  type: "location" | "policy" | "passive_event" | "trap" | "item";
+  type: "location" | "policy" | "passive_event" | "trap" | "item" | "unit";
   cardId: string;
   definitionId: string;
   ownerId: string;

--- a/engine/src/listeners/types.ts
+++ b/engine/src/listeners/types.ts
@@ -1,5 +1,5 @@
 import type { Draft } from "immer";
-import type { Card, GameEvent, MainAction, MainGameState, StatName, UnitCard } from "../types";
+import type { Card, GameEvent, MainAction, MainGameState, Reveals, StatName, UnitCard } from "../types";
 
 export type { StatName };
 
@@ -111,8 +111,19 @@ export type QueryListener =
 // Combined effect definition
 // ---------------------------------------------------------------------------
 
-/** Result of an effect factory — both event listeners and query listeners. */
+/**
+ * Returns this card's contribution to what `viewerId` is allowed to see.
+ * Called fresh per visible-state build; should be side-effect free.
+ */
+export type RevealsProvider = (
+  state: MainGameState,
+  viewerId: string,
+) => Partial<Reveals>;
+
+/** Result of an effect factory — listeners, query listeners, and reveals. */
 export interface EffectDefinition {
   listeners: EffectListener[];
   queries: QueryListener[];
+  /** Optional: contributes to VisibleState.reveals when called per viewer. */
+  reveals?: RevealsProvider;
 }

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -202,22 +202,34 @@ export type SeedingStep =
   /** Post-policy reorder pass for cards like Scholar that reorder owner's main deck. */
   | "post_policy_pick";
 
-export interface SeedingState {
-  step: SeedingStep;
+interface SeedingStateBase {
   /** Whose input is needed next during seeding. */
   currentPlayerId: string;
   middleArea: Card[];
   /** Index into players array for whose turn it is to steal. */
   stealTurnIndex: number;
-  /**
-   * Queue of player ids waiting for a post-policy prompt (e.g. Scholar reorder).
-   * Populated by handlePolicySelection; drained by resolve_pick during the
-   * `post_policy_pick` step. Main-phase transition happens when this empties.
-   */
-  pendingPostPolicyPicks?: string[];
   /** Players who have submitted seed_keep this round. Reset at step entry. */
   keepSubmitted: string[];
 }
+
+/**
+ * Seeding state. The `pendingPostPolicyPicks` field exists only on the
+ * `post_policy_pick` variant — keeping `step` and the queue in lockstep
+ * makes the two illegal combinations (`post_policy_pick` with no queue,
+ * other steps with a non-empty queue) unrepresentable.
+ *
+ * Order matters: the queue is populated in turn order so multi-player
+ * Scholar games drain deterministically (player 0 reorders first, then
+ * player 1, etc.). Independent of game outcome.
+ */
+export type SeedingState =
+  | (SeedingStateBase & {
+      step: Exclude<SeedingStep, "post_policy_pick">;
+    })
+  | (SeedingStateBase & {
+      step: "post_policy_pick";
+      pendingPostPolicyPicks: readonly [string, ...string[]];
+    });
 
 export interface TurnState {
   activePlayerId: string;
@@ -259,37 +271,36 @@ export interface SeedingGameState extends GameStateBase {
 export type PickSource = "main_deck";
 
 /**
- * A prompt asking the player to pick from a set of revealed cards.
+ * Fields shared by every `PickPrompt` variant.
  *
- * Appears on `MainGameState.pickPrompt` (full engine state) and
- * `VisibleState.pickPrompt` (only populated when the viewer is the picker).
- * It is only meaningful while the engine is paused mid-effect waiting for a
- * player choice.
+ * Lives on `GameStateBase.pickPrompt` (so it surfaces in main and seeding
+ * phases) and on `VisibleState.pickPrompt` (only populated when the viewer
+ * is the picker). Used both mid-effect during main and during the
+ * `post_policy_pick` seeding step.
  */
-export interface PickPrompt {
+interface PickPromptBase {
   playerId: string;
   /** Card instance IDs the player may pick from, in revealed order. Always non-empty. Items are unique (instance ids). */
   options: readonly [string, ...string[]];
-  /**
-   * How many of the options the player must pick. Always `1 <= count < options.length`.
-   * The DSL validator enforces `count >= 1` at parse time; `execPick` enforces the upper
-   * bound by auto-picking instead of suspending when `count >= peeked.length`.
-   */
-  count: number;
   source: PickSource;
-  /**
-   * When true, the picker must select all `options` and the submission order
-   * defines the outcome (e.g. Scholar's top-5 reorder). When false (default),
-   * the picker selects a subset of size `count` and order does not matter.
-   */
-  ordered?: boolean;
-  /**
-   * Distinguishes resolution semantics. "deck_pick" (default) is the existing
-   * pick-from-revealed-cards flow used by the DSL `pick` verb. Other kinds
-   * trigger card-specific resolution (e.g. Scholar's reorder).
-   */
-  purpose?: "deck_pick" | "scholar_reorder";
 }
+
+/**
+ * A prompt asking the player to pick from a set of revealed cards.
+ *
+ * Discriminated on `kind`:
+ *
+ * - `"deck_pick"`: the picker chooses a `count`-sized subset of `options`;
+ *   order does not matter. `1 <= count < options.length` (the DSL validator
+ *   enforces `count >= 1` at parse time; `execPick` auto-picks instead of
+ *   suspending when `count >= peeked.length`).
+ * - `"scholar_reorder"`: the picker submits a permutation of `options` (all
+ *   of them, in chosen order). `count` is implicitly `options.length` and
+ *   not stored on the variant. The submission order is the outcome.
+ */
+export type PickPrompt =
+  | (PickPromptBase & { kind: "deck_pick"; count: number })
+  | (PickPromptBase & { kind: "scholar_reorder" });
 
 export interface MainGameState extends GameStateBase {
   phase: "main";
@@ -301,6 +312,8 @@ export interface EndedGameState extends GameStateBase {
   turn: TurnState;
   winner?: string;
   scores: Record<string, number>;
+  /** Ended games never carry a pending pick — make that compile-time. */
+  pickPrompt?: never;
 }
 
 export type GameState = SeedingGameState | MainGameState | EndedGameState;
@@ -349,7 +362,18 @@ export type SeedingAction =
       rotation?: number;
     }
   | { type: "policy_select"; playerId: string }
-  | { type: "resolve_pick"; playerId: string; pickedCardIds: [string, ...string[]] };
+  | ResolvePickAction;
+
+/**
+ * Submitted by the picker to resolve a pending `pickPrompt`. Valid in both
+ * main and seeding phases (during `post_policy_pick`); the dispatcher routes
+ * by phase. `pickedCardIds` must be non-empty.
+ */
+export interface ResolvePickAction {
+  type: "resolve_pick";
+  playerId: string;
+  pickedCardIds: [string, ...string[]];
+}
 
 export type MainAction =
   | { type: "deploy"; playerId: string; cardId: string }
@@ -392,7 +416,7 @@ export type MainAction =
     }
   | { type: "attempt_mission"; playerId: string; row: number; col: number }
   | { type: "pass"; playerId: string }
-  | { type: "resolve_pick"; playerId: string; pickedCardIds: [string, ...string[]] };
+  | ResolvePickAction;
 
 export type Action = SeedingAction | MainAction;
 
@@ -561,13 +585,23 @@ export type GameEvent =
 /**
  * Conditional information surfaced to a specific viewer by active card
  * passives — e.g. Alexandria Harbor lets its owner see the top of their
- * main deck; Spy Glass un-redacts specific opponent trap cards. Computed
- * fresh from active listeners each time the visible state is built.
+ * main deck; Spy Glass un-redacts specific opponent trap cards.
+ *
+ * Computed fresh by walking the same card surfaces as `rebuildListeners`
+ * (locations, items, units, policies, passive events, traps, HQ cards)
+ * each time the visible state is built. Each card's effect factory may
+ * return a `reveals` provider (separate from the `listeners`/`queries`
+ * surface) that contributes to this object.
  */
 export interface Reveals {
   /** Top card of viewer's own main deck (Alexandria Harbor and similar). */
   mainDeckTop?: Card;
-  /** Opponent trap card-instance ids the viewer is allowed to see un-redacted. */
+  /**
+   * Opponent trap card-instance ids the viewer is allowed to see
+   * un-redacted. Always deduplicated (set semantics, list representation
+   * for JSON serialization). Set by `computeReveals` via a `Set` and
+   * converted to an array at return.
+   */
   revealedTrapIds: string[];
 }
 
@@ -593,7 +627,7 @@ export interface VisibleState {
   middleArea: Card[];
   /** Current seeding step, if in seeding phase. */
   seedingStep?: SeedingStep;
-  /** Set during main phase when the active player must resolve a `pick`. */
+  /** Set during main or seeding phase when this viewer is the picker. */
   pickPrompt?: PickPrompt;
   winner?: string;
   scores?: Record<string, number>;

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -198,7 +198,9 @@ export type SeedingStep =
   | "seed_keep"
   | "seed_steal"
   | "seed_place_location"
-  | "policy_selection";
+  | "policy_selection"
+  /** Post-policy reorder pass for cards like Scholar that reorder owner's main deck. */
+  | "post_policy_pick";
 
 export interface SeedingState {
   step: SeedingStep;
@@ -207,6 +209,12 @@ export interface SeedingState {
   middleArea: Card[];
   /** Index into players array for whose turn it is to steal. */
   stealTurnIndex: number;
+  /**
+   * Queue of player ids waiting for a post-policy prompt (e.g. Scholar reorder).
+   * Populated by handlePolicySelection; drained by resolve_pick during the
+   * `post_policy_pick` step. Main-phase transition happens when this empties.
+   */
+  pendingPostPolicyPicks?: string[];
   /** Players who have submitted seed_keep this round. Reset at step entry. */
   keepSubmitted: string[];
 }
@@ -231,6 +239,12 @@ interface GameStateBase {
   rngState: readonly number[];
   seed: string;
   actionLog: Action[];
+  /**
+   * Set when an effect or passive needs player input. Cleared by `resolve_pick`.
+   * Lives on the base so seeding-time prompts (e.g. Scholar's reorder) can use
+   * the same surface as main-phase `pick` verbs.
+   */
+  pickPrompt?: PickPrompt;
 }
 
 export interface SeedingGameState extends GameStateBase {
@@ -263,13 +277,23 @@ export interface PickPrompt {
    */
   count: number;
   source: PickSource;
+  /**
+   * When true, the picker must select all `options` and the submission order
+   * defines the outcome (e.g. Scholar's top-5 reorder). When false (default),
+   * the picker selects a subset of size `count` and order does not matter.
+   */
+  ordered?: boolean;
+  /**
+   * Distinguishes resolution semantics. "deck_pick" (default) is the existing
+   * pick-from-revealed-cards flow used by the DSL `pick` verb. Other kinds
+   * trigger card-specific resolution (e.g. Scholar's reorder).
+   */
+  purpose?: "deck_pick" | "scholar_reorder";
 }
 
 export interface MainGameState extends GameStateBase {
   phase: "main";
   turn: TurnState;
-  /** Set mid-effect when a `pick` verb needs player input. Cleared by `resolve_pick`. */
-  pickPrompt?: PickPrompt;
 }
 
 export interface EndedGameState extends GameStateBase {
@@ -324,7 +348,8 @@ export type SeedingAction =
       col: number;
       rotation?: number;
     }
-  | { type: "policy_select"; playerId: string };
+  | { type: "policy_select"; playerId: string }
+  | { type: "resolve_pick"; playerId: string; pickedCardIds: [string, ...string[]] };
 
 export type MainAction =
   | { type: "deploy"; playerId: string; cardId: string }

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -173,9 +173,13 @@ export interface Trap {
   targetId?: string;
 }
 
-/** Redacted trap view for opponents — card contents hidden. */
+/** Redacted trap view for opponents — card contents hidden unless revealed (e.g. by Spy Glass). */
 export interface TrapView {
   targetId?: string;
+  /** Card-instance id of the trap (always present so revealers can look it up). */
+  cardId: string;
+  /** Trap card contents — only populated when the viewer has reveal rights for this trap. */
+  card?: TrapEventCard;
 }
 
 export type Grid = GridCell[][];
@@ -529,6 +533,19 @@ export type GameEvent =
 // Visibility
 // ---------------------------------------------------------------------------
 
+/**
+ * Conditional information surfaced to a specific viewer by active card
+ * passives — e.g. Alexandria Harbor lets its owner see the top of their
+ * main deck; Spy Glass un-redacts specific opponent trap cards. Computed
+ * fresh from active listeners each time the visible state is built.
+ */
+export interface Reveals {
+  /** Top card of viewer's own main deck (Alexandria Harbor and similar). */
+  mainDeckTop?: Card;
+  /** Opponent trap card-instance ids the viewer is allowed to see un-redacted. */
+  revealedTrapIds: string[];
+}
+
 /** Filtered game state for a specific player. Hidden info is omitted. */
 export interface VisibleState {
   config: GameConfig;
@@ -555,6 +572,8 @@ export interface VisibleState {
   pickPrompt?: PickPrompt;
   winner?: string;
   scores?: Record<string, number>;
+  /** Conditional reveals granted by active passives for this viewer. */
+  reveals: Reveals;
 }
 
 export interface OpponentView {

--- a/engine/src/valid-actions.ts
+++ b/engine/src/valid-actions.ts
@@ -13,6 +13,7 @@ import {
 } from "./grid-helpers";
 import { getConfigNumber, getPlayerById } from "./state-helpers";
 import { rebuildListeners } from "./listeners/rebuild";
+import { POLICY_ACTIONS } from "./listeners/effects";
 import { getModifiedCost, getModifiedAPCost } from "./listeners/query";
 import type {
   Action,
@@ -374,6 +375,28 @@ function getMainValidActions(
             type: "activate",
             playerId,
             cardId: unit.id,
+            actionName: actionDef.name,
+            ...t,
+          });
+        }
+      }
+    }
+  }
+
+  // activate — policy actions (HQ-origin: no grid position)
+  const ownerPlayer = state.players.find((p) => p.id === playerId);
+  if (ownerPlayer) {
+    const hqOrigin: BoardPosition = { type: "hq", playerId };
+    for (const policy of ownerPlayer.activePolicies) {
+      const policyActions = POLICY_ACTIONS[policy.definitionId] ?? [];
+      for (const actionDef of policyActions) {
+        if (ap < actionDef.apCost) continue;
+        const targets = inferActivateTargets(state, policy.id, actionDef.effect, hqOrigin, playerId);
+        for (const t of targets) {
+          actions.push({
+            type: "activate",
+            playerId,
+            cardId: policy.id,
             actionName: actionDef.name,
             ...t,
           });

--- a/engine/src/valid-actions.ts
+++ b/engine/src/valid-actions.ts
@@ -243,15 +243,16 @@ function getMainValidActions(
     }
   }
 
-  // play_event — events in hand that player can afford (1 AP)
-  if (ap >= 1) {
-    for (const card of player.hand) {
-      if (card.type !== "event") continue;
-      const cost = tryParseCost(card.cost);
-      if (cost !== null && player.gold >= cost) {
-        actions.push({ type: "play_event", playerId, cardId: card.id });
-      }
-    }
+  // play_event — events in hand that player can afford. AP cost goes through
+  // getModifiedAPCost so passives like Mary Shelley (first event free) surface
+  // at AP=0; checking gold cost separately.
+  for (const card of player.hand) {
+    if (card.type !== "event") continue;
+    const cost = tryParseCost(card.cost);
+    if (cost === null || player.gold < cost) continue;
+    const candidate: MainAction = { type: "play_event", playerId, cardId: card.id };
+    const apCost = getModifiedAPCost(state, queries, candidate, 1);
+    if (ap >= apCost) actions.push(candidate);
   }
 
   // equip — items to co-located units, across all positions (1 AP)
@@ -423,15 +424,40 @@ function getResolvePickActions(
   prompt: PickPrompt,
   playerId: string,
 ): MainAction[] {
-  // PickPrompt.count is validated >= 1 (validator rejects peek[0]/pick[0]),
-  // so every subset is non-empty — safe to assert the non-empty-tuple shape.
-  return subsetsOfSize(prompt.options, prompt.count).map(
-    (pickedCardIds) => ({
-      type: "resolve_pick" as const,
-      playerId,
-      pickedCardIds: pickedCardIds as [string, ...string[]],
-    }),
-  );
+  // `deck_pick` enumerates count-sized subsets (set selection); `scholar_reorder`
+  // enumerates permutations of the full options list (the submission order is
+  // the outcome). Both shapes produce non-empty pickedCardIds tuples — safe
+  // to assert via `as`.
+  const combos = prompt.kind === "scholar_reorder"
+    ? permutationsOf(prompt.options)
+    : subsetsOfSize(prompt.options, prompt.count);
+  return combos.map((pickedCardIds) => ({
+    type: "resolve_pick" as const,
+    playerId,
+    pickedCardIds: pickedCardIds as [string, ...string[]],
+  }));
+}
+
+function permutationsOf<T>(items: readonly T[]): T[][] {
+  if (items.length === 0) return [[]];
+  const result: T[][] = [];
+  const buf: T[] = new Array(items.length);
+  const used = new Array(items.length).fill(false);
+  const choose = (depth: number): void => {
+    if (depth === items.length) {
+      result.push([...buf]);
+      return;
+    }
+    for (let i = 0; i < items.length; i++) {
+      if (used[i]) continue;
+      used[i] = true;
+      buf[depth] = items[i];
+      choose(depth + 1);
+      used[i] = false;
+    }
+  };
+  choose(0);
+  return result;
 }
 
 function subsetsOfSize<T>(items: readonly T[], size: number): T[][] {

--- a/engine/src/valid-actions.ts
+++ b/engine/src/valid-actions.ts
@@ -110,6 +110,13 @@ function getSeedingValidActions(
 
     case "policy_selection":
       return [{ type: "policy_select", playerId }];
+
+    case "post_policy_pick": {
+      if (state.pickPrompt && state.pickPrompt.playerId === playerId) {
+        return getResolvePickActions(state.pickPrompt, playerId) as SeedingAction[];
+      }
+      return [];
+    }
   }
 }
 

--- a/engine/src/visible-state.ts
+++ b/engine/src/visible-state.ts
@@ -107,7 +107,17 @@ function toOpponentView(player: PlayerState, revealedTrapIds: string[]): Opponen
 
 function redactTrap(trap: Trap, revealedTrapIds: string[]): TrapView {
   const view: TrapView = { targetId: trap.targetId, cardId: trap.card.id };
-  if (revealedTrapIds.includes(trap.card.id)) view.card = trap.card;
+  if (revealedTrapIds.includes(trap.card.id)) {
+    view.card = trap.card;
+    // Defensive invariant: revealed `card.id` must equal `cardId`. A
+    // mismatch indicates an upstream bug populating revealedTrapIds with
+    // ids that don't belong to this trap.
+    if (view.card.id !== view.cardId) {
+      throw new Error(
+        `redactTrap invariant: revealed card id "${view.card.id}" does not match cardId "${view.cardId}"`,
+      );
+    }
+  }
   return view;
 }
 
@@ -115,9 +125,9 @@ function redactTrap(trap: Trap, revealedTrapIds: string[]): TrapView {
  * Compute the union of reveal contributions from all active cards for a
  * specific viewer. Walks the same surfaces as rebuildListeners; each card's
  * factory may return a `reveals` provider that maps (state, viewerId) →
- * partial Reveals. Contributions are merged: mainDeckTop is last-write-wins
- * (cards owned by the viewer that grant deck-top access are mutually
- * exclusive in practice); revealedTrapIds are deduped.
+ * partial Reveals. Contributions are merged: mainDeckTop must be set by at
+ * most one provider per viewer (throw on conflict — see assertion below);
+ * revealedTrapIds are deduped.
  */
 function computeReveals(state: MainGameState, viewerId: string): Reveals {
   const result: Reveals = { revealedTrapIds: [] };
@@ -126,7 +136,17 @@ function computeReveals(state: MainGameState, viewerId: string): Reveals {
   const apply = (provider: RevealsProvider | undefined) => {
     if (!provider) return;
     const contribution = provider(state, viewerId);
-    if (contribution.mainDeckTop) result.mainDeckTop = contribution.mainDeckTop;
+    if (contribution.mainDeckTop) {
+      if (result.mainDeckTop && result.mainDeckTop.id !== contribution.mainDeckTop.id) {
+        // No two passives should grant mainDeckTop for the same viewer.
+        // Surface as an invariant violation rather than silently picking
+        // the iteration-order winner.
+        throw new Error(
+          `computeReveals invariant: multiple providers contributed conflicting mainDeckTop for viewer "${viewerId}" (saw "${result.mainDeckTop.id}" then "${contribution.mainDeckTop.id}")`,
+        );
+      }
+      result.mainDeckTop = contribution.mainDeckTop;
+    }
     for (const id of contribution.revealedTrapIds ?? []) trapIds.add(id);
   };
 

--- a/engine/src/visible-state.ts
+++ b/engine/src/visible-state.ts
@@ -1,11 +1,23 @@
 import type {
   GameState,
+  MainGameState,
   OpponentView,
   PlayerState,
+  Reveals,
+  Trap,
   TrapView,
   VisibleState,
 } from "./types";
 import { getActivePlayerId } from "./types";
+import {
+  ITEM_EFFECTS,
+  LOCATION_EFFECTS,
+  PASSIVE_EVENT_EFFECTS,
+  POLICY_EFFECTS,
+  TRAP_EFFECTS,
+  UNIT_EFFECTS,
+} from "./listeners/effects";
+import type { RevealsProvider } from "./listeners/types";
 
 /**
  * Return a filtered view of the state for a specific player.
@@ -21,6 +33,10 @@ export function getVisibleState(
     throw new Error(`Player "${playerId}" not found in game state`);
   }
 
+  const reveals = state.phase === "main" || state.phase === "ended"
+    ? computeReveals(state as MainGameState, playerId)
+    : { revealedTrapIds: [] };
+
   // When player has no team, all others are opponents.
   // When player has a team, non-teammates are opponents.
   const isTeammate = (p: PlayerState) =>
@@ -28,7 +44,7 @@ export function getVisibleState(
 
   const opponents: OpponentView[] = state.players
     .filter((p) => p.id !== playerId && !isTeammate(p))
-    .map(toOpponentView);
+    .map((p) => toOpponentView(p, reveals.revealedTrapIds));
 
   const teammates = state.players.filter(isTeammate);
 
@@ -62,10 +78,11 @@ export function getVisibleState(
         : undefined,
     winner: state.phase === "ended" ? state.winner : undefined,
     scores: state.phase === "ended" ? state.scores : undefined,
+    reveals,
   };
 }
 
-function toOpponentView(player: PlayerState): OpponentView {
+function toOpponentView(player: PlayerState, revealedTrapIds: string[]): OpponentView {
   return {
     id: player.id,
     name: player.name,
@@ -80,11 +97,84 @@ function toOpponentView(player: PlayerState): OpponentView {
     discardPileSize: player.discardPile.length,
     hq: player.hq,
     activePolicies: player.activePolicies,
-    // Traps are face-down: show that they exist and their target, but not the card
-    activeTraps: player.activeTraps.map(redactTrap),
+    // Traps are face-down: show that they exist and their target, but redact
+    // card contents unless the viewer has explicit reveal rights for this trap.
+    activeTraps: player.activeTraps.map((t) => redactTrap(t, revealedTrapIds)),
   };
 }
 
-function redactTrap(trap: { targetId?: string }): TrapView {
-  return { targetId: trap.targetId };
+function redactTrap(trap: Trap, revealedTrapIds: string[]): TrapView {
+  const view: TrapView = { targetId: trap.targetId, cardId: trap.card.id };
+  if (revealedTrapIds.includes(trap.card.id)) view.card = trap.card;
+  return view;
+}
+
+/**
+ * Compute the union of reveal contributions from all active cards for a
+ * specific viewer. Walks the same surfaces as rebuildListeners; each card's
+ * factory may return a `reveals` provider that maps (state, viewerId) →
+ * partial Reveals. Contributions are merged: mainDeckTop is last-write-wins
+ * (cards owned by the viewer that grant deck-top access are mutually
+ * exclusive in practice); revealedTrapIds are deduped.
+ */
+function computeReveals(state: MainGameState, viewerId: string): Reveals {
+  const result: Reveals = { revealedTrapIds: [] };
+  const trapIds = new Set<string>();
+
+  const apply = (provider: RevealsProvider | undefined) => {
+    if (!provider) return;
+    const contribution = provider(state, viewerId);
+    if (contribution.mainDeckTop) result.mainDeckTop = contribution.mainDeckTop;
+    for (const id of contribution.revealedTrapIds ?? []) trapIds.add(id);
+  };
+
+  // Grid: locations, items, units
+  for (let r = 0; r < state.grid.length; r++) {
+    for (let c = 0; c < state.grid[r].length; c++) {
+      const cell = state.grid[r][c];
+
+      if (cell.location) {
+        const factory = LOCATION_EFFECTS[cell.location.definitionId];
+        if (factory) apply(factory(cell.location, cell.location.ownerId, r, c).reveals);
+      }
+
+      for (const item of cell.items) {
+        const factory = ITEM_EFFECTS[item.definitionId];
+        if (factory) apply(factory(item, item.ownerId, { row: r, col: c }).reveals);
+      }
+
+      for (const unit of cell.units) {
+        const factory = UNIT_EFFECTS[unit.definitionId];
+        if (factory) apply(factory(unit, unit.ownerId, { row: r, col: c }).reveals);
+      }
+    }
+  }
+
+  // Per-player: policies, passive events, traps, HQ items + units
+  for (const player of state.players) {
+    for (const policy of player.activePolicies) {
+      const factory = POLICY_EFFECTS[policy.definitionId];
+      if (factory) apply(factory(policy, player.id).reveals);
+    }
+    for (const pe of player.passiveEvents) {
+      const factory = PASSIVE_EVENT_EFFECTS[pe.definitionId];
+      if (factory) apply(factory(pe, player.id).reveals);
+    }
+    for (const trap of player.activeTraps) {
+      const factory = TRAP_EFFECTS[trap.card.definitionId];
+      if (factory) apply(factory(trap, player.id).reveals);
+    }
+    for (const card of player.hq) {
+      if (card.type === "item") {
+        const factory = ITEM_EFFECTS[card.definitionId];
+        if (factory) apply(factory(card, player.id).reveals);
+      } else if (card.type === "unit") {
+        const factory = UNIT_EFFECTS[card.definitionId];
+        if (factory) apply(factory(card, player.id).reveals);
+      }
+    }
+  }
+
+  result.revealedTrapIds = Array.from(trapIds);
+  return result;
 }

--- a/engine/src/visible-state.ts
+++ b/engine/src/visible-state.ts
@@ -72,8 +72,10 @@ export function getVisibleState(
     seedingStep:
       state.phase === "seeding" ? state.seedingState.step : undefined,
     // pickPrompt is private to the picker — peek() options must not leak to opponents.
+    // Surfaces in both main and seeding phases so passives like Scholar's
+    // top-5 reorder can prompt during seeding.
     pickPrompt:
-      state.phase === "main" && state.pickPrompt?.playerId === playerId
+      state.phase !== "ended" && state.pickPrompt?.playerId === playerId
         ? state.pickPrompt
         : undefined,
     winner: state.phase === "ended" ? state.winner : undefined,


### PR DESCRIPTION
## Summary

Wire alpha-1 cards whose ability text exists in CSV but has no engine implementation. Four cards (Spymaster seeding override, Scholar Investigate, Spymaster trap-decoy passive, Spartacus) were carved out to [#45](https://github.com/lalli-oni/cards/issues/45) for redesign — they're blocked on missing primitives or out of proportion to gameplay value.

## In-scope cards (5 wired)

| # | Card | Type | Ability | Status |
|---|---|---|---|---|
| 1 | Spymaster — Infiltrate | policy action | `Infiltrate:1:reveal(opponent + hand)` | ✅ |
| 2 | Mary Shelley | unit | First event/turn costs 0 AP | ✅ |
| 3 | Alexandria Harbor | location | Owner peeks top of own main deck | ✅ |
| 4 | Spy Glass | item | Equipped unit sees face-down traps at its location | ✅ |
| 5 | Scholar — seeding reorder | policy seeding | After deck build, reorder top 5 of own main deck | ✅ |

## Out of scope (flagged to #45)

- **Spymaster seeding override** — no-op vs current engine ([comment](https://github.com/lalli-oni/cards/issues/45#issuecomment-4639944163))
- **Scholar Investigate** — blocked on missing dilemma card type ([comment](https://github.com/lalli-oni/cards/issues/45#issuecomment-4639944163))
- **Spymaster trap decoy** — pending redesign decision ([comment](https://github.com/lalli-oni/cards/issues/45#issuecomment-4639944163))
- **Spartacus** — text assumes per-pair kill/injure choice; engine auto-resolves combat ([comment](https://github.com/lalli-oni/cards/issues/45#issuecomment-4640029777))

## Engine infra added

1. **`UNIT_EFFECTS` registry** — mirrors `POLICY_EFFECTS`. Scaffolding for unit-level passives. ✅
2. **`POLICY_ACTIONS` registry** — activatable policy actions until #68 lands CSV extraction. ✅
3. **VisibleState reveals channel** — `EffectDefinition.reveals` + per-viewer aggregation. Reusable by #111. ✅
4. **`pickPrompt` on `GameStateBase`** as a discriminated union — `deck_pick` (existing) and `scholar_reorder` (new, ordered permutation). ✅
5. **New seeding step `post_policy_pick`** + `pendingPostPolicyPicks` queue, discriminated-union'd into `SeedingState`. ✅

## Iteration log

| Phase | Date | Note |
|---|---|---|
| A | 2026-06-06 | Mary Shelley + Spymaster Infiltrate wired; AP modifier routing fix; policy action dispatch |
| B | 2026-06-06 | Alexandria Harbor + Spy Glass wired; VisibleState `reveals` channel + per-viewer trap un-redaction |
| C | 2026-06-06 | Spartacus carved out to #45 (combat-model mismatch) |
| D | 2026-06-06 | Scholar's post-policy reorder wired; seeding-phase pickPrompt + ordered variant + `post_policy_pick` step |
| Review | 2026-06-06 | Multi-agent review (5 agents, 31 findings). Discriminated unions for PickPrompt/SeedingState; invariant throws for finalizeSeeding/openScholarReorderPrompt/handleSeedingResolvePick/computeReveals; getResolvePickActions enumerates permutations for ordered prompts; getValidActions routes play_event through getModifiedAPCost; DevPreview.svelte updated for required TrapView.cardId + VisibleState.reveals; 9 new tests. |

## Test plan
- [x] Mary Shelley: first event/turn costs 0 AP (HQ + grid); surfaces at AP=0 via getValidActions
- [x] Spymaster Infiltrate: activating spends 1 AP and emits cards_revealed; not surfaced at AP=0; empty opponent hand handled
- [x] Alexandria Harbor: owner sees top of own main deck while location is on grid
- [x] Spy Glass: trap content visible to equipped unit's owner when co-located; redacted otherwise (HQ-stored, non-location cell, not equipped, wrong viewer)
- [x] Scholar: post-policy reorder prompt opens for Scholar holders; chosen order persists; queue drains monotonically in turn order; no Scholar = straight to main
- [x] TrapView.cardId always present (redacted + revealed)
- [x] All engine tests pass (428/428); workspace tests pass (462/462); library builds clean (66 cards)

## Total surface

4 commits · 16 files touched · ~1200 lines net.

Closes #107.
Unblocks #68 (DSL migration can now sweep everything in one batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)