### PR TITLE
#169 — Engine: route combat matchups through the strength-contest primitive

### DIFF
--- a/engine/src/__tests__/contest-surfacing.test.ts
+++ b/engine/src/__tests__/contest-surfacing.test.ts
@@ -249,6 +249,52 @@ describe("combat_pair_resolved", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Combat survivor semantics (drop-out) — #169
+// ---------------------------------------------------------------------------
+
+describe("combat drop-out survivor semantics", () => {
+  it("drops an injured unit from the pool after the round it is hurt", () => {
+    // Strength 17 vs 11: the gap (>=6) makes the attacker win every round
+    // regardless of the d6, and (17+6 < 2*(11+1)) makes round 1 an INJURE, not
+    // a kill, for every roll. Under the old "injured keep fighting" rule the
+    // defender would re-roll round 2 (now at effective strength 10, injured)
+    // and die; under drop-out it leaves the pool and survives injured, so
+    // exactly one matchup resolves.
+    const attacker = makeUnit({ ownerId: ACTIVE, strength: 17 });
+    const defender = makeUnit({ ownerId: OTHER, strength: 11 });
+    const state = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(attacker, defender);
+    });
+
+    const { state: next, events } = applyAction(state, {
+      type: "attack",
+      playerId: ACTIVE,
+      unitIds: [attacker.id],
+      row: 0,
+      col: 0,
+    });
+    const ns = next as MainGameState;
+
+    // Exactly one matchup — the injured defender does not re-roll a round 2.
+    const pairs = findAllPairs(events);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].outcome).toBe("injure_defender");
+
+    // Defender survives, injured, still on the grid; attacker unharmed.
+    const survivor = ns.grid[0][0].units.find((u) => u.id === defender.id);
+    expect(survivor?.injured).toBe(true);
+    const atk = ns.grid[0][0].units.find((u) => u.id === attacker.id);
+    expect(atk?.injured).toBe(false);
+
+    // A side reduced to only-injured survivors is not "empty" → no winner.
+    const resolved = events.find((e) => e.type === "combat_resolved");
+    if (resolved?.type !== "combat_resolved") throw new Error("expected combat_resolved");
+    expect(resolved.winnerId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // deriveCombatOutcome — exhaustive over the reachable outcomes ("tie" is
 // never returned: equal powers resolve against the attacker)
 // ---------------------------------------------------------------------------

--- a/engine/src/__tests__/contest-surfacing.test.ts
+++ b/engine/src/__tests__/contest-surfacing.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { produce } from "immer";
 import { applyAction } from "../apply-action";
 import { deriveCombatOutcome } from "../apply-main";
-import { decideKillVsInjure } from "../unit-helpers";
+import { decideKillVsInjure, computeContestPower } from "../unit-helpers";
 import { rebuildListeners } from "../listeners/rebuild";
 import { POLICY_ACTIONS } from "../listeners/effects";
 import { getModifiedStatWithSources } from "../listeners/query";
@@ -181,6 +181,15 @@ describe("combat_pair_resolved", () => {
     expect(penalty).toBeDefined();
     expect(penalty!.source.cardId).toBe(defender.id);
     expect(penalty!.delta).toBe(-1);
+    // Exactly ONE injured chip. The #171 refactor moved the penalty from a
+    // combat-local push in buildCombatantRoll to the global synthesis in
+    // getModifiedStatWithSources; re-introducing the old push would emit two
+    // -1 chips (double-counting the penalty), which this guards against.
+    const injuredChips = pair.defender.modifiers.filter((m) => m.source.definitionId === "injured");
+    expect(injuredChips).toHaveLength(1);
+    // Power reflects the penalty exactly once: base + Σmodifiers + roll.
+    const defSum = pair.defender.modifiers.reduce((a, m) => a + m.delta, 0);
+    expect(pair.defender.baseStrength + defSum + pair.defender.roll).toBe(pair.defender.power);
   });
 
   it("emits per pair across a 2v2 — pairing pulls highest-power vs highest-power", () => {
@@ -292,6 +301,123 @@ describe("combat drop-out survivor semantics", () => {
     if (resolved?.type !== "combat_resolved") throw new Error("expected combat_resolved");
     expect(resolved.winnerId).toBeNull();
   });
+
+  it("lets a pre-injured unit fight round 0, then drops it from round 1", () => {
+    // The filter is `round === 0 || !u.injured`: a unit injured BEFORE combat
+    // still fights round 0, then leaves the pool. Here a pre-injured attacker
+    // (str 20, effective 19) kills one of two defenders in round 0; in round 1
+    // it is excluded, so the second defender — which sat out round 0 — is never
+    // engaged and survives un-injured.
+    const attacker = makeUnit({ ownerId: ACTIVE, strength: 20, injured: true });
+    const defenders = [
+      makeUnit({ ownerId: OTHER, strength: 1 }),
+      makeUnit({ ownerId: OTHER, strength: 1 }),
+    ];
+    const state = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(attacker, ...defenders);
+    });
+
+    const { state: next, events } = applyAction(state, {
+      type: "attack",
+      playerId: ACTIVE,
+      unitIds: [attacker.id],
+      row: 0,
+      col: 0,
+    });
+    const ns = next as MainGameState;
+
+    // Round 0 ran (pre-injured attacker participated, killing one defender);
+    // round 1 did not (attacker excluded, no attackers left to roll).
+    const pairs = findAllPairs(events);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].outcome).toBe("kill_defender");
+
+    // Attacker survives, still injured, still on the grid.
+    const atk = ns.grid[0][0].units.find((u) => u.id === attacker.id);
+    expect(atk?.injured).toBe(true);
+    // The sat-out defender is untouched: exactly one defender remains, un-injured.
+    const liveDefenders = ns.grid[0][0].units.filter((u) => u.ownerId === OTHER);
+    expect(liveDefenders).toHaveLength(1);
+    expect(liveDefenders[0].injured).toBe(false);
+
+    const resolved = events.find((e) => e.type === "combat_resolved");
+    if (resolved?.type !== "combat_resolved") throw new Error("expected combat_resolved");
+    expect(resolved.winnerId).toBeNull();
+  });
+
+  it("halts combat at combat_round_cap even when live units remain to fight", () => {
+    // 1 attacker (str 20) vs 3 defenders (str 1): the attacker kills one
+    // defender per round (20 >= 2*1) while the other two sit out, so an
+    // uncapped combat takes 3 rounds. Pinning the cap at 1 must stop after the
+    // first round with two live, un-injured defenders remaining. A typo in the
+    // "combat_round_cap" config key would ignore the override and fail here.
+    const attacker = makeUnit({ ownerId: ACTIVE, strength: 20 });
+    const defenders = [
+      makeUnit({ ownerId: OTHER, strength: 1 }),
+      makeUnit({ ownerId: OTHER, strength: 1 }),
+      makeUnit({ ownerId: OTHER, strength: 1 }),
+    ];
+    const state = produce(
+      createTestGame({ config: { ...COMBAT_CONFIG, combat_round_cap: 1 } }),
+      (d) => {
+        d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+        d.grid[0][0].units.push(attacker, ...defenders);
+      },
+    );
+
+    const { state: next, events } = applyAction(state, {
+      type: "attack",
+      playerId: ACTIVE,
+      unitIds: [attacker.id],
+      row: 0,
+      col: 0,
+    });
+    const ns = next as MainGameState;
+
+    // Only one round ran → exactly one matchup resolved.
+    expect(findAllPairs(events)).toHaveLength(1);
+    // Two defenders never fought; they survive, un-injured, on the grid.
+    const liveDefenders = ns.grid[0][0].units.filter((u) => u.ownerId === OTHER && !u.injured);
+    expect(liveDefenders).toHaveLength(2);
+    // Combat did not clear the cell → no winner.
+    const resolved = events.find((e) => e.type === "combat_resolved");
+    if (resolved?.type !== "combat_resolved") throw new Error("expected combat_resolved");
+    expect(resolved.winnerId).toBeNull();
+  });
+
+  it("uses the default round cap (10) when combat_round_cap is absent from config", () => {
+    // The same 1-vs-3 setup resolves fully under the default cap: the attacker
+    // kills all three defenders across three rounds and takes the cell. Pins
+    // the `getConfigNumber(..., 10)` fallback. COMBAT_CONFIG never sets
+    // combat_round_cap, so gameWith exercises the default path directly.
+    const attacker = makeUnit({ ownerId: ACTIVE, strength: 20 });
+    const defenders = [
+      makeUnit({ ownerId: OTHER, strength: 1 }),
+      makeUnit({ ownerId: OTHER, strength: 1 }),
+      makeUnit({ ownerId: OTHER, strength: 1 }),
+    ];
+    const state = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(attacker, ...defenders);
+    });
+
+    const { state: next, events } = applyAction(state, {
+      type: "attack",
+      playerId: ACTIVE,
+      unitIds: [attacker.id],
+      row: 0,
+      col: 0,
+    });
+    const ns = next as MainGameState;
+
+    // Three rounds, three kills — all defenders cleared, attacker takes the cell.
+    expect(findAllPairs(events)).toHaveLength(3);
+    expect(ns.grid[0][0].units.filter((u) => u.ownerId === OTHER)).toHaveLength(0);
+    const resolved = events.find((e) => e.type === "combat_resolved");
+    if (resolved?.type !== "combat_resolved") throw new Error("expected combat_resolved");
+    expect(resolved.winnerId).toBe(ACTIVE);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -372,6 +498,23 @@ describe("decideKillVsInjure", () => {
   it("throws on invalid power inputs (negative, NaN)", () => {
     expect(() => decideKillVsInjure(false, -1, 5, 2)).toThrow(/winnerPower/);
     expect(() => decideKillVsInjure(false, 5, NaN, 2)).toThrow(/loserPower/);
+  });
+});
+
+describe("computeContestPower", () => {
+  // The shared primitive both combat (buildCombatantRoll) and DSL contests
+  // (executeContest) depend on: power = max(0, base + Σmodifiers) + roll.
+  it("adds the roll to the positive clamped stat", () => {
+    expect(computeContestPower(5, 2, 4)).toBe(11); // max(0, 7) + 4
+    expect(computeContestPower(5, 0, 1)).toBe(6);
+  });
+  it("clamps a negative base+Σmodifiers to 0 before adding the roll", () => {
+    // The die roll is NOT clamped away — a fully-debuffed unit still rolls.
+    expect(computeContestPower(1, -3, 4)).toBe(4); // max(0, -2)=0, +4
+    expect(computeContestPower(0, -5, 6)).toBe(6);
+  });
+  it("treats an exact-zero clamped stat as contributing only the roll", () => {
+    expect(computeContestPower(2, -2, 3)).toBe(3);
   });
 });
 
