### PR TITLE
#154 — Rules: investigate unifying combat as repeatable 1v1 stat contests

### DIFF
--- a/rules/README.md
+++ b/rules/README.md
@@ -244,7 +244,7 @@ intended design but is **not yet implemented** (see #164). The engine
 currently auto-resolves combat atomically: the attacker commits units,
 both sides are paired greedily highest-power vs highest-power, excess
 units on the larger side sit out lowest-power-first, and all rounds run
-without pausing for player decisions. Three further deviations from the
+without pausing for player decisions. Two further deviations from the
 text above: (1) combat is capped at a 10-round engine safety limit;
 (2) injured units are **not** removed between rounds — they keep fighting
 and re-roll (with the injury penalty) each round, whereas the Next round

--- a/rules/README.md
+++ b/rules/README.md
@@ -208,20 +208,18 @@ be present.
    the location participate. Must commit at least one.
 2. **Commit (defender)**: All defender units at the location are
    committed automatically — the defender cannot hold units back.
-3. **Roll**: Each side rolls one d6 per committed unit. Each unit's
-   **attack power** = printed strength + d6 roll.
+3. **Roll**: Each side rolls one d[var:combat_die:6] per committed unit.
+   Each unit's **attack power** = strength (including modifiers) + roll.
 4. **Matchup (defender assigns)**: The defender pairs units into 1v1
    matchups. The number of pairs equals the smaller side's committed
    count. The side with more units chooses which of their excess units
    sit out (decided after seeing all rolls).
 5. **Resolve**: Each pair is a **strength [stat contest](stat-contests.md)**
-   and resolves independently:
-   - Higher attack power wins. **Tie = defender wins.**
-   - Loser is **injured** (see Unit status). Items are dropped at the
-     location.
-   - If the winner's attack power is [var:combat_kill_ratio:2]x or more the loser's
-     attack power, the loser is **killed** instead (see Unit status).
-     Items are dropped at the location.
+   and resolves independently by that file's rules — higher attack power
+   wins, ties go to the defender, and the loser is **injured** or (at
+   [var:combat_kill_ratio:2]x attack power) **killed** (see Unit status).
+   Combat adds one consequence on top of the primitive: a unit that is
+   **killed** drops its equipped items at the location.
 6. **Next round or end**: After all pairs resolve, if both sides still
    have surviving (non-injured, non-killed) units at the location,
    combat continues — return to step 3 (re-roll all surviving units).
@@ -240,15 +238,23 @@ be present.
   order). Surviving attacker units carry over between resolutions.
 
 [design: The multi-unit *tactical* layer above — the defender assigning
-matchups (step 4), the larger side choosing which units sit out (step 4),
-and per-round retreat (step 6) — is the intended design but is **not yet
-implemented**. The engine currently auto-resolves combat atomically:
-attacker commits units, both sides are paired greedily highest-power vs
-highest-power, and all rounds run without pausing for player decisions.
-This is an engine deviation documented here to keep rules and engine
-consistent; building the interactive layer is tracked in #164. The
-injure/kill consequences and tie-to-defender rule are implemented and
-match this text.]
+matchups and the larger side choosing which units sit out (the Matchup
+step), and per-round retreat (the Next round or end step) — is the
+intended design but is **not yet implemented** (see #164). The engine
+currently auto-resolves combat atomically: the attacker commits units,
+both sides are paired greedily highest-power vs highest-power, excess
+units on the larger side sit out lowest-power-first, and all rounds run
+without pausing for player decisions. Three further deviations from the
+text above: (1) combat is capped at a 10-round engine safety limit;
+(2) injured units are **not** removed between rounds — they keep fighting
+and re-roll (with the injury penalty) each round, whereas the Next round
+step continues only "surviving (non-injured, non-killed)" units;
+reconciling this per-round survivor/injury semantics with the contest
+primitive is tracked in #169. The injure/kill consequences and
+tie-to-defender rule *are* implemented and match this text. Until #164
+lands, do not build card designs on the tactical layer or on injured
+units dropping out mid-combat — validate such designs against engine
+behavior.]
 
 > See [Market and Economy Rules](market.md) for details on the Buy action.
 

