### PR TITLE
#111 — Engine + client: opponent hand reveal (Galileo + Spymaster Infiltrate)

### DIFF
--- a/clients/web/src/App.svelte
+++ b/clients/web/src/App.svelte
@@ -17,6 +17,7 @@
   import EventLog from "./components/EventLog.svelte";
   import CombatResultPopup from "./components/CombatResultPopup.svelte";
   import PickPromptOverlay from "./components/PickPromptOverlay.svelte";
+  import ViewPromptOverlay from "./components/ViewPromptOverlay.svelte";
   // TODO: Remove DevPreview import and /#dev route once quick-start variant (#82) lands
   import DevPreview from "./DevPreview.svelte";
 
@@ -73,6 +74,10 @@
 
     {#if vs?.pickPrompt}
       <PickPromptOverlay />
+    {/if}
+
+    {#if vs?.viewPrompt}
+      <ViewPromptOverlay />
     {/if}
 
     {#if vs}

--- a/clients/web/src/components/ActionPanel.svelte
+++ b/clients/web/src/components/ActionPanel.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import type { Action } from "cards-engine";
   import { groupActions, describeAction } from "../lib/actionGroups";
-  import { selectAction, resolveCardName } from "../lib/gameStore.svelte";
+  import {
+    resolveActionTooltip,
+    resolveCardName,
+    selectAction,
+  } from "../lib/gameStore.svelte";
 
   interface Props {
     actions: Action[];
@@ -49,6 +53,7 @@
       <div>
         <button
           onclick={() => handleGroupClick(group.type, group.actions)}
+          title={group.actions.length === 1 ? resolveActionTooltip(group.actions[0]) : undefined}
           class="w-full rounded px-3 py-1.5 text-left text-sm transition-colors
             {expandedGroup === group.type
             ? 'bg-highlight-bg text-highlight'
@@ -67,6 +72,7 @@
             {#each group.actions as action}
               <button
                 onclick={() => handleActionClick(action)}
+                title={resolveActionTooltip(action)}
                 class="w-full rounded px-3 py-1 text-left text-xs text-text-secondary bg-surface-raised/50 hover:bg-surface-hover"
               >
                 {describeAction(action, resolveCardName)}

--- a/clients/web/src/components/ViewPromptOverlay.svelte
+++ b/clients/web/src/components/ViewPromptOverlay.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getVisibleState, selectAction } from "../lib/gameStore.svelte";
+  import { getError, getVisibleState, selectAction } from "../lib/gameStore.svelte";
   import CardView from "./CardView.svelte";
   import Modal from "./Modal.svelte";
 
@@ -18,6 +18,15 @@
   $effect(() => {
     void prompt?.cards.length;
     submitted = false;
+  });
+
+  // If the engine surfaces an error while we're mid-submit, unlock the
+  // button so the user can retry. Mirrors PickPromptOverlay's recovery
+  // pattern — guards against any error path (engine reject, controller
+  // failure, save error) leaving the button stuck on "Dismissing…".
+  const error = $derived(getError());
+  $effect(() => {
+    if (error && submitted) submitted = false;
   });
 
   function dismiss(): void {

--- a/clients/web/src/components/ViewPromptOverlay.svelte
+++ b/clients/web/src/components/ViewPromptOverlay.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import { getVisibleState, selectAction } from "../lib/gameStore.svelte";
+  import CardView from "./CardView.svelte";
+  import Modal from "./Modal.svelte";
+
+  const vs = $derived(getVisibleState());
+  const prompt = $derived(vs?.viewPrompt);
+  const sourceName: string = $derived(
+    vs?.opponents.find((o) => o.id === prompt?.sourcePlayerId)?.name
+      ?? prompt?.sourcePlayerId
+      ?? "",
+  );
+
+  let submitted = $state(false);
+
+  // Reset submit lock when the prompt changes (defensive — today the outer
+  // `{#if vs?.viewPrompt}` unmounts on dismiss).
+  $effect(() => {
+    void prompt?.cards.length;
+    submitted = false;
+  });
+
+  function dismiss(): void {
+    if (!prompt || submitted) return;
+    submitted = true;
+    selectAction({ type: "dismiss_view", playerId: prompt.playerId });
+  }
+</script>
+
+{#if prompt}
+  <Modal width="w-auto max-w-3xl">
+    <h3 class="mb-2 text-center text-lg font-bold text-text-primary">
+      {sourceName}'s hand
+    </h3>
+    <p class="mb-4 text-center text-sm text-text-muted">
+      {#if prompt.cards.length === 0}
+        Hand is empty.
+      {:else}
+        {prompt.cards.length} card{prompt.cards.length === 1 ? "" : "s"}.
+      {/if}
+    </p>
+
+    {#if prompt.cards.length > 0}
+      <div class="mb-4 flex flex-wrap justify-center gap-3">
+        {#each prompt.cards as card (card.id)}
+          <CardView {card} />
+        {/each}
+      </div>
+    {/if}
+
+    <button
+      onclick={dismiss}
+      disabled={submitted}
+      class="w-full rounded bg-amber-600 py-2 font-semibold text-white hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {submitted ? "Dismissing…" : "Dismiss"}
+    </button>
+  </Modal>
+{/if}

--- a/clients/web/src/lib/__tests__/gameSetup.test.ts
+++ b/clients/web/src/lib/__tests__/gameSetup.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+import type { PlayerDescriptor } from "cards-engine";
+import { buildMainSetup, DEFAULT_CONFIG } from "../gameSetup";
+
+const TWO_PLAYERS: PlayerDescriptor[] = [
+  { id: "p1", name: "Alice" },
+  { id: "p2", name: "Bob" },
+];
+
+function getActivePolicyDefIds(seed: string): Record<string, string[]> {
+  const setup = buildMainSetup(TWO_PLAYERS, DEFAULT_CONFIG, seed);
+  if (setup.mode !== "main") throw new Error("expected main-mode setup");
+  return Object.fromEntries(
+    Object.entries(setup.decks).map(([playerId, deck]) => [
+      playerId,
+      deck.activePolicies.map((p) => p.definitionId),
+    ]),
+  );
+}
+
+describe("buildMainSetup — policy assignment", () => {
+  it("assigns 2 active policies per player (matching the seeded policy_selection flow)", () => {
+    const policies = getActivePolicyDefIds("seed-1");
+    expect(policies.p1).toHaveLength(2);
+    expect(policies.p2).toHaveLength(2);
+  });
+
+  it("is deterministic for a given seed", () => {
+    const first = getActivePolicyDefIds("seed-abc");
+    const second = getActivePolicyDefIds("seed-abc");
+    expect(second).toEqual(first);
+  });
+
+  it("does NOT give every player the same first policy (the militarist bug)", () => {
+    // Sample several seeds — if the shuffle is wired the assignment varies.
+    // The pre-fix code returned `playerPolicies[0]` (always the first definition
+    // in library order, "militarist") for every player on every seed; a single
+    // counter-example in this sample is enough to prove the bug is fixed.
+    const seeds = ["aaa", "bbb", "ccc", "ddd", "eee"];
+    const observedFirstPolicies = new Set<string>();
+    for (const seed of seeds) {
+      const policies = getActivePolicyDefIds(seed);
+      observedFirstPolicies.add(policies.p1[0]);
+      observedFirstPolicies.add(policies.p2[0]);
+    }
+    expect(observedFirstPolicies.size).toBeGreaterThan(1);
+  });
+
+  it("assigns independent policies to each player within a single setup", () => {
+    // Each player's pool is shuffled independently via the same rng chain, so
+    // p1 and p2 should not get identical policy sets on every seed. Sample
+    // across several seeds and assert at least one disagreement.
+    const seeds = ["aaa", "bbb", "ccc", "ddd", "eee"];
+    let sawDisagreement = false;
+    for (const seed of seeds) {
+      const policies = getActivePolicyDefIds(seed);
+      const p1Set = new Set(policies.p1);
+      const p2Set = new Set(policies.p2);
+      if (p1Set.size !== p2Set.size || [...p1Set].some((id) => !p2Set.has(id))) {
+        sawDisagreement = true;
+        break;
+      }
+    }
+    expect(sawDisagreement).toBe(true);
+  });
+});

--- a/clients/web/src/lib/__tests__/pickPrompt.test.ts
+++ b/clients/web/src/lib/__tests__/pickPrompt.test.ts
@@ -20,7 +20,7 @@ function makeUnit(id: string): UnitCard {
 }
 
 function makePrompt(options: [string, ...string[]], count = 1): PickPrompt {
-  return { playerId: "p1", options, count, source: "main_deck" };
+  return { kind: "deck_pick", playerId: "p1", options, count, source: "main_deck" };
 }
 
 describe("resolvePickOptions", () => {

--- a/clients/web/src/lib/eventDescriptions.ts
+++ b/clients/web/src/lib/eventDescriptions.ts
@@ -122,8 +122,6 @@ export function describeEvent(event: GameEvent, r?: NameResolvers): string {
       return `${p(event.playerId, r)} discarded ${c(event.cardId, r)} (${event.reason})`;
     case "unit_buffed":
       return `${c(event.unitId, r)} got ${event.delta > 0 ? "+" : ""}${event.delta} ${event.stat}`;
-    case "cards_revealed":
-      return `${p(event.playerId, r)} revealed ${event.cardIds.length} card(s)`;
     case "cards_peeked":
       return `${p(event.playerId, r)} peeked at ${event.cardIds.length} card(s)`;
     case "cards_picked":

--- a/clients/web/src/lib/gameSetup.ts
+++ b/clients/web/src/lib/gameSetup.ts
@@ -96,7 +96,14 @@ export function buildMainSetup(
   for (const p of players) {
     const playerLocs = shuffleCards(instantiateCards(locations, p.id, counter));
     const playerOther = shuffleCards(instantiateCards(other, p.id, counter));
-    const playerPolicies = instantiateCards(policies, p.id, counter) as PolicyCard[];
+    // Shuffle the policy pool with the seed-driven rng (mirrors the full
+    // seeding flow in engine/src/apply-seeding.ts) and assign 2 — matching
+    // the count assigned during policy_selection. Without the shuffle every
+    // skip-seeded game gave both players the first policy in library order
+    // (deterministic Militarist start).
+    const playerPolicies = shuffleCards(
+      instantiateCards(policies, p.id, counter) as PolicyCard[],
+    );
 
     const hand = playerOther.splice(0, handSize);
     // Split remaining cards: half to main deck, half to market deck
@@ -109,7 +116,7 @@ export function buildMainSetup(
       mainDeck,
       prospectDeck: playerLocs,
       marketDeck,
-      activePolicies: playerPolicies.length > 0 ? [playerPolicies[0]] : [],
+      activePolicies: playerPolicies.slice(0, 2),
     };
   }
 

--- a/clients/web/src/lib/gameStore.svelte.ts
+++ b/clients/web/src/lib/gameStore.svelte.ts
@@ -2,6 +2,8 @@ import {
   GameController,
   getVisibleState as engineGetVisibleState,
   type Action,
+  type ActionDef,
+  type Card,
   type GameEvent,
   type GameState,
   type PlayerDescriptor,
@@ -112,6 +114,42 @@ let _cardNameMap = $derived.by(() => {
 
 export function resolveCardName(id: string): string {
   return _cardNameMap.get(id) ?? id;
+}
+
+/**
+ * Tooltip text for an `activate` action — looks up the source card and its
+ * named action. For policies, `action.effect` is human-readable prose. For
+ * units/items, the action `effect` is DSL, so we fall back to the card's
+ * `text` field which carries the player-facing description.
+ */
+export function resolveActionTooltip(action: Action): string | undefined {
+  if (action.type !== "activate") return undefined;
+  const vs = _visibleState;
+  if (!vs) return undefined;
+  const zones: Card[][] = [
+    vs.self.hq as Card[],
+    vs.self.activePolicies as Card[],
+    ...vs.grid.flatMap((row) =>
+      row.flatMap((cell): Card[][] => [
+        cell.units as Card[],
+        cell.items as Card[],
+        cell.location ? [cell.location as Card] : [],
+      ]),
+    ),
+  ];
+  for (const zone of zones) {
+    for (const card of zone) {
+      if (card.id !== action.cardId) continue;
+      const actions: ActionDef[] | undefined =
+        "actions" in card ? card.actions : undefined;
+      const def = actions?.find((a) => a.name === action.actionName);
+      // Policies: action.effect is human-readable prose. Units/items: card.text
+      // is the player-facing description (action.effect is DSL).
+      if (card.type === "policy") return def?.effect ?? card.text ?? undefined;
+      return card.text ?? undefined;
+    }
+  }
+  return undefined;
 }
 export function resolvePlayerName(id: string): string {
   const p = players.find((pl) => pl.id === id);

--- a/engine/src/__tests__/effect-dsl-verbs.test.ts
+++ b/engine/src/__tests__/effect-dsl-verbs.test.ts
@@ -10,7 +10,6 @@ const EXPECTED: Record<Verb, boolean> = {
   peek: true,
   pick: true,
   buy: true,
-  reveal: true,
   kill: false,
   injure: false,
   buff: false,

--- a/engine/src/__tests__/listeners.test.ts
+++ b/engine/src/__tests__/listeners.test.ts
@@ -1051,18 +1051,18 @@ describe("AP modifier queries", () => {
     expect(getModifiedAPCost(state, queries, opponentPlayEvent, 1)).toBe(1);
   });
 
-  it("Spymaster Infiltrate: activating the policy reveals an opponent's hand and spends 1 AP", () => {
+  it("Spymaster Infiltrate: activating the policy peeks an opponent's hand, sets viewPrompt, and spends 1 AP", () => {
     const initial = gameWith((d, p) => {
       d.players[p.activeIdx].activePolicies.push(
         makePolicy({ ownerId: p.active, definitionId: "spymaster" }),
       );
-      // Put some cards in the opponent's hand to be revealed.
+      // Put some cards in the opponent's hand to be peeked.
       d.players[p.otherIdx].hand.push(
         makeInstantEvent({ ownerId: p.other }),
         makeInstantEvent({ ownerId: p.other }),
       );
     });
-    const { active } = getPlayers(initial);
+    const { active, other } = getPlayers(initial);
     const apBefore = initial.turn.actionPointsRemaining;
     const spymaster = initial.players.find((p) => p.id === active)!.activePolicies[0];
 
@@ -1075,10 +1075,15 @@ describe("AP modifier queries", () => {
     const after = state as MainGameState;
 
     expect(after.turn.actionPointsRemaining).toBe(apBefore - 1);
-    const revealed = events.find((e) => e.type === "cards_revealed");
-    expect(revealed).toBeDefined();
-    expect((revealed as any).playerId).toBe(active);
-    expect((revealed as any).cardIds.length).toBe(2);
+    expect(after.viewPrompt?.playerId).toBe(active);
+    expect(after.viewPrompt?.source).toBe("opponent_hand");
+    expect(after.viewPrompt?.sourcePlayerId).toBe(other);
+    expect(after.viewPrompt?.cards.length).toBe(2);
+    const peeked = events.find((e) => e.type === "cards_peeked");
+    expect(peeked).toBeDefined();
+    expect((peeked as any).playerId).toBe(active);
+    expect((peeked as any).cardIds.length).toBe(2);
+    expect((peeked as any).source).toBe("opponent_hand");
   });
 
   it("Mary Shelley on the grid: first play_event still 0 AP (grid factory branch)", () => {
@@ -1124,7 +1129,7 @@ describe("AP modifier queries", () => {
     expect(playEvent.length).toBeGreaterThan(0);
   });
 
-  it("Spymaster Infiltrate: empty opponent hand emits cards_revealed with empty cardIds", () => {
+  it("Spymaster Infiltrate: empty opponent hand still emits cards_peeked and sets an empty viewPrompt", () => {
     const initial = gameWith((d, p) => {
       d.players[p.activeIdx].activePolicies.push(
         makePolicy({ ownerId: p.active, definitionId: "spymaster" }),
@@ -1133,16 +1138,18 @@ describe("AP modifier queries", () => {
     });
     const { active } = getPlayers(initial);
     const spymaster = initial.players.find((p) => p.id === active)!.activePolicies[0];
-    const { events } = applyAction(initial, {
+    const { state, events } = applyAction(initial, {
       type: "activate",
       playerId: active,
       cardId: spymaster.id,
       actionName: "Infiltrate",
     });
-    const revealed = events.find((e) => e.type === "cards_revealed");
-    expect(revealed).toBeDefined();
-    expect((revealed as any).cardIds).toEqual([]);
-    expect((revealed as any).source).toBe("opponent_hand");
+    const after = state as MainGameState;
+    expect(after.viewPrompt?.cards).toEqual([]);
+    const peeked = events.find((e) => e.type === "cards_peeked");
+    expect(peeked).toBeDefined();
+    expect((peeked as any).cardIds).toEqual([]);
+    expect((peeked as any).source).toBe("opponent_hand");
   });
 
   it("Mary Shelley: applyAction(play_event) spends 0 AP for first event, 1 AP for second", () => {

--- a/engine/src/__tests__/reveal-pick.test.ts
+++ b/engine/src/__tests__/reveal-pick.test.ts
@@ -66,7 +66,6 @@ describe("reveal > pick — player choice required", () => {
     expect(ns.players[ACTIVE_IDX].hand).toHaveLength(0);
     expect(ns.players[ACTIVE_IDX].mainDeck).toHaveLength(3);
     expect(events.some((e) => e.type === "cards_peeked")).toBe(true);
-    expect(events.some((e) => e.type === "cards_revealed")).toBe(false);
     expect(events.some((e) => e.type === "cards_picked")).toBe(false);
   });
 

--- a/engine/src/__tests__/reveal-pick.test.ts
+++ b/engine/src/__tests__/reveal-pick.test.ts
@@ -404,6 +404,36 @@ describe("DSL validator: positive counts", () => {
   });
 });
 
+describe("DSL validator: peek(opponent + hand)", () => {
+  it("accepts the standalone form (no count, no chain)", () => {
+    expect(() => parse("peek(opponent + hand)")).not.toThrow();
+  });
+
+  it("rejects an explicit count — the full hand is always revealed", () => {
+    expect(() => parse("peek(opponent + hand)[3]")).toThrow(
+      /does not accept a count/,
+    );
+  });
+
+  it("rejects a chained pick — viewPrompt suspends; the pick would silently drop", () => {
+    expect(() => parse("peek(opponent + hand) > pick[1]")).toThrow(
+      DSLValidationError,
+    );
+  });
+
+  it("rejects a trailing step in the same chain", () => {
+    expect(() => parse("peek(opponent + hand) > draw[1]")).toThrow(
+      /must be the terminal primitive/,
+    );
+  });
+
+  it("rejects a later chain joined by `+`", () => {
+    expect(() => parse("peek(opponent + hand) + draw[1]")).toThrow(
+      /must be the terminal primitive/,
+    );
+  });
+});
+
 describe("getValidActions precondition: peek(deck) with empty deck", () => {
   it("filters out the activate action when the deck is empty", () => {
     // Build a scenario where Ada is on the grid but the deck is empty.

--- a/engine/src/__tests__/valid-actions.test.ts
+++ b/engine/src/__tests__/valid-actions.test.ts
@@ -34,6 +34,8 @@ describe("getValidActions", () => {
         ...base,
         phase: "ended",
         scores: {},
+        pickPrompt: undefined,
+        viewPrompt: undefined,
       };
       const actions = getValidActions(
         endedState,
@@ -62,7 +64,13 @@ describe("getValidActions", () => {
 
     it("throws for ended phase", () => {
       const base = createTestGame();
-      const endedState: EndedGameState = { ...base, phase: "ended", scores: {} };
+      const endedState: EndedGameState = {
+        ...base,
+        phase: "ended",
+        scores: {},
+        pickPrompt: undefined,
+        viewPrompt: undefined,
+      };
       expect(() => getActivePlayerId(endedState)).toThrow(
         "No active player in ended phase",
       );

--- a/engine/src/__tests__/view-prompt.test.ts
+++ b/engine/src/__tests__/view-prompt.test.ts
@@ -1,0 +1,244 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { produce } from "immer";
+import { applyAction } from "../apply-action";
+import { getValidActions } from "../valid-actions";
+import { getVisibleState } from "../visible-state";
+import type { MainGameState, UnitCard } from "../types";
+import { createTestGame, makeUnit, resetIds } from "./helpers";
+
+beforeEach(() => resetIds());
+
+// Active player under SEED="test-seed" (matches reveal-pick.test.ts).
+const ACTIVE = "p2";
+const OPPONENT = "p1";
+const ACTIVE_IDX = 0;
+const OPPONENT_IDX = 1;
+
+function gameWith(fn: (draft: MainGameState) => void): MainGameState {
+  return produce(createTestGame(), fn);
+}
+
+function makeObserver(): UnitCard {
+  return makeUnit({
+    ownerId: ACTIVE,
+    actions: [
+      { name: "observe", apCost: 1, effect: "peek(opponent + hand)" },
+    ],
+  });
+}
+
+function setupObserveScenario() {
+  const observer = makeObserver();
+  const oppCard1 = makeUnit({ ownerId: OPPONENT, name: "OppCard1" });
+  const oppCard2 = makeUnit({ ownerId: OPPONENT, name: "OppCard2" });
+  const state = gameWith((d) => {
+    d.grid[0][0].units.push(observer);
+    d.players[OPPONENT_IDX].hand.push(oppCard1, oppCard2);
+  });
+  return { state, observer, oppCard1, oppCard2 };
+}
+
+describe("peek(opponent + hand) — view prompt", () => {
+  it("sets viewPrompt with opponent's full hand cards", () => {
+    const { state, observer, oppCard1, oppCard2 } = setupObserveScenario();
+
+    const { state: next } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: observer.id,
+      actionName: "observe",
+    });
+    const ns = next as MainGameState;
+
+    expect(ns.viewPrompt).toBeDefined();
+    expect(ns.viewPrompt?.playerId).toBe(ACTIVE);
+    expect(ns.viewPrompt?.source).toBe("opponent_hand");
+    expect(ns.viewPrompt?.sourcePlayerId).toBe(OPPONENT);
+    expect(ns.viewPrompt?.cards.map((c) => c.id)).toEqual([oppCard1.id, oppCard2.id]);
+  });
+
+  it("emits cards_peeked with source=opponent_hand", () => {
+    const { state, observer, oppCard1, oppCard2 } = setupObserveScenario();
+
+    const { events } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: observer.id,
+      actionName: "observe",
+    });
+
+    const peeked = events.find((e) => e.type === "cards_peeked");
+    expect(peeked).toEqual({
+      type: "cards_peeked",
+      playerId: ACTIVE,
+      cardIds: [oppCard1.id, oppCard2.id],
+      source: "opponent_hand",
+    });
+  });
+
+  it("does not mutate opponent's hand", () => {
+    const { state, observer, oppCard1, oppCard2 } = setupObserveScenario();
+
+    const { state: next } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: observer.id,
+      actionName: "observe",
+    });
+    const ns = next as MainGameState;
+
+    expect(ns.players[OPPONENT_IDX].hand.map((c) => c.id)).toEqual([
+      oppCard1.id,
+      oppCard2.id,
+    ]);
+  });
+
+  it("getVisibleState exposes viewPrompt to the viewer", () => {
+    const { state, observer, oppCard1, oppCard2 } = setupObserveScenario();
+    const { state: paused } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: observer.id,
+      actionName: "observe",
+    });
+
+    const vs = getVisibleState(paused, ACTIVE);
+    expect(vs.viewPrompt?.source).toBe("opponent_hand");
+    expect(vs.viewPrompt?.cards.map((c) => c.id)).toEqual([oppCard1.id, oppCard2.id]);
+  });
+
+  it("getVisibleState hides viewPrompt from the opponent", () => {
+    const { state, observer } = setupObserveScenario();
+    const { state: paused } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: observer.id,
+      actionName: "observe",
+    });
+
+    const opponentView = getVisibleState(paused, OPPONENT);
+    expect(opponentView.viewPrompt).toBeUndefined();
+    // Opponent's own hand is still visible to them via self (not redacted).
+    expect(opponentView.self.hand).toHaveLength(2);
+  });
+
+  it("getValidActions returns only dismiss_view for the viewer while paused", () => {
+    const { state, observer } = setupObserveScenario();
+    const { state: paused } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: observer.id,
+      actionName: "observe",
+    });
+
+    const actions = getValidActions(paused, ACTIVE);
+    expect(actions).toEqual([{ type: "dismiss_view", playerId: ACTIVE }]);
+  });
+
+  it("rejects normal actions while viewPrompt is set", () => {
+    const { state, observer } = setupObserveScenario();
+    const { state: paused } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: observer.id,
+      actionName: "observe",
+    });
+
+    expect(() =>
+      applyAction(paused, { type: "pass", playerId: ACTIVE }),
+    ).toThrow("pending view must be dismissed first");
+  });
+
+  it("rejects dismiss_view when there is no pending view", () => {
+    const state = createTestGame();
+    expect(() =>
+      applyAction(state, { type: "dismiss_view", playerId: ACTIVE }),
+    ).toThrow("no pending view");
+  });
+
+  it("rejects dismiss_view from a player who isn't the pending viewer", () => {
+    const { state, observer } = setupObserveScenario();
+    const { state: paused } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: observer.id,
+      actionName: "observe",
+    });
+
+    expect(() =>
+      applyAction(paused, { type: "dismiss_view", playerId: OPPONENT }),
+    ).toThrow(/player "p1" rejected|pending view is for/);
+  });
+
+  it("dismiss_view clears viewPrompt and lets normal play resume", () => {
+    const { state, observer } = setupObserveScenario();
+    const { state: paused } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: observer.id,
+      actionName: "observe",
+    });
+
+    const { state: dismissed } = applyAction(paused, {
+      type: "dismiss_view",
+      playerId: ACTIVE,
+    });
+    const ns = dismissed as MainGameState;
+
+    expect(ns.viewPrompt).toBeUndefined();
+    // Normal actions should now be available again.
+    const actions = getValidActions(dismissed, ACTIVE);
+    expect(actions.some((a) => a.type === "pass")).toBe(true);
+  });
+
+  it("does not refund AP on dismiss", () => {
+    const { state, observer } = setupObserveScenario();
+    const apBefore = state.turn.actionPointsRemaining;
+    const { state: paused } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: observer.id,
+      actionName: "observe",
+    });
+    const apAfterActivate = (paused as MainGameState).turn.actionPointsRemaining;
+
+    const { state: dismissed } = applyAction(paused, {
+      type: "dismiss_view",
+      playerId: ACTIVE,
+    });
+    const ns = dismissed as MainGameState;
+
+    expect(apAfterActivate).toBe(apBefore - 1);
+    expect(ns.turn.actionPointsRemaining).toBe(apAfterActivate);
+  });
+});
+
+describe("Spymaster Infiltrate — view prompt via policy action", () => {
+  it("Infiltrate sets viewPrompt with opponent's hand", () => {
+    const oppCard = makeUnit({ ownerId: OPPONENT, name: "OppCard" });
+    const state = gameWith((d) => {
+      d.players[ACTIVE_IDX].activePolicies.push({
+        id: "spymaster-inst",
+        definitionId: "spymaster",
+        type: "policy",
+        name: "Spymaster",
+        cost: "0",
+        rarity: "epic",
+        effect: "",
+        ownerId: ACTIVE,
+      });
+      d.players[OPPONENT_IDX].hand.push(oppCard);
+    });
+
+    const { state: next } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: "spymaster-inst",
+      actionName: "Infiltrate",
+    });
+    const ns = next as MainGameState;
+
+    expect(ns.viewPrompt?.source).toBe("opponent_hand");
+    expect(ns.viewPrompt?.cards.map((c) => c.id)).toEqual([oppCard.id]);
+  });
+});

--- a/engine/src/__tests__/view-prompt.test.ts
+++ b/engine/src/__tests__/view-prompt.test.ts
@@ -3,8 +3,8 @@ import { produce } from "immer";
 import { applyAction } from "../apply-action";
 import { getValidActions } from "../valid-actions";
 import { getVisibleState } from "../visible-state";
-import type { MainGameState, UnitCard } from "../types";
-import { createTestGame, makeUnit, resetIds } from "./helpers";
+import type { MainAction, MainGameState, UnitCard } from "../types";
+import { createTestGame, makePolicy, makeUnit, resetIds } from "./helpers";
 
 beforeEach(() => resetIds());
 
@@ -135,19 +135,32 @@ describe("peek(opponent + hand) — view prompt", () => {
     expect(actions).toEqual([{ type: "dismiss_view", playerId: ACTIVE }]);
   });
 
-  it("rejects normal actions while viewPrompt is set", () => {
-    const { state, observer } = setupObserveScenario();
-    const { state: paused } = applyAction(state, {
-      type: "activate",
-      playerId: ACTIVE,
-      cardId: observer.id,
-      actionName: "observe",
-    });
+  // Parameterized lockout — guards against a narrowing of the dispatcher
+  // gate (e.g. accidentally matching only "pass") silently letting other
+  // actions slip through.
+  const lockedOutActions: { label: string; action: () => MainAction }[] = [
+    { label: "pass", action: () => ({ type: "pass", playerId: ACTIVE }) },
+    {
+      label: "deploy",
+      action: () => ({ type: "deploy", playerId: ACTIVE, cardId: "anything" }),
+    },
+    { label: "draw", action: () => ({ type: "draw", playerId: ACTIVE }) },
+  ];
+  for (const { label, action } of lockedOutActions) {
+    it(`rejects ${label} while viewPrompt is set`, () => {
+      const { state, observer } = setupObserveScenario();
+      const { state: paused } = applyAction(state, {
+        type: "activate",
+        playerId: ACTIVE,
+        cardId: observer.id,
+        actionName: "observe",
+      });
 
-    expect(() =>
-      applyAction(paused, { type: "pass", playerId: ACTIVE }),
-    ).toThrow("pending view must be dismissed first");
-  });
+      expect(() => applyAction(paused, action())).toThrow(
+        "pending view must be dismissed first",
+      );
+    });
+  }
 
   it("rejects dismiss_view when there is no pending view", () => {
     const state = createTestGame();
@@ -156,7 +169,7 @@ describe("peek(opponent + hand) — view prompt", () => {
     ).toThrow("no pending view");
   });
 
-  it("rejects dismiss_view from a player who isn't the pending viewer", () => {
+  it("rejects dismiss_view from a non-active player (outer active-player check)", () => {
     const { state, observer } = setupObserveScenario();
     const { state: paused } = applyAction(state, {
       type: "activate",
@@ -165,9 +178,35 @@ describe("peek(opponent + hand) — view prompt", () => {
       actionName: "observe",
     });
 
+    // Outer applyAction check fires first: the non-active player is rejected
+    // before handleDismissView sees the call.
     expect(() =>
       applyAction(paused, { type: "dismiss_view", playerId: OPPONENT }),
-    ).toThrow(/player "p1" rejected|pending view is for/);
+    ).toThrow(/it is player "p2"'s turn/);
+  });
+
+  it("rejects dismiss_view when the active player isn't the pending viewer (synthetic state)", () => {
+    // Synthetic: viewPrompt belongs to OPPONENT, but ACTIVE is the active
+    // player. The outer active-player check passes (the dismisser IS the
+    // active player), exposing handleDismissView's own ownership throw.
+    const observer = makeObserver();
+    const oppCard = makeUnit({ ownerId: OPPONENT, name: "OppCard" });
+    const base = gameWith((d) => {
+      d.grid[0][0].units.push(observer);
+      d.players[OPPONENT_IDX].hand.push(oppCard);
+    });
+    const tampered = produce(base, (d) => {
+      d.viewPrompt = {
+        playerId: OPPONENT,
+        cards: [oppCard],
+        source: "opponent_hand",
+        sourcePlayerId: ACTIVE,
+      };
+    });
+
+    expect(() =>
+      applyAction(tampered, { type: "dismiss_view", playerId: ACTIVE }),
+    ).toThrow(/pending view is for "p1", not "p2"/);
   });
 
   it("dismiss_view clears viewPrompt and lets normal play resume", () => {
@@ -215,25 +254,17 @@ describe("peek(opponent + hand) — view prompt", () => {
 
 describe("Spymaster Infiltrate — view prompt via policy action", () => {
   it("Infiltrate sets viewPrompt with opponent's hand", () => {
+    const spymaster = makePolicy({ ownerId: ACTIVE, definitionId: "spymaster" });
     const oppCard = makeUnit({ ownerId: OPPONENT, name: "OppCard" });
     const state = gameWith((d) => {
-      d.players[ACTIVE_IDX].activePolicies.push({
-        id: "spymaster-inst",
-        definitionId: "spymaster",
-        type: "policy",
-        name: "Spymaster",
-        cost: "0",
-        rarity: "epic",
-        effect: "",
-        ownerId: ACTIVE,
-      });
+      d.players[ACTIVE_IDX].activePolicies.push(spymaster);
       d.players[OPPONENT_IDX].hand.push(oppCard);
     });
 
     const { state: next } = applyAction(state, {
       type: "activate",
       playerId: ACTIVE,
-      cardId: "spymaster-inst",
+      cardId: spymaster.id,
       actionName: "Infiltrate",
     });
     const ns = next as MainGameState;

--- a/engine/src/__tests__/visible-state.test.ts
+++ b/engine/src/__tests__/visible-state.test.ts
@@ -165,6 +165,7 @@ describe("getVisibleState", () => {
         phase: "ended",
         scores: {},
         pickPrompt: undefined,
+        viewPrompt: undefined,
       };
       const vis = getVisibleState(endedState, "p1");
       expect(vis.phase).toBe("ended");

--- a/engine/src/__tests__/win-condition.test.ts
+++ b/engine/src/__tests__/win-condition.test.ts
@@ -3,7 +3,7 @@ import { produce } from "immer";
 import { applyAction } from "../apply-action";
 import type { MainGameState, EndedGameState, MainAction } from "../types";
 import { getActivePlayerId } from "../types";
-import { findSoleLeader, getScores, shouldEndGame } from "../win-condition";
+import { findSoleLeader, getScores, shouldEndGame, toEndedState } from "../win-condition";
 import { createTestGame, DEFAULT_CONFIG, resetIds } from "./helpers";
 
 beforeEach(() => resetIds());
@@ -97,6 +97,44 @@ describe("shouldEndGame", () => {
       d.players[0].vp = 10;
     });
     expect(shouldEndGame(withVp)).toBe(true);
+  });
+});
+
+// ---- toEndedState: prompt clearing ----
+
+describe("toEndedState", () => {
+  it("clears a populated viewPrompt when transitioning to ended", () => {
+    const base = createTestGame();
+    const opponentId = base.players.find(
+      (p) => p.id !== base.turn.activePlayerId,
+    )!.id;
+    const withPrompt = produce(base, (d) => {
+      d.viewPrompt = {
+        playerId: d.turn.activePlayerId,
+        cards: [],
+        source: "opponent_hand",
+        sourcePlayerId: opponentId,
+      };
+    });
+
+    const ended = toEndedState(withPrompt, base.turn.activePlayerId, []);
+    expect(ended.viewPrompt).toBeUndefined();
+  });
+
+  it("clears a populated pickPrompt when transitioning to ended", () => {
+    const base = createTestGame();
+    const withPrompt = produce(base, (d) => {
+      d.pickPrompt = {
+        kind: "deck_pick",
+        playerId: d.turn.activePlayerId,
+        options: ["card-1"],
+        count: 1,
+        source: "main_deck",
+      };
+    });
+
+    const ended = toEndedState(withPrompt, base.turn.activePlayerId, []);
+    expect(ended.pickPrompt).toBeUndefined();
   });
 });
 

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -995,6 +995,19 @@ export function applyMainAction(
   const events: GameEvent[] = [];
   let roundIncremented = false;
 
+  // Invariant: pickPrompt and viewPrompt are mutually exclusive. The
+  // executor's suspend guard in `effect-dsl/executor.ts` ensures producers
+  // never co-set them, but assert here so a future producer that bypasses the
+  // executor (e.g. a listener mutating state directly) fails loud instead of
+  // deadlocking the dispatcher.
+  if (state.pickPrompt && state.viewPrompt) {
+    throw new Error(
+      `applyMainAction invariant: both pickPrompt and viewPrompt are set ` +
+        `(picker="${state.pickPrompt.playerId}", viewer="${state.viewPrompt.playerId}") — ` +
+        `at most one prompt may be pending at a time`,
+    );
+  }
+
   if (state.pickPrompt && action.type !== "resolve_pick") {
     throw new Error(
       `Action "${action.type}" by "${action.playerId}" rejected: ` +

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -968,6 +968,22 @@ function handleResolvePick(
   draft.pickPrompt = undefined;
 }
 
+function handleDismissView(
+  draft: Draft<MainGameState>,
+  playerId: string,
+): void {
+  const prompt = draft.viewPrompt;
+  if (!prompt) {
+    throw new Error(`dismiss_view rejected: no pending view (by player "${playerId}")`);
+  }
+  if (prompt.playerId !== playerId) {
+    throw new Error(
+      `dismiss_view rejected: pending view is for "${prompt.playerId}", not "${playerId}"`,
+    );
+  }
+  draft.viewPrompt = undefined;
+}
+
 // ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
@@ -985,6 +1001,15 @@ export function applyMainAction(
         `pending pick must be resolved first ` +
         `(picker="${state.pickPrompt.playerId}", kind="${state.pickPrompt.kind}", ` +
         `options=[${state.pickPrompt.options.join(",")}])`,
+    );
+  }
+
+  if (state.viewPrompt && action.type !== "dismiss_view") {
+    throw new Error(
+      `Action "${action.type}" by "${action.playerId}" rejected: ` +
+        `pending view must be dismissed first ` +
+        `(viewer="${state.viewPrompt.playerId}", source="${state.viewPrompt.source}", ` +
+        `sourcePlayerId="${state.viewPrompt.sourcePlayerId}")`,
     );
   }
 
@@ -1055,6 +1080,10 @@ export function applyMainAction(
 
       case "resolve_pick":
         handleResolvePick(draft, action.playerId, action.pickedCardIds, emit);
+        break;
+
+      case "dismiss_view":
+        handleDismissView(draft, action.playerId);
         break;
 
       default: {

--- a/engine/src/card-loader.ts
+++ b/engine/src/card-loader.ts
@@ -324,6 +324,7 @@ export function instantiateCard(
         ...base,
         type: "policy",
         effect: def.effect,
+        actions: def.actions ?? undefined,
       } satisfies PolicyCard;
   }
 }

--- a/engine/src/effect-dsl/executor.ts
+++ b/engine/src/effect-dsl/executor.ts
@@ -58,14 +58,14 @@ export function executeEffect(
 
 function executeExpression(expr: Expression, ctx: ExecutionContext): void {
   for (const effect of expr) {
-    if (ctx.draft.pickPrompt) return;
+    if (ctx.draft.pickPrompt || ctx.draft.viewPrompt) return;
     executeEffectChain(effect, ctx);
   }
 }
 
 function executeEffectChain(effect: Effect, ctx: ExecutionContext): void {
   for (const step of effect) {
-    if (ctx.draft.pickPrompt) return;
+    if (ctx.draft.pickPrompt || ctx.draft.viewPrompt) return;
     executeStep(step, ctx);
   }
 }
@@ -101,8 +101,6 @@ function executePrimitive(p: Primitive, ctx: ExecutionContext): void {
       return execBuff(p, ctx);
     case "move":
       return execMove(p, ctx);
-    case "reveal":
-      return execReveal(p, ctx);
     case "peek":
       return execPeek(p, ctx);
     case "pick":
@@ -304,22 +302,34 @@ function execMove(p: Primitive, ctx: ExecutionContext): void {
   }
 }
 
-function execReveal(p: Primitive, ctx: ExecutionContext): void {
+// Private peek. Two selectors today:
+//   `peek(deck)[N]` — top N of own deck, stored in `_peekedCards` for a chained `pick`.
+//   `peek(opponent + hand)` — opponent's full hand, parked on `viewPrompt`
+//     (private to the active player) until they submit `dismiss_view`.
+// Both emit `cards_peeked` for engine record-keeping (replay, listeners, debug).
+// Privacy filtering of the event log is tracked separately (#105).
+function execPeek(p: Primitive, ctx: ExecutionContext): void {
   const tokenNames = p.target?.tokens.map((t) => t.name) ?? [];
 
   if (tokenNames.includes("opponent") && tokenNames.includes("hand")) {
     const opponent = ctx.draft.players.find((pl) => pl.id !== ctx.playerId);
     if (!opponent) return;
-    const cardIds = opponent.hand.map((c) => c.id);
-    ctx.emit({ type: "cards_revealed", playerId: ctx.playerId, cardIds, source: "opponent_hand" });
+    const cards = [...opponent.hand];
+    ctx.draft.viewPrompt = {
+      playerId: ctx.playerId,
+      cards: cards as Card[],
+      source: "opponent_hand",
+      sourcePlayerId: opponent.id,
+    };
+    ctx.emit({
+      type: "cards_peeked",
+      playerId: ctx.playerId,
+      cardIds: cards.map((c) => c.id),
+      source: "opponent_hand",
+    });
+    return;
   }
-}
 
-// Private peek: look at top N of own deck, store for a chained `pick`.
-// Emits `cards_peeked` for engine record-keeping (replay, listeners, debug).
-// Privacy filtering of the event log is tracked separately.
-function execPeek(p: Primitive, ctx: ExecutionContext): void {
-  const tokenNames = p.target?.tokens.map((t) => t.name) ?? [];
   if (!tokenNames.includes("deck")) return;
 
   const count = p.value ?? 0;

--- a/engine/src/effect-dsl/executor.ts
+++ b/engine/src/effect-dsl/executor.ts
@@ -58,19 +58,23 @@ export function executeEffect(
 
 function executeExpression(expr: Expression, ctx: ExecutionContext): void {
   for (const effect of expr) {
-    if (ctx.draft.pickPrompt || ctx.draft.viewPrompt) return;
     executeEffectChain(effect, ctx);
   }
 }
 
 function executeEffectChain(effect: Effect, ctx: ExecutionContext): void {
   for (const step of effect) {
-    if (ctx.draft.pickPrompt || ctx.draft.viewPrompt) return;
     executeStep(step, ctx);
   }
 }
 
 function executeStep(step: Step, ctx: ExecutionContext): void {
+  // Single suspend guard: once any verb has set pickPrompt or viewPrompt,
+  // every subsequent step (including contest consequence steps which call
+  // executeStep recursively) no-ops. Placing the guard here — rather than at
+  // the outer loops — covers every call site uniformly.
+  if (ctx.draft.pickPrompt || ctx.draft.viewPrompt) return;
+
   const p = step.primitive;
 
   if (p.verb === "contest") {
@@ -304,8 +308,10 @@ function execMove(p: Primitive, ctx: ExecutionContext): void {
 
 // Private peek. Two selectors today:
 //   `peek(deck)[N]` — top N of own deck, stored in `_peekedCards` for a chained `pick`.
-//   `peek(opponent + hand)` — opponent's full hand, parked on `viewPrompt`
-//     (private to the active player) until they submit `dismiss_view`.
+//   `peek(opponent + hand)` — full hand of the first non-active player (multi-
+//     opponent target selection not yet implemented; see #94 / task notes on
+//     #111), parked on `viewPrompt` (private to the active player) until they
+//     submit `dismiss_view`.
 // Both emit `cards_peeked` for engine record-keeping (replay, listeners, debug).
 // Privacy filtering of the event log is tracked separately (#105).
 function execPeek(p: Primitive, ctx: ExecutionContext): void {
@@ -313,7 +319,11 @@ function execPeek(p: Primitive, ctx: ExecutionContext): void {
 
   if (tokenNames.includes("opponent") && tokenNames.includes("hand")) {
     const opponent = ctx.draft.players.find((pl) => pl.id !== ctx.playerId);
-    if (!opponent) return;
+    if (!opponent) {
+      throw new Error(
+        `peek(opponent + hand): no opponent found for player "${ctx.playerId}"`,
+      );
+    }
     const cards = [...opponent.hand];
     ctx.draft.viewPrompt = {
       playerId: ctx.playerId,

--- a/engine/src/effect-dsl/validate.ts
+++ b/engine/src/effect-dsl/validate.ts
@@ -10,8 +10,10 @@ export class DSLValidationError extends Error {
 // Static rules for `peek` and `pick`:
 //
 //   peek:
-//     - count >= 1 (zero or negative makes no sense; the executor stores []
-//       which then no-ops on pick).
+//     - For `peek(deck)`: count >= 1 (zero or negative makes no sense; the
+//       executor stores [] which then no-ops on pick).
+//     - For `peek(opponent + hand)`: no count required — the whole hand is
+//       shown via `viewPrompt`; there is no chained `pick` consumer.
 //
 //   pick:
 //     - count >= 1 (default 1 if omitted).
@@ -30,11 +32,15 @@ export function validateEffectChain(ast: Expression): void {
     effect.forEach((step, stepIdx) => {
       if (step.primitive.verb === "peek") {
         sawProducer = true;
-        const value = step.primitive.value ?? 0;
-        if (value < 1) {
-          throw new DSLValidationError(
-            `'peek' requires a positive count (got ${value})`,
-          );
+        const tokens = step.primitive.target?.tokens.map((t) => t.name) ?? [];
+        const isOpponentHand = tokens.includes("opponent") && tokens.includes("hand");
+        if (!isOpponentHand) {
+          const value = step.primitive.value ?? 0;
+          if (value < 1) {
+            throw new DSLValidationError(
+              `'peek' requires a positive count (got ${value})`,
+            );
+          }
         }
       }
       if (step.primitive.verb !== "pick") return;

--- a/engine/src/effect-dsl/validate.ts
+++ b/engine/src/effect-dsl/validate.ts
@@ -12,8 +12,10 @@ export class DSLValidationError extends Error {
 //   peek:
 //     - For `peek(deck)`: count >= 1 (zero or negative makes no sense; the
 //       executor stores [] which then no-ops on pick).
-//     - For `peek(opponent + hand)`: no count required — the whole hand is
-//       shown via `viewPrompt`; there is no chained `pick` consumer.
+//     - For `peek(opponent + hand)`: count must NOT be supplied — the whole
+//       hand is revealed. Must be the terminal step of the last effect chain
+//       (suspends execution via `viewPrompt`; anything after it would be
+//       silently dropped when execution resumes after `dismiss_view`).
 //
 //   pick:
 //     - count >= 1 (default 1 if omitted).
@@ -34,7 +36,21 @@ export function validateEffectChain(ast: Expression): void {
         sawProducer = true;
         const tokens = step.primitive.target?.tokens.map((t) => t.name) ?? [];
         const isOpponentHand = tokens.includes("opponent") && tokens.includes("hand");
-        if (!isOpponentHand) {
+        if (isOpponentHand) {
+          if (step.primitive.value !== undefined) {
+            throw new DSLValidationError(
+              `'peek(opponent + hand)' does not accept a count (got [${step.primitive.value}]) — the full hand is revealed`,
+            );
+          }
+          const isLastStep = stepIdx === effect.length - 1;
+          const isLastEffect = effectIdx === ast.length - 1;
+          if (!isLastStep || !isLastEffect) {
+            throw new DSLValidationError(
+              `'peek(opponent + hand)' must be the terminal primitive of the last effect chain in an expression ` +
+                `(chain #${effectIdx} of ${ast.length - 1}, step ${stepIdx} of ${effect.length - 1})`,
+            );
+          }
+        } else {
           const value = step.primitive.value ?? 0;
           if (value < 1) {
             throw new DSLValidationError(

--- a/engine/src/effect-dsl/verbs.ts
+++ b/engine/src/effect-dsl/verbs.ts
@@ -10,7 +10,6 @@ export const VERBS = [
   "peek",
   "pick",
   "buy",
-  "reveal",
   "kill",
   "injure",
   "buff",
@@ -33,7 +32,6 @@ const HQ_SAFE: ReadonlySet<Verb> = new Set([
   "peek",
   "pick",
   "buy",
-  "reveal",
 ]);
 
 /** True if the verb operates purely on player state (no grid context needed). */

--- a/engine/src/index.ts
+++ b/engine/src/index.ts
@@ -33,6 +33,7 @@ export {
 // Types
 export type {
   Action,
+  ActionDef,
   ActionForState,
   Card,
   CardType,

--- a/engine/src/listeners/effects.ts
+++ b/engine/src/listeners/effects.ts
@@ -550,7 +550,7 @@ export const ITEM_EFFECTS: Record<string, ItemEffectFactory> = {
 
 export const POLICY_ACTIONS: Record<string, ActionDef[]> = {
   "spymaster": [
-    { name: "Infiltrate", apCost: 1, effect: "reveal(opponent + hand)" },
+    { name: "Infiltrate", apCost: 1, effect: "peek(opponent + hand)" },
   ],
 };
 

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -302,9 +302,32 @@ export type PickPrompt =
   | (PickPromptBase & { kind: "deck_pick"; count: number })
   | (PickPromptBase & { kind: "scholar_reorder" });
 
+/**
+ * Set when a `peek(opponent + hand)` effect runs. Pauses the active player
+ * until they submit `dismiss_view`. Stores full `Card[]` (not ids) because
+ * `getVisibleState` redacts opponent hands to `handSize` — the viewer has no
+ * other way to resolve ids back into card data on the client. Filtered on
+ * `VisibleState.viewPrompt` so only the viewer sees the contents.
+ */
+export interface ViewPrompt {
+  /** Who is viewing (the active player who triggered the effect). */
+  playerId: string;
+  /** Snapshot of the opponent's hand at peek time. */
+  cards: Card[];
+  source: "opponent_hand";
+  /** Whose hand is shown (for UI labelling). */
+  sourcePlayerId: string;
+}
+
 export interface MainGameState extends GameStateBase {
   phase: "main";
   turn: TurnState;
+  /**
+   * Set by `peek(opponent + hand)` to surface opponent hand contents to the
+   * active player. Cleared by `dismiss_view`. Main-phase only — Galileo and
+   * Spymaster's Infiltrate are the current producers.
+   */
+  viewPrompt?: ViewPrompt;
 }
 
 export interface EndedGameState extends GameStateBase {
@@ -314,6 +337,8 @@ export interface EndedGameState extends GameStateBase {
   scores: Record<string, number>;
   /** Ended games never carry a pending pick — make that compile-time. */
   pickPrompt?: never;
+  /** Ended games never carry a pending view either. */
+  viewPrompt?: never;
 }
 
 export type GameState = SeedingGameState | MainGameState | EndedGameState;
@@ -416,7 +441,19 @@ export type MainAction =
     }
   | { type: "attempt_mission"; playerId: string; row: number; col: number }
   | { type: "pass"; playerId: string }
-  | ResolvePickAction;
+  | ResolvePickAction
+  | DismissViewAction;
+
+/**
+ * Submitted by the viewer to dismiss a pending `viewPrompt`. The view is
+ * read-only (no outcome to feed downstream), so the engine just clears the
+ * prompt and resumes normal play. AP is not refunded (already spent on the
+ * activating action).
+ */
+export interface DismissViewAction {
+  type: "dismiss_view";
+  playerId: string;
+}
 
 export type Action = SeedingAction | MainAction;
 
@@ -545,8 +582,7 @@ export type GameEvent =
     }
   | { type: "card_discarded"; playerId: string; cardId: string; reason: string }
   | { type: "unit_buffed"; unitId: string; stat: StatName; delta: number; source: string }
-  | { type: "cards_revealed"; playerId: string; cardIds: string[]; source: "opponent_hand" }
-  | { type: "cards_peeked"; playerId: string; cardIds: string[]; source: PickSource }
+  | { type: "cards_peeked"; playerId: string; cardIds: string[]; source: PickSource | "opponent_hand" }
   | { type: "cards_picked"; playerId: string; cardIds: string[]; source: PickSource }
   | { type: "unit_controlled"; unitId: string; controllerId: string; previousOwnerId: string; duration: number }
   | { type: "contest_resolved"; stat: StatName; attackerId: string; defenderId: string; attackerPower: number; defenderPower: number; winnerId: string }
@@ -629,6 +665,8 @@ export interface VisibleState {
   seedingStep?: SeedingStep;
   /** Set during main or seeding phase when this viewer is the picker. */
   pickPrompt?: PickPrompt;
+  /** Set during main phase when this viewer is the active player on a `peek(opponent + hand)`. */
+  viewPrompt?: ViewPrompt;
   winner?: string;
   scores?: Record<string, number>;
   /** Conditional reveals granted by active passives for this viewer. */

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -303,18 +303,32 @@ export type PickPrompt =
   | (PickPromptBase & { kind: "scholar_reorder" });
 
 /**
+ * Origin of a `ViewPrompt`. Extend the union when new private-view sources are
+ * added (e.g. `opponent_deck`) so consumers stay exhaustive.
+ */
+export type ViewSource = "opponent_hand";
+
+/**
  * Set when a `peek(opponent + hand)` effect runs. Pauses the active player
  * until they submit `dismiss_view`. Stores full `Card[]` (not ids) because
  * `getVisibleState` redacts opponent hands to `handSize` — the viewer has no
  * other way to resolve ids back into card data on the client. Filtered on
  * `VisibleState.viewPrompt` so only the viewer sees the contents.
+ *
+ * Today the selector picks the first non-active player deterministically;
+ * multi-opponent target selection (matching the card text "target opponent's
+ * hand") is not yet implemented.
  */
 export interface ViewPrompt {
   /** Who is viewing (the active player who triggered the effect). */
   playerId: string;
-  /** Snapshot of the opponent's hand at peek time. */
+  /**
+   * Opponent hand contents captured when the peek fired. Shallow-cloned at
+   * peek time — under immer's structural sharing, mutations after peek do not
+   * propagate, so this acts as a snapshot in practice.
+   */
   cards: Card[];
-  source: "opponent_hand";
+  source: ViewSource;
   /** Whose hand is shown (for UI labelling). */
   sourcePlayerId: string;
 }
@@ -324,8 +338,11 @@ export interface MainGameState extends GameStateBase {
   turn: TurnState;
   /**
    * Set by `peek(opponent + hand)` to surface opponent hand contents to the
-   * active player. Cleared by `dismiss_view`. Main-phase only — Galileo and
-   * Spymaster's Infiltrate are the current producers.
+   * active player. Cleared by `dismiss_view`. Main-phase only.
+   *
+   * Invariant: at most one of `pickPrompt` / `viewPrompt` is set at a time
+   * (enforced by the executor's early-pause guard in `effect-dsl/executor.ts`
+   * and asserted at the top of `applyMainAction`).
    */
   viewPrompt?: ViewPrompt;
 }
@@ -582,7 +599,7 @@ export type GameEvent =
     }
   | { type: "card_discarded"; playerId: string; cardId: string; reason: string }
   | { type: "unit_buffed"; unitId: string; stat: StatName; delta: number; source: string }
-  | { type: "cards_peeked"; playerId: string; cardIds: string[]; source: PickSource | "opponent_hand" }
+  | { type: "cards_peeked"; playerId: string; cardIds: string[]; source: PickSource | ViewSource }
   | { type: "cards_picked"; playerId: string; cardIds: string[]; source: PickSource }
   | { type: "unit_controlled"; unitId: string; controllerId: string; previousOwnerId: string; duration: number }
   | { type: "contest_resolved"; stat: StatName; attackerId: string; defenderId: string; attackerPower: number; defenderPower: number; winnerId: string }

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -74,6 +74,18 @@ interface CardBase {
 
 export type StatName = "strength" | "cunning" | "charisma";
 
+/**
+ * An activatable action defined on a card.
+ *
+ * For unit and item cards, `effect` is a DSL string parsed by the executor
+ * (e.g. `peek(opponent + hand)`). The library build script validates it
+ * through `parseDSL`.
+ *
+ * For policy cards, `effect` is human-readable prose intended for UI display
+ * (e.g. "Look at one opponent's hand."). The executable DSL is stored in
+ * `engine/src/listeners/effects.ts:POLICY_ACTIONS`, keyed by the policy's
+ * `definitionId`. The build script skips DSL validation for policy actions.
+ */
 export interface ActionDef {
   name: string;
   apCost: number;
@@ -153,6 +165,8 @@ export type EventCard = InstantEventCard | PassiveEventCard | TrapEventCard;
 export interface PolicyCard extends CardBase {
   type: "policy";
   effect: string;
+  /** UI-only action descriptions — `ActionDef.effect` is human-readable here. */
+  actions?: ActionDef[];
 }
 
 export type Card = UnitCard | LocationCard | ItemCard | EventCard | PolicyCard;

--- a/engine/src/valid-actions.ts
+++ b/engine/src/valid-actions.ts
@@ -131,6 +131,9 @@ function getMainValidActions(
   if (state.pickPrompt && state.pickPrompt.playerId === playerId) {
     return getResolvePickActions(state.pickPrompt, playerId);
   }
+  if (state.viewPrompt && state.viewPrompt.playerId === playerId) {
+    return [{ type: "dismiss_view", playerId }];
+  }
 
   const actions: MainAction[] = [];
   const player = getPlayerById(state, playerId);

--- a/engine/src/visible-state.ts
+++ b/engine/src/visible-state.ts
@@ -79,8 +79,8 @@ export function getVisibleState(
         ? state.pickPrompt
         : undefined,
     // viewPrompt is private to the viewer — opponent hand contents must not
-    // leak through this surface. Main-phase only (no seeding-time peek of
-    // opponent hand exists).
+    // leak through this surface. The `phase === "main"` guard is required
+    // for type narrowing (viewPrompt only exists on MainGameState).
     viewPrompt:
       state.phase === "main" && state.viewPrompt?.playerId === playerId
         ? state.viewPrompt

--- a/engine/src/visible-state.ts
+++ b/engine/src/visible-state.ts
@@ -78,6 +78,13 @@ export function getVisibleState(
       state.phase !== "ended" && state.pickPrompt?.playerId === playerId
         ? state.pickPrompt
         : undefined,
+    // viewPrompt is private to the viewer — opponent hand contents must not
+    // leak through this surface. Main-phase only (no seeding-time peek of
+    // opponent hand exists).
+    viewPrompt:
+      state.phase === "main" && state.viewPrompt?.playerId === playerId
+        ? state.viewPrompt
+        : undefined,
     winner: state.phase === "ended" ? state.winner : undefined,
     scores: state.phase === "ended" ? state.scores : undefined,
     reveals,

--- a/engine/src/win-condition.ts
+++ b/engine/src/win-condition.ts
@@ -55,5 +55,12 @@ export function toEndedState(
   events.push({ type: "phase_changed", from: "main", to: "ended" });
   events.push({ type: "game_ended", winner, scores });
 
-  return { ...state, phase: "ended" as const, winner, scores };
+  return {
+    ...state,
+    phase: "ended" as const,
+    winner,
+    scores,
+    pickPrompt: undefined,
+    viewPrompt: undefined,
+  };
 }

--- a/library/build.ts
+++ b/library/build.ts
@@ -147,6 +147,12 @@ function transformCard(type: CardType, raw: Record<string, string>): Record<stri
 
     case "policies":
       base.effect = raw.effect;
+      // Policy actions: the third colon-separated field is human-readable
+      // prose for UI display (e.g. "Look at one opponent's hand."), not a
+      // DSL string. The executable DSL is wired in
+      // engine/src/listeners/effects.ts:POLICY_ACTIONS. Validation skips
+      // DSL parsing for these — see the `validate` function.
+      base.actions = splitList(raw.actions || "").map(parseAction).filter(Boolean);
       break;
   }
 
@@ -172,9 +178,10 @@ function validate(type: CardType, card: Record<string, unknown>): ValidationErro
     errors.push({ card: id, field: "subtype", message: `invalid subtype: ${card.subtype}` });
   }
 
-  // DSL effect validation
+  // DSL effect validation — skipped for policies (action.effect is
+  // human-readable prose; executable DSL lives in POLICY_ACTIONS).
   const actions = card.actions as { name: string; apCost: number; effect: string }[] | undefined;
-  if (actions) {
+  if (actions && type !== "policies") {
     for (const action of actions) {
       try {
         parseDSL(action.effect);

--- a/library/schema.md
+++ b/library/schema.md
@@ -129,8 +129,7 @@ Core primitives the engine implements. New cards compose these — no per-card c
 | `draw` | count | Draw cards from your deck. `draw[2]`. Implicit `[1]`. |
 | `buy` | cost override | Buy a card from market. `buy(item)[0]` = buy item for free. `buy[-1]` = 1 gold discount on anything. |
 | `move` | distance | Move a unit. `move(self)[2]` = 2 spaces. Implicit `[1]`. |
-| `reveal` | — | Publicly reveal cards (visible to all players). `reveal(opponent + hand)` |
-| `peek` | count | Privately look at the top N of your own deck. Feeds into `pick`. `peek(deck)[3]` |
+| `peek` | count | Privately view cards. `peek(deck)[N]` looks at top N of your own deck and feeds into `pick`. `peek(opponent + hand)` shows the opponent's hand to you only (no count, no chained `pick`). |
 | `pick` | count | Player picks N from previously peeked cards (used after `>` pipe from `peek`). `peek(deck)[3] > pick[1]` |
 | `buff.STAT` | amount | Temporary stat increase. Requires `~duration`. `buff.strength(all + friendly)[2]~turn` |
 | `contest.STAT` | bonus | Stat contest using named stat. Value = attacker bonus. `contest.strength[3]` = +3 bonus. |
@@ -239,7 +238,7 @@ Complete action definitions (`name:ap_cost:effect`):
 | Harriet Tubman | `underground:1:move(friendly)~ignore_blocked` |
 | Alexander the Great | `march:1:move(self) + contest.strength(enemy)` |
 | Ada Lovelace | `analyze:1:peek(deck)[3] > pick[1]` |
-| Galileo Galilei | `observe:1:reveal(opponent + hand)` |
+| Galileo Galilei | `observe:1:peek(opponent + hand)` |
 | Nikola Tesla | `invent:2:buy(item)[0]` |
 | Genghis Khan | `conquer:3:raze(location) > to(hq)` |
 | Ramesses II | `monument:2:vp[1] + kill(self)` |

--- a/library/schema.md
+++ b/library/schema.md
@@ -129,7 +129,7 @@ Core primitives the engine implements. New cards compose these — no per-card c
 | `draw` | count | Draw cards from your deck. `draw[2]`. Implicit `[1]`. |
 | `buy` | cost override | Buy a card from market. `buy(item)[0]` = buy item for free. `buy[-1]` = 1 gold discount on anything. |
 | `move` | distance | Move a unit. `move(self)[2]` = 2 spaces. Implicit `[1]`. |
-| `peek` | count | Privately view cards. `peek(deck)[N]` looks at top N of your own deck and feeds into `pick`. `peek(opponent + hand)` shows the opponent's hand to you only (no count, no chained `pick`). |
+| `peek` | varies | Privately view cards. See [peek selectors](#peek-selectors) below. |
 | `pick` | count | Player picks N from previously peeked cards (used after `>` pipe from `peek`). `peek(deck)[3] > pick[1]` |
 | `buff.STAT` | amount | Temporary stat increase. Requires `~duration`. `buff.strength(all + friendly)[2]~turn` |
 | `contest.STAT` | bonus | Stat contest using named stat. Value = attacker bonus. `contest.strength[3]` = +3 bonus. |
@@ -139,6 +139,17 @@ Core primitives the engine implements. New cards compose these — no per-card c
 | `raze` | — | Remove a location from the grid. `raze(location)` |
 | `to` | — | Move result to a zone (used after `>` pipe). `raze(location) > to(hq)` |
 | `remove` | — | Remove card from play. `remove(location)` |
+
+### peek selectors
+
+- `peek(deck)[N]` — privately reveal the top N of your own deck to yourself.
+  Feeds `_peekedCards` into a chained `pick`. `N >= 1`. Example: Ada Lovelace —
+  `analyze:1:peek(deck)[3] > pick[1]`.
+- `peek(opponent + hand)` — show one opponent's full hand to the active player
+  only (via `viewPrompt`, dismissed by the player). No count; must be the
+  terminal step. Today the engine deterministically picks the first non-active
+  player — multi-opponent target selection is tracked for when multi-player
+  support lands. Example: Galileo Galilei — `observe:1:peek(opponent + hand)`.
 
 ### Targets
 

--- a/library/sets/alpha-1/units.csv
+++ b/library/sets/alpha-1/units.csv
@@ -12,7 +12,7 @@ joan-of-arc,Joan of Arc,alpha-1,epic,5,7,4,8,Warrior;Spiritual,,rally:1:buff.str
 marco-polo,Marco Polo,alpha-1,uncommon,3,4,5,8,Diplomat;Merchant,,trade-route:1:move(self) + gold[1],Move Marco Polo to an adjacent location and gain 1 gold.,Twenty-four years of road and wonder.
 alexander-the-great,Alexander the Great,alpha-1,legendary,8,9,7,8,Warrior;Politician,,march:1:move(self) + contest.strength(enemy),Move to adjacent location and initiate a strength contest against target unit there.,He wept for there were no more worlds to conquer.
 nefertiti,Nefertiti,alpha-1,uncommon,3,4,5,8,Politician;Spiritual,,inspire:1:buff.charisma(all + friendly)[2]~turn,All friendly units at this location get +2 charisma until end of turn.,Beauty was the least of her powers.
-galileo-galilei,Galileo Galilei,alpha-1,uncommon,3,3,8,4,Scientist,,observe:1:reveal(opponent + hand),Look at target opponent's hand.,And yet it moves.
+galileo-galilei,Galileo Galilei,alpha-1,uncommon,3,3,8,4,Scientist,,observe:1:peek(opponent + hand),Look at target opponent's hand.,And yet it moves.
 hannibal-barca,Hannibal Barca,alpha-1,epic,6,8,8,5,Warrior,,flank:2:contest.strength(enemy)[3],Strength contest against target unit at same location with +3 bonus.,He brought elephants across mountains.
 harriet-tubman,Harriet Tubman,alpha-1,uncommon,2,5,7,7,Politician,,underground:1:move(friendly)~ignore_blocked,Move target friendly unit to an adjacent location ignoring one blocked edge.,She never lost a passenger.
 ibn-battuta,Ibn Battuta,alpha-1,common,2,3,7,6,Diplomat;Scientist,,wander:1:move(self) + gold[1],Move Ibn Battuta to an adjacent location and gain 1 gold.,Seventy-five thousand miles before the age of jet.


### PR DESCRIPTION
## Summary

Add the privacy-respecting client surface for `reveal(opponent + hand)` / `peek(opponent + hand)` effects so the active player actually sees the cards. Fixes both Galileo Galilei's `observe` and Spymaster's `Infiltrate` actions with a single overlay. Also rolls in two playtest UX fixes discovered during manual verification: skip-seeding randomization (#126) and missing action descriptions.

## Engine changes

- Extend `execPeek` to handle `(opponent + hand)` selector
- Add `viewPrompt?: ViewPrompt` to `MainGameState` (and per-viewer filtered `VisibleState`)
- New `dismiss_view` action + pre-produce lockout pattern (mirrors `pickPrompt`)
- Drop the `reveal` verb entirely (only consumer migrated to `peek`); drop `cards_revealed` event
- Library: rename effect string from `reveal(opponent + hand)` → `peek(opponent + hand)` on Galileo (CSV) and Spymaster (POLICY_ACTIONS)
- Add `actions?: ActionDef[]` to `PolicyCard`; document `ActionDef.effect`'s dual meaning (DSL for units, prose for policies); export `ActionDef`

## Client changes

- New `ViewPromptOverlay.svelte` (modeled on `PickPromptOverlay`, Dismiss button only, looks up opponent name via `vs.opponents`)
- Wired into `App.svelte` alongside `PickPromptOverlay`
- Skip-seeding (`buildMainSetup`) now shuffles the policy pool with the seed-driven RNG and assigns 2 per player — was deterministically picking Militarist every game (#126)
- New `resolveActionTooltip` in `gameStore`; `ActionPanel` shows native `title=` tooltips with the action description (policy `effect` field for policies, card `text` for units/items)

## Library

- `policies` build branch now preserves the `actions` column so policy action descriptions reach the client; DSL validation skipped for policy actions

## Review findings applied (commit c606817)

Multi-agent review surfaced 16 findings, all addressed: validator now rejects `peek(opponent + hand)[N]` / chained `pick` / trailing steps; executor throws on missing opponent; suspend guard centralized in `executeStep`; dispatcher asserts pickPrompt/viewPrompt mutex; `ViewSource` type extracted; overlay mirrors `PickPromptOverlay`'s error recovery; +10 engine test cases for validator coverage, lockout parameterization, synthetic owner-mismatch, `toEndedState` clearing.

## Out of scope

- Multi-player opponent targeting (v0.1 is 1v1; noted in #111 for when multi-player lands)
- Event-log privacy filter (#105)

## Discovered during this work — filed separately, not blocking

- #122 — The Great Wall: missing DSL verb + stale defender bonus
- #123 — Machu Picchu: missing "until your next turn" duration
- #124 — Trap events with location targets aren't enumerated as targeted actions
- #127 — StartScreen briefly shows previous seed/skip-seeding values after refresh

## Related

- Closes #111
- Closes #126
- Establishes the transient-view pattern for future `peek(opponent + X)` variants
- Fixes the UX defect inherited from #107 (Spymaster Infiltrate)

## Test plan

- [x] Engine: 449/449 pass, including `view-prompt.test.ts` (12 cases) and 5 new DSL validator cases for `peek(opponent + hand)`
- [x] Web client: 4 new `gameSetup.test.ts` cases for the policy randomization fix
- [x] Library: `bun library/build.ts` succeeds
- [x] Web client: `bun run typecheck` clean
- [x] Manual: Galileo's `observe` shows opponent's hand cards on active player's view
- [x] Manual: Spymaster's `Infiltrate` does the same via the same overlay
- [x] Manual: Action tooltips show descriptions on hover
- [ ] Manual: Opponent's view shows no modal and hand contents stay redacted
- [ ] Manual: Dismiss clears the prompt, normal play resumes (no AP refund)
- [ ] Manual: Skip-seeding gives different policies across consecutive games