@@ -683,6 +826,50 @@ describe("contest_resolved per-side breakdown", () => {
       roll: contest.defender.roll,
       power: 4 + contest.defender.roll,
     });
+  });
+
+  it("applies the global injury penalty inside a DSL stat contest", () => {
+    // The injury penalty lives in getModifiedStatWithSources, so it must reach
+    // the DSL contest path (executeContest) too — not just combat. An injured
+    // caster contests at charisma - injury_stat_penalty, surfaced as an
+    // `injured` chip in the contest breakdown.
+    const cleopatra = makeUnit({
+      ownerId: ACTIVE,
+      definitionId: "cleopatra",
+      charisma: 9,
+      injured: true,
+      actions: [{
+        name: "diplomacy",
+        apCost: 1,
+        effect: "contest.charisma(enemy + adjacent) > control(target)~round",
+      }],
+    });
+    const enemy = makeUnit({ ownerId: OTHER, charisma: 4 });
+    const state = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][1].location = makeLocation({ ownerId: OTHER });
+      d.grid[0][0].units.push(cleopatra);
+      d.grid[0][1].units.push(enemy);
+    });
+
+    const { events } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: cleopatra.id,
+      actionName: "diplomacy",
+      targetId: enemy.id,
+    });
+
+    const contest = findContest(events);
+    expect(contest.attacker.baseStat).toBe(9);
+    const injuredChip = modifierFrom(contest.attacker, "injured");
+    expect(injuredChip).toBeDefined();
+    expect(injuredChip!.delta).toBe(-1);
+    expect(injuredChip!.source.cardId).toBe(cleopatra.id);
+    // Applied exactly once and folded into power: base + Σmodifiers + roll.
+    expect(contest.attacker.modifiers.filter((m) => m.source.definitionId === "injured")).toHaveLength(1);
+    const atkSum = contest.attacker.modifiers.reduce((a, m) => a + m.delta, 0);
+    expect(contest.attacker.baseStat + atkSum + contest.attacker.roll).toBe(contest.attacker.power);
   });
 
   it("surfaces a buff-verb modifier on the DSL contest payload too", () => {

--- a/engine/src/__tests__/contest-surfacing.test.ts
+++ b/engine/src/__tests__/contest-surfacing.test.ts
@@ -1001,4 +1001,30 @@ describe("getModifiedStatWithSources", () => {
     expect(breakdown.modifiers[0].delta).toBe(-2);
     expect(breakdown.final).toBe(0);  // clamped from -1
   });
+
+  it("applies a global injury penalty to ANY stat for injured units", () => {
+    // Injury is "-1 to all stats" (rules/README.md Unit status), not a
+    // combat-only modifier. Assert on a non-combat stat (charisma) to prove
+    // it's global — combat, DSL contests, and mission stat checks all read
+    // this one function, so applying it here covers every consumer.
+    const state = gameWith(() => {});
+    const { queries } = rebuildListeners(state);
+    const injured = makeUnit({ ownerId: ACTIVE, charisma: 6, injured: true });
+
+    const breakdown = getModifiedStatWithSources(state, queries, injured, "charisma");
+    expect(breakdown.base).toBe(6);
+    const injuredChip = breakdown.modifiers.find((m) => m.source.definitionId === "injured");
+    expect(injuredChip?.delta).toBe(-1);  // injury_stat_penalty pinned to 1 in COMBAT_CONFIG
+    expect(breakdown.final).toBe(5);
+  });
+
+  it("does not apply an injury penalty to healthy units", () => {
+    const state = gameWith(() => {});
+    const { queries } = rebuildListeners(state);
+    const healthy = makeUnit({ ownerId: ACTIVE, charisma: 6, injured: false });
+
+    const breakdown = getModifiedStatWithSources(state, queries, healthy, "charisma");
+    expect(breakdown.modifiers.find((m) => m.source.definitionId === "injured")).toBeUndefined();
+    expect(breakdown.final).toBe(6);
+  });
 });