--- a/rules/README.md
+++ b/rules/README.md
@@ -192,9 +192,11 @@ Each deck has its own draw behavior:
 
 #### Combat
 
-> Combat is a series of **strength contests** resolved through a
-> multi-unit commitment and matchup system. See
-> [Stat Contests](stat-contests.md) for the general contest mechanic.
+> Combat is a multi-unit commitment and matchup system in which **each
+> matchup is resolved as a single strength [stat contest](stat-contests.md)**
+> — same roll, same tie rule, same injure/kill consequences. Combat is
+> the multi-unit *orchestration* of that 1v1 primitive, not a parallel
+> mechanic.
 
 Combat is initiated by the **Attack** action (1 AP). The attacker must
 have at least one unit at the location and at least one enemy unit must
@@ -212,7 +214,8 @@ be present.
    matchups. The number of pairs equals the smaller side's committed
    count. The side with more units chooses which of their excess units
    sit out (decided after seeing all rolls).
-5. **Resolve**: Each pair resolves independently:
+5. **Resolve**: Each pair is a **strength [stat contest](stat-contests.md)**
+   and resolves independently:
    - Higher attack power wins. **Tie = defender wins.**
    - Loser is **injured** (see Unit status). Items are dropped at the
      location.
@@ -235,6 +238,17 @@ be present.
   Each opponent's units are committed separately and the attacker
   resolves combat against each opponent in turn (attacker chooses
   order). Surviving attacker units carry over between resolutions.
+
+[design: The multi-unit *tactical* layer above — the defender assigning
+matchups (step 4), the larger side choosing which units sit out (step 4),
+and per-round retreat (step 6) — is the intended design but is **not yet
+implemented**. The engine currently auto-resolves combat atomically:
+attacker commits units, both sides are paired greedily highest-power vs
+highest-power, and all rounds run without pausing for player decisions.
+This is an engine deviation documented here to keep rules and engine
+consistent; building the interactive layer is tracked in #164. The
+injure/kill consequences and tie-to-defender rule are implemented and
+match this text.]
 
 > See [Market and Economy Rules](market.md) for details on the Buy action.
 

--- a/rules/stat-contests.md
+++ b/rules/stat-contests.md
@@ -7,7 +7,7 @@ the **attacker**; the targeted unit is the **defender**.
 
 ## Resolution
 