--- a/engine/src/__tests__/main-actions.test.ts
+++ b/engine/src/__tests__/main-actions.test.ts
@@ -1201,7 +1201,8 @@ describe("combat details", () => {
   // modifier stands in for any modifier source (location passive, item, injury
   // penalty, a future StatModifierListener) — all fold into one sum. Combat is
   // multi-round, so we assert the tied *pair* resolves against the attacker,
-  // not the terminal state (the injured attacker fights on in later rounds).
+  // not the terminal state — under drop-out survivor semantics the injured
+  // attacker leaves the pool after this round rather than fighting on.
   it("resolves a tied combat pair against the attacker (injure_attacker)", () => {
     const attacker = makeUnit({ ownerId: ACTIVE, strength: 5 });
     attacker.statModifiers = [

--- a/engine/src/__tests__/mission-helpers.test.ts
+++ b/engine/src/__tests__/mission-helpers.test.ts
@@ -7,6 +7,8 @@ import {
   parseRewards,
 } from "../mission-helpers";
 import { isAttribute } from "../attributes";
+import { createTestGame } from "./helpers";
+import { rebuildListeners } from "../listeners/rebuild";
 import type { UnitCard } from "../types";
 
 function unit(attrs: string[], overrides?: Partial<UnitCard>): UnitCard {
@@ -143,6 +145,29 @@ describe("checkMissionRequirements", () => {
     const reqs = parseRequirements("strength_15");
     const units = [unit([], { strength: 5 }), unit([], { strength: 5 })];
     expect(checkMissionRequirements(reqs, units)).toBe(false); // 10 < 15
+  });
+
+  it("stat: an injured contributor's penalty can flip a mission from met to unmet", () => {
+    // Injury is a global -1 to all stats (rules/README.md Unit status), applied
+    // to mission stat checks via the same getModifiedStat path production uses
+    // — but only when state+queries are supplied. strength_16 with two
+    // strength-8 units is met at 16; injuring one drops the modified sum to
+    // 8 + (8-1) = 15 → unmet. This closes the mission leg of the #171 "one
+    // primitive applies the injury penalty everywhere" claim.
+    const reqs = parseRequirements("strength_16");
+    const state = createTestGame();
+    const { queries } = rebuildListeners(state);
+
+    const healthy1 = unit([], { id: "h1", strength: 8 });
+    const healthy2 = unit([], { id: "h2", strength: 8 });
+    const hurt = unit([], { id: "i1", strength: 8, injured: true });
+
+    // Both healthy → 16 >= 16 (met).
+    expect(checkMissionRequirements(reqs, [healthy1, healthy2], state, queries)).toBe(true);
+    // One injured → 8 + 7 = 15 < 16 (unmet) once the penalty is applied.
+    expect(checkMissionRequirements(reqs, [healthy1, hurt], state, queries)).toBe(false);
+    // Without state+queries the raw fallback ignores injury → 16, still met.
+    expect(checkMissionRequirements(reqs, [healthy1, hurt])).toBe(true);
   });
 
   it("stat: non-attribute units still contribute to stat sum", () => {

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -690,8 +690,11 @@ function handleAttack(
 
   let rng = fromState(draft.rngState);
 
-  // Auto-resolve combat rounds
-  const maxRounds = 10; // safety limit
+  // Auto-resolve combat rounds. Drop-out survivor semantics already guarantee
+  // termination (every matchup removes its loser from the pool); this cap is a
+  // documented safety limit for pathological states — see rules/README.md
+  // Combat ([var:combat_round_cap]).
+  const maxRounds = getConfigNumber(draft, "combat_round_cap", 10);
   for (let round = 0; round < maxRounds; round++) {
     // Drop-out survivor semantics (rules/README.md Combat step 6, "Next round
     // or end"): the first round rolls all committed units, but subsequent

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -26,7 +26,7 @@ import { rebuildListeners } from "./listeners/rebuild";
 import { getModifiedStatWithSources, getModifiedCost, getModifiedAPCost } from "./listeners/query";
 import type { EmitFn, QueryListener } from "./listeners/types";
 import { needsLocationTarget } from "./valid-actions";
-import { killUnit, injureUnit, dropEquippedItems } from "./unit-helpers";
+import { killUnit, injureUnit, dropEquippedItems, decideKillVsInjure, computeContestPower } from "./unit-helpers";
 import type {
   ActionDef,
   ActivePassiveEvent,
@@ -798,13 +798,12 @@ function buildCombatantRoll(
       delta: -clampedFloor,
     });
   }
-  const strength = Math.max(0, clampedFloor);
   return {
     unit,
     baseStrength: breakdown.base,
     modifiers,
     roll,
-    power: strength + roll,
+    power: computeContestPower(breakdown.base, sum, roll),
     injuredBefore,
   };
 }
@@ -840,8 +839,9 @@ export function deriveCombatOutcome(
   const winnerPower = attackerWins ? atkPower : defPower;
   const loserPower = attackerWins ? defPower : atkPower;
   const loserInjured = attackerWins ? defInjured : atkInjured;
-  const isKill = winnerPower >= killRatio * loserPower;
-  const loserKilled = isKill || loserInjured;
+  // Single source of truth for kill-vs-injure — shared with DSL stat contests
+  // (executor.ts:executeContest) via unit-helpers.decideKillVsInjure.
+  const loserKilled = decideKillVsInjure(loserInjured, winnerPower, loserPower, killRatio) === "kill";
   return attackerWins
     ? (loserKilled ? "kill_defender" : "injure_defender")
     : (loserKilled ? "kill_attacker" : "injure_attacker");

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -698,20 +698,18 @@ function handleAttack(
 
     if (livingAttackers.length === 0 || livingDefenders.length === 0) break;
 
-    const injuryPenalty = getConfigNumber(draft, "injury_stat_penalty", 1);
-
     const atkRolls: CombatantRoll[] = [];
     for (const u of livingAttackers) {
       const [roll, nextRng] = uniformIntDistribution(1, 6, rng);
       rng = nextRng;
-      atkRolls.push(buildCombatantRoll(draft, queries, u, "attacker", row, col, roll, injuryPenalty));
+      atkRolls.push(buildCombatantRoll(draft, queries, u, "attacker", row, col, roll));
     }
 
     const defRolls: CombatantRoll[] = [];
     for (const u of livingDefenders) {
       const [roll, nextRng] = uniformIntDistribution(1, 6, rng);
       rng = nextRng;
-      defRolls.push(buildCombatantRoll(draft, queries, u, "defender", row, col, roll, injuryPenalty));
+      defRolls.push(buildCombatantRoll(draft, queries, u, "defender", row, col, roll));
     }
 
     // Sort by power descending, pair highest vs highest
@@ -767,7 +765,6 @@ function buildCombatantRoll(
   row: number,
   col: number,
   roll: number,
-  injuryPenalty: number,
 ): CombatantRoll {
   const breakdown = getModifiedStatWithSources(
     draft as MainGameState,
@@ -777,17 +774,11 @@ function buildCombatantRoll(
     { row, col },
     { role, row, col },
   );
+  // The injury penalty is now a global stat modifier applied inside
+  // getModifiedStatWithSources, so the "injured" chip already lives in
+  // `breakdown.modifiers` — no combat-specific push needed here.
   const injuredBefore = unit.injured;
   const modifiers: ModifierEntry[] = [...breakdown.modifiers];
-  if (injuredBefore && injuryPenalty !== 0) {
-    // Synthesize a `definitionId: "injured"` source so the breakdown chip
-    // reads "injured" rather than the unit name. `cardId` stays as the
-    // unit instance for downstream tooltip resolution.
-    modifiers.push({
-      source: { type: "unit", cardId: unit.id, definitionId: "injured" },
-      delta: -injuryPenalty,
-    });
-  }
   const sum = modifiers.reduce((acc, m) => acc + m.delta, 0);
   const clampedFloor = breakdown.base + sum;
   if (clampedFloor < 0) {

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -690,10 +690,13 @@ function handleAttack(
 
   let rng = fromState(draft.rngState);
 
-  // Auto-resolve combat rounds. Drop-out survivor semantics already guarantee
-  // termination (every matchup removes its loser from the pool); this cap is a
-  // documented safety limit for pathological states — see rules/README.md
-  // Combat ([var:combat_round_cap]).
+  // Auto-resolve combat rounds. Drop-out survivor semantics guarantee the loop
+  // terminates regardless of this cap: every matchup removes its loser (killed,
+  // or injured → out next round), so the fighting pool strictly shrinks. The
+  // worst case is the larger committed side's size — a lone unit injuring one
+  // of N enemies per round takes N rounds — so this cap only bounds combats
+  // with unusually large unit stacks; normal combats end well within it. See
+  // rules/README.md Combat design note ([var:combat_round_cap:10]).
   const maxRounds = getConfigNumber(draft, "combat_round_cap", 10);
   for (let round = 0; round < maxRounds; round++) {
     // Drop-out survivor semantics (rules/README.md Combat step 6, "Next round

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -693,8 +693,15 @@ function handleAttack(
   // Auto-resolve combat rounds
   const maxRounds = 10; // safety limit
   for (let round = 0; round < maxRounds; round++) {
-    const livingAttackers = attackers.filter((u) => !isDeadOrRemoved(cell, u));
-    const livingDefenders = defenders.filter((u) => !isDeadOrRemoved(cell, u));
+    // Drop-out survivor semantics (rules/README.md Combat step 6, "Next round
+    // or end"): the first round rolls all committed units, but subsequent
+    // rounds continue only "surviving (non-injured, non-killed)" units. An
+    // injured unit therefore fights the round in which it is hurt, then leaves
+    // the pool. Because every matchup removes its loser (killed, or injured →
+    // out next round), the combined fighting pool strictly shrinks each round,
+    // guaranteeing termination.
+    const livingAttackers = attackers.filter((u) => !isDeadOrRemoved(cell, u) && (round === 0 || !u.injured));
+    const livingDefenders = defenders.filter((u) => !isDeadOrRemoved(cell, u) && (round === 0 || !u.injured));
 
     if (livingAttackers.length === 0 || livingDefenders.length === 0) break;
 

--- a/engine/src/effect-dsl/executor.ts
+++ b/engine/src/effect-dsl/executor.ts
@@ -6,7 +6,7 @@ import type { Card, GameEvent, LocationCard, MainGameState, ModifierSource, Stat
 import type { QueryListener, EmitFn } from "../listeners/types";
 import { getPlayerById, getConfigNumber } from "../state-helpers";
 import { drawOneCard } from "../deck-helpers";
-import { killUnit, injureUnit, decideKillVsInjure } from "../unit-helpers";
+import { killUnit, injureUnit, decideKillVsInjure, computeContestPower } from "../unit-helpers";
 import { findUnitOnGrid } from "../grid-helpers";
 import { getModifiedStatWithSources } from "../listeners/query";
 
@@ -553,9 +553,9 @@ function executeContest(step: Step, ctx: ExecutionContext): void {
   ctx.rng = rng2;
 
   const atkSum = atkBreakdown.modifiers.reduce((acc, m) => acc + m.delta, 0);
-  const atkPower = Math.max(0, atkBreakdown.base + atkSum) + atkRoll;
+  const atkPower = computeContestPower(atkBreakdown.base, atkSum, atkRoll);
   const defSum = defBreakdown.modifiers.reduce((acc, m) => acc + m.delta, 0);
-  const defPower = Math.max(0, defBreakdown.base + defSum) + defRoll;
+  const defPower = computeContestPower(defBreakdown.base, defSum, defRoll);
 
   // Ties go to defender
   const attackerWins = atkPower > defPower;

--- a/engine/src/listeners/query.ts
+++ b/engine/src/listeners/query.ts
@@ -1,5 +1,6 @@
 import type { Action, Card, MainAction, MainGameState, ModifierEntry, ModifierSource, UnitCard } from "../types";
 import { parseCost } from "../cost-helpers";
+import { getConfigNumber } from "../state-helpers";
 import type {
   APQueryContext,
   CostModifierListener,
@@ -56,6 +57,20 @@ export function getModifiedStatWithSources(
     // source proxy gets revoked when `produce` returns and any later
     // read throws "Proxy has already been revoked".
     modifiers.push({ source: cloneModifierSource(mod.source), delta: mod.delta });
+  }
+
+  // Injured units take a global -injury_stat_penalty to every stat
+  // (rules/README.md Unit status). Synthesized here — the single source of
+  // truth for effective stats — so combat, DSL contests, and mission stat
+  // checks all apply it uniformly. `definitionId: "injured"` labels the chip.
+  if (unit.injured) {
+    const penalty = getConfigNumber(state, "injury_stat_penalty", 1);
+    if (penalty !== 0) {
+      modifiers.push({
+        source: { type: "unit", cardId: unit.id, definitionId: "injured" },
+        delta: -penalty,
+      });
+    }
   }
 
   const sum = modifiers.reduce((acc, m) => acc + m.delta, 0);

--- a/engine/src/listeners/query.ts
+++ b/engine/src/listeners/query.ts
@@ -62,7 +62,8 @@ export function getModifiedStatWithSources(
   // Injured units take a global -injury_stat_penalty to every stat
   // (rules/README.md Unit status). Synthesized here — the single source of
   // truth for effective stats — so combat, DSL contests, and mission stat
-  // checks all apply it uniformly. `definitionId: "injured"` labels the chip.
+  // checks (the last via the `getModifiedStat` wrapper) all apply it
+  // uniformly. `definitionId: "injured"` labels the chip.
   if (unit.injured) {
     const penalty = getConfigNumber(state, "injury_stat_penalty", 1);
     if (penalty !== 0) {

--- a/engine/src/unit-helpers.ts
+++ b/engine/src/unit-helpers.ts
@@ -70,6 +70,14 @@ export function decideKillVsInjure(
   return "injure";
 }
 
+/** Pure — effective contest power: the stat clamped at 0 (negative effective
+ *  stats contribute 0 for v0.1 — see stat-contests.md #156) plus the die roll.
+ *  Shared by combat matchups (`apply-main.ts:buildCombatantRoll`) and DSL stat
+ *  contests (`executor.ts:executeContest`) so both compute power identically. */
+export function computeContestPower(base: number, modifierSum: number, roll: number): number {
+  return Math.max(0, base + modifierSum) + roll;
+}
+
 /** Drop all items equipped to a unit at the unit's location. */
 export function dropEquippedItems(
   cell: Draft<{ units: UnitCard[]; items: ItemCard[] }>,

--- a/rules/README.md
+++ b/rules/README.md
@@ -244,17 +244,15 @@ intended design but is **not yet implemented** (see #164). The engine
 currently auto-resolves combat atomically: the attacker commits units,
 both sides are paired greedily highest-power vs highest-power, excess
 units on the larger side sit out lowest-power-first, and all rounds run
-without pausing for player decisions. Two further deviations from the
-text above: (1) combat is capped at a 10-round engine safety limit;
-(2) injured units are **not** removed between rounds — they keep fighting
-and re-roll (with the injury penalty) each round, whereas the Next round
-step continues only "surviving (non-injured, non-killed)" units;
-reconciling this per-round survivor/injury semantics with the contest
-primitive is tracked in #169. The injure/kill consequences and
-tie-to-defender rule *are* implemented and match this text. Until #164
-lands, do not build card designs on the tactical layer or on injured
-units dropping out mid-combat — validate such designs against engine
-behavior.]
+without pausing for player decisions. The injure/kill consequences, the
+tie-to-defender rule, and the drop-out survivor semantics (injured units
+leave the fighting pool between rounds, per the Next round or end step)
+*are* implemented and match this text. As a safety limit, combat
+resolution is capped at [var:combat_round_cap:10] rounds — drop-out
+already guarantees termination well within this bound, so the cap only
+guards against pathological states. Until #164 lands, do not build card
+designs on the tactical layer (defender-assigned matchups, sit-out,
+per-round retreat) — validate such designs against engine behavior.]
 
 > See [Market and Economy Rules](market.md) for details on the Buy action.
 

--- a/rules/README.md
+++ b/rules/README.md
@@ -249,8 +249,10 @@ tie-to-defender rule, and the drop-out survivor semantics (injured units
 leave the fighting pool between rounds, per the Next round or end step)
 *are* implemented and match this text. As a safety limit, combat
 resolution is capped at [var:combat_round_cap:10] rounds — drop-out
-already guarantees termination well within this bound, so the cap only
-guards against pathological states. Until #164 lands, do not build card
+guarantees termination regardless (each round removes every matchup's
+loser), and normal combats finish in far fewer rounds; the cap only
+bounds combats with unusually large unit stacks (worst case scales with
+the larger committed side's size). Until #164 lands, do not build card
 designs on the tactical layer (defender-assigned matchups, sit-out,
 per-round retreat) — validate such designs against engine behavior.]
 


### PR DESCRIPTION
## Summary

Unify combat matchup resolution onto the shared **strength stat-contest** primitive, per the #154 decision (Option A: multi-unit combat orchestrating one shared contest primitive). Surviving-useful part of the closed #153.

Each combat matchup now *literally is* a strength stat contest — same power formula, same tie rule, same kill/injure predicate — instead of combat carrying a parallel resolution path.

## What changed (by commit)

| Part | Commit | Change |
|------|--------|--------|
| A | `unify combat & contest onto one primitive` | Shared `computeContestPower` + `deriveCombatOutcome` delegates to `decideKillVsInjure`. Behavior-preserving. |
| B | `apply the injury stat penalty globally` | Move the injury penalty into `getModifiedStatWithSources` (single source of truth); remove combat's hand-applied push. |
| C | `drop-out combat survivor semantics` | Injured units leave the fighting pool between rounds (rules step 6), instead of re-rolling until killed. |
| D+E | `combat round cap as documented variant; reconcile rules` | Cap becomes `[var:combat_round_cap:10]`; rewrite the `[design:]` note. |
| F | `Tests & doc precision from PR review` | Coverage for injury-in-DSL-contest, `combat_round_cap` override/default, no-double-count guard, `computeContestPower` unit tests, pre-injured round-0 drop, and a mission met→unmet flip; soften the termination-bound wording and fix the `[var:combat_round_cap:10]` token in the round-cap comment. |

## Decisions surfaced for review (engine ↔ rules agreement)

1. **Survivor/injury semantics → drop-out.** Injured units now leave the pool after the round they're hurt (surviving injured at the location), matching `rules/README.md` Combat step 6. The first round still rolls all committed units, so a pre-injured committed unit fights once. *Rationale:* the rules already stated this; the old "grind injured units to death" behavior was the deviation. Makes injury a meaningful state and guarantees termination.
2. **Round cap → kept & documented**, not lifted. Now `[var:combat_round_cap:10]`; drop-out already guarantees termination regardless, so the cap only bounds combats with unusually large unit stacks (worst case scales with the larger committed side's size), not a small constant.
3. **Injury penalty made global (bonus fix).** It was combat-only, contradicting `rules/README.md` "−1 to all stats" — DSL contests and mission stat-checks silently ignored it. Now applied uniformly. *This changes injured-unit outcomes in DSL contests and mission stat-checks — a real balance change, flagged for review.*
4. **`winnerId` retained here.** Its removal is spun out to #172 (depends on #45) to avoid a schema change mid-refactor.

The two `[design:]` engine-deviation callouts in `rules/README.md` Combat that named #169 are removed.

## Related issues spun out during this work
- **#172** — retire the combat-winner concept (`winnerId`); depends on #45.
- **#173** — mission stat-check raw-stat fallback bypasses modifiers (surfaced by decision 3; now documented by a test asserting the raw path ignores injury).
- **#170** closed → per-opponent requirement folded into **#141** (both post-v0.1).

## Verification
- `bun test` (engine): **566 pass / 0 fail** (added coverage: injury penalty inside DSL contests, `combat_round_cap` override + default, no-double-count guard, `computeContestPower` unit tests, pre-injured round-0 drop-out, and a mission met→unmet flip).
- `bun run typecheck`: clean.
- `bun library/build.ts` + rules-config build: valid (`combat_round_cap` surfaces in `rules/build/baseline.json`).

Closes #169