-1. Each unit rolls a d6. **Attack power** = relevant stat + d6 roll.
+1. Each unit rolls a d[var:combat_die:6]. **Attack power** = relevant stat + roll.
    [design: temporary v0.1 shortcut — the engine floors effective stats at 0,
    so a stat driven below 0 by modifiers contributes 0 (not a negative) to
    attack power. The rules intend negative effective stats to be supported;
@@ -26,7 +26,7 @@ the **attacker**; the targeted unit is the **defender**.
   winner's attack power is [var:combat_kill_ratio:2]x or more the
   loser's, the loser is **killed** instead. The **Attack** action
   initiates strength contests — **each combat matchup is one strength
-  contest resolved by exactly these rules**; see
+  contest resolved by the same win/tie/consequence rules**; see
   [Combat](README.md#combat) for how the multi-unit flow orchestrates
   them.
 - **All other stat contests** have no default consequence. The card or

--- a/rules/stat-contests.md
+++ b/rules/stat-contests.md
@@ -25,8 +25,10 @@ the **attacker**; the targeted unit is the **defender**.
   **injured** (see [Unit status](README.md#unit-status)). If the
   winner's attack power is [var:combat_kill_ratio:2]x or more the
   loser's, the loser is **killed** instead. The **Attack** action
-  initiates strength contests — see [Combat](README.md#combat) for
-  the full multi-unit flow.
+  initiates strength contests — **each combat matchup is one strength
+  contest resolved by exactly these rules**; see
+  [Combat](README.md#combat) for how the multi-unit flow orchestrates
+  them.
 - **All other stat contests** have no default consequence. The card or
   effect that initiates the contest defines what happens on win and/or
   loss.


### PR DESCRIPTION
## Decision

**Option A — keep multi-unit combat — with the contest *primitive* unified.** Combat stays a multi-unit commitment/matchup framework (attacker commits, defender assigns pairs, sit-out, multi-round, retreat), but **each matchup is now explicitly one strength [stat contest](rules/stat-contests.md)** — same roll, tie-to-defender, and injure/kill consequences. Combat is the multi-unit *orchestration* of the 1v1 primitive, not a parallel mechanic.

### Why A over B / C

- **Preserves both design pillars.** Power-in-numbers (defender pairing, sacrifice plays, attrition) and few-elite viability both stay intact. B (1v1 chain) deletes the defender's assign-pairs counterplay and makes the **Duelist** keyword dead; C keeps both but forces the engine to carry two combat paths.
- **The "we're mostly there" case is real — but for A's *primitive*, not its tactics.** Audit finding: the engine already runs a simplified multi-unit auto-resolve. Of A's five pillars, attacker-commit + injure/kill + tie-to-defender are **built**; defender-assigned pairing, sit-out, and per-round retreat are **rules fiction with no code** (engine auto-pairs highest-vs-highest, resolves atomically — `engine/src/apply-main.ts:695-727`). So A-as-written is actually the *most* remaining engine work; this PR keeps the rich rules as the target and files the build-out.
- **No unplaytested leap.** B/C introduce combat models never playtested; A refines what exists.

### What happened to #153

**#153 closed (not planned — superseded), replaced by #164.** Its "unify as a 1v1 chain" premise is rejected by this decision. Its still-useful internals (share the kill/injure predicate; route each matchup through the strength-contest primitive) survive as sub-task #169 under the new parent **#164**.

## Rules changes (in this PR)

- `rules/README.md` Combat — reframed each matchup as a strength stat contest; step 5 defers tie/injure/kill to the primitive; added a `[design:]` note enumerating every current engine deviation (auto-pairing, lowest-power sit-out, 10-round cap, injured-units-keep-fighting) with pointers to #164 / #169.
- Fixed pre-existing Combat-section bugs while the section was open: injured losers no longer drop items (only killed units do, per Unit status); attack power now reads "strength (including modifiers)" not "printed strength"; combat die annotated `[var:combat_die:6]`.
- `rules/stat-contests.md` — reciprocal "each matchup is one strength contest" wording (win/tie/consequence rules).

## Card audit — no revisions required

A real upside of keeping A: existing card text stays valid.

| Card | Current text | Verdict |
|---|---|---|
| Spartacus (`units.csv`) | "When Spartacus wins combat you may injure him to kill the target instead." | ✅ valid; optional tighten → "wins a combat matchup" |
| Warlord (`policies.csv`) | "Gain 1 gold each time one of your units wins combat." | ✅ valid |
| Diplomat (`policies.csv`) | "prevent one combat at a location…" | ✅ valid |
| Duelist keyword | "matchup resolved in isolation" | ✅ **stays meaningful** (would be dead under B) |
| Fortified / Resolute | strength/tie scoping | ✅ already contest-based |

No balance tuning here (separate follow-up, out of scope).

## Follow-up work

- **#164** — parent (milestone `v0.1-playtest`): build the multi-unit interactive layer, with sub-issues **#165–#170** (mid-combat suspension, defender-assigned matchups, sit-out, retreat, route matchups through the contest primitive + reconcile survivor/injury semantics & 10-round cap, verify Spoils-of-War per-opponent).

## Iteration log

| # | Change |
|---|--------|
| 1 | Decision landed (A + unified primitive); rules reconciled; #153 closed → #164 + #165–170 opened. |
| 2 | Applied PR-review fixes: completed the `[design:]` deviation note, fixed pre-existing Combat contradictions (item-drop, printed-strength), annotated combat die, deferred step 5 to the primitive. |

## Related

- Closes #154
- Supersedes #153; opens #164 (+ #165–170)
- Surfaced during #146 (contest-result dialog). The combat-tie behavior from #151 (merged) is preserved (tie = defender).
