### PR TITLE
#165 — Engine: mid-combat suspension between rounds

### DIFF
--- a/engine/VISIBILITY.md
+++ b/engine/VISIBILITY.md
@@ -1,0 +1,111 @@
+# Visibility borders
+
+A **living, non-exhaustive** reference for what information each player can and
+cannot see. It exists so that card design (and client work) can reason about
+visibility without reverse-engineering the filter every time. When in doubt, the
+**source of truth is `getVisibleState` in `engine/src/visible-state.ts`** — this
+doc summarizes it, it does not replace it. If you change the filter, update this
+file in the same PR.
+
+Card designers: if a card wants to *leverage* visibility (reveal hidden
+information, or hide something normally public), start here to see where the
+current borders are, then wire it through the `reveals` provider (see
+[Bending the borders](#bending-the-borders)).
+
+---
+
+## The three tiers
+
+Every field on `VisibleState` falls into one of three tiers:
+
+| Tier | Who sees it | Examples |
+|------|-------------|----------|
+| **Public** | every viewer, unredacted | grid, market, turn, scores, **combatPrompt** |
+| **Private** | only the acting player | `pickPrompt` (the picker), `viewPrompt` (the viewer) |
+| **Redacted** | shape/counts public, contents hidden per-viewer | opponent hands, decks, face-down traps |
+
+Teammates are treated as **self** — they share full visibility (see
+`isTeammate` in `visible-state.ts`).
+
+---
+
+## Surface-by-surface
+
+### Public — all viewers, unredacted
+- `config`, `phase`, `turn`, `currentPlayerId`, `turnOrder`
+- `grid` — the whole board, including every unit/item/location on it
+- `market`
+- `winner`, `scores` (ended phase)
+- `middleArea`, `seedingStep` (seeding phase)
+- **`combatPrompt`** — combat is fully open information. When a combat suspends
+  between rounds (#165), *every* viewer sees the full prompt (cell, round,
+  committed unit-id lists, and which player must decide). This is deliberately
+  unlike `pickPrompt`/`viewPrompt`. Rationale: the units in the prompt are
+  already on the public grid, so nothing new leaks — and both sides watching a
+  fight need to see it pause. See #165, and #166–#168 for the decisions that
+  will drive real pauses.
+
+### Private — only the acting player
+- `pickPrompt` — surfaced **only** to `pickPrompt.playerId`. A `peek()`'s
+  candidate cards must not leak to opponents. Present in both main and seeding
+  (e.g. Scholar's top-5 reorder).
+- `viewPrompt` — surfaced **only** to `viewPrompt.playerId`. Carries opponent
+  hand contents captured by `peek(opponent + hand)`; leaking it would defeat the
+  hidden-hand rule.
+
+### Redacted — counts public, contents hidden (`toOpponentView`)
+For every opponent, these are reduced to sizes/counts, not contents:
+- `hand` → `handSize`
+- `seedingDeck` / `mainDeck` / `marketDeck` / `prospectDeck` / `discardPile`
+  → `*Size` counts only
+Still public for opponents: `gold`, `vp`, `hq`, `activePolicies`,
+`passiveEvents`, and `activeTraps` (redacted — see below).
+
+`self` and `teammates` are returned as **full `PlayerState`** — no redaction.
+
+### Face-down traps
+`activeTraps` are visible as *existence + target* (`TrapView` = `{ targetId,
+cardId }`) but the **card contents are redacted** unless the viewer has explicit
+reveal rights for that trap (`redactTrap`). Rights come from the reveal system
+below.
+
+---
+
+## Bending the borders
+
+Cards change visibility through a **`reveals` provider** — an optional function a
+card's effect factory returns, shaped `(state, viewerId) => Partial<Reveals>`.
+`computeReveals` walks every active card (grid + per-player surfaces) and merges
+the contributions for the specific viewer. Two levers exist today:
+
+- **`mainDeckTop`** — expose the top card of a main deck to a viewer. Example:
+  *Alexandria Harbor* reveals the owner's own top card. At most one provider may
+  set `mainDeckTop` per viewer (conflicts **throw**, they are not silently
+  merged).
+- **`revealedTrapIds`** — grant a viewer the right to see specific face-down
+  traps' contents (deduped across providers).
+
+```
+card effect factory ──returns──▶ reveals?: (state, viewerId) => Partial<Reveals>
+                                      │
+                        computeReveals merges per viewer
+                                      │
+                                      ▼
+              VisibleState.reveals  +  trap redaction rights
+```
+
+If you need a *new* kind of reveal (e.g. "see an opponent's hand", "hide a unit
+on the grid"), that is a change to the `Reveals` type and the filter, not just a
+card — extend `Reveals`, teach `getVisibleState`/`computeReveals` to honor it,
+and document the new border here.
+
+---
+
+## Known gaps / not-yet-modeled
+- No mechanism to **hide** something that is otherwise public (e.g. a cloaked
+  unit on the grid) — the grid is all-or-nothing public today.
+- No per-viewer redaction of `market` or `hq`.
+- Multi-opponent `peek` target selection is not implemented — `viewPrompt`
+  currently targets the first non-active player deterministically.
+
+Add rows here as new borders (or gaps) are discovered.

--- a/engine/src/__tests__/main-actions.test.ts
+++ b/engine/src/__tests__/main-actions.test.ts
@@ -856,6 +856,8 @@ describe("mid-combat suspension (#165)", () => {
     expect(allEvents.filter((e) => e.type === "combat_started")).toHaveLength(1);
     // All three defenders killed; the attacker holds the cell.
     expect(cur.grid[0][0].units.map((u) => u.id)).toEqual([attackerId]);
+    // Resuming spends no AP — it was all spent up front on the initiating attack.
+    expect(cur.turn.actionPointsRemaining).toBe(2);
   });
 
   it("rejects any non-resolver action while combat is suspended", () => {
@@ -930,6 +932,132 @@ describe("mid-combat suspension (#165)", () => {
 
     expect(ns.combatPrompt).toBeUndefined();
     expect(events.some((e) => e.type === "combat_resolved")).toBe(true);
+  });
+
+  it("yields identical rolls, grid and winner whether auto-resolved or suspended", () => {
+    // The scope guard's strongest form: suspend/resume must reproduce the exact
+    // auto-resolve outcome. rng is persisted across the suspend boundary, so the
+    // per-round d6 stream — captured here from `combat_pair_resolved` — must
+    // match between the two paths. A resume that re-drew or dropped an rng value
+    // would desync round ≥1 rolls and fail this test even when the win/loss
+    // outcome happens to be roll-insensitive.
+    function rollSequence(events: GameEvent[]): Array<[number, number]> {
+      return events
+        .filter((e) => e.type === "combat_pair_resolved")
+        .map((e) => [e.attacker.roll, e.defender.roll] as [number, number]);
+    }
+
+    // Build one fight, then derive both paths from it so unit instance ids (and
+    // the seed) are identical and the final grids are directly comparable.
+    const { state: base, attackerId } = suspendingCombat();
+
+    // Auto path (seam off): one atomic action.
+    const autoState = produce(base, (d) => {
+      d.config["combat_suspend_between_rounds"] = 0;
+    });
+    const autoRun = applyAction(autoState, { ...attackAction, unitIds: [attackerId] });
+    const autoFinal = autoRun.state as MainGameState;
+
+    // Suspended path (seam on): drive resolve_combat_round to completion.
+    const first = applyAction(base, { ...attackAction, unitIds: [attackerId] });
+    let cur = first.state as MainGameState;
+    const suspEvents: GameEvent[] = [...first.events];
+    let guard = 0;
+    while (cur.combatPrompt) {
+      if (guard++ > 10) throw new Error("combat failed to terminate");
+      const r = applyAction(cur, { type: "resolve_combat_round", playerId: ACTIVE });
+      cur = r.state as MainGameState;
+      suspEvents.push(...r.events);
+    }
+
+    expect(rollSequence(suspEvents)).toEqual(rollSequence(autoRun.events));
+    expect(cur.grid[0][0].units.map((u) => u.id)).toEqual(
+      autoFinal.grid[0][0].units.map((u) => u.id),
+    );
+    const suspWinner = suspEvents.find((e) => e.type === "combat_resolved");
+    const autoWinner = autoRun.events.find((e) => e.type === "combat_resolved");
+    expect(suspWinner).toEqual(autoWinner);
+  });
+
+  it("keeps an injured survivor out of the resumed round and alive in the cell", () => {
+    // Drop-out survivor semantics across a suspend boundary: an already-injured
+    // unit must not fight the resumed round, yet must remain in the cell.
+    // Constructed synthetically (a real fight can't deterministically injure
+    // without killing under d6 swing) — the decider is the active attacker so
+    // the resolve is accepted.
+    const attacker = makeUnit({ ownerId: ACTIVE, strength: 100 });
+    const dInjured = makeUnit({ ownerId: OTHER, strength: 1, injured: true });
+    const dHealthy = makeUnit({ ownerId: OTHER, strength: 1 });
+    const state = gameWith((d) => {
+      d.config["combat_suspend_between_rounds"] = 1;
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(attacker, dInjured, dHealthy);
+      d.combatPrompt = {
+        playerId: ACTIVE,
+        row: 0,
+        col: 0,
+        attackerId: ACTIVE,
+        defenderId: OTHER,
+        round: 1,
+        attackerUnitIds: [attacker.id],
+        defenderUnitIds: [dInjured.id, dHealthy.id],
+      };
+    });
+
+    const { state: next, events } = applyAction(state, {
+      type: "resolve_combat_round",
+      playerId: ACTIVE,
+    });
+    const ns = next as MainGameState;
+
+    // Only the healthy defender was ever paired; the injured one sat out.
+    const pairedDefenders = events
+      .filter((e) => e.type === "combat_pair_resolved")
+      .map((e) => e.defender.unitId);
+    expect(pairedDefenders).toEqual([dHealthy.id]);
+    // The injured survivor is still in the cell; the healthy one was killed.
+    const survivors = ns.grid[0][0].units.map((u) => u.id);
+    expect(survivors).toContain(dInjured.id);
+    expect(survivors).not.toContain(dHealthy.id);
+  });
+
+  it("returns no valid actions to a non-decider while combat is suspended", () => {
+    // Documents the current contract: getValidActions returns [] for any
+    // non-active player, and today the decider is always the active attacker.
+    // #166 (defender-assigned decision) must revisit both this and the
+    // active-player gate in apply-action.ts (see the TODO there).
+    const { state, attackerId } = suspendingCombat();
+    const { state: next } = applyAction(state, { ...attackAction, unitIds: [attackerId] });
+
+    expect(getValidActions(next as MainGameState, OTHER)).toEqual([]);
+  });
+
+  it("throws if multiple prompts are set at once (mutual-exclusion invariant)", () => {
+    // combatPrompt / pickPrompt / viewPrompt are mutually exclusive; a producer
+    // that co-sets two must fail loud at dispatch rather than deadlock.
+    const state = gameWith((d) => {
+      d.combatPrompt = {
+        playerId: ACTIVE,
+        row: 0,
+        col: 0,
+        attackerId: ACTIVE,
+        defenderId: OTHER,
+        round: 1,
+        attackerUnitIds: [],
+        defenderUnitIds: [],
+      };
+      d.pickPrompt = {
+        playerId: ACTIVE,
+        kind: "deck_pick",
+        count: 1,
+        options: ["a", "b"],
+        source: "main_deck",
+      };
+    });
+
+    expect(() =>
+      applyAction(state, { type: "resolve_combat_round", playerId: ACTIVE }),
+    ).toThrow("multiple prompts are set");
   });
 });
 

--- a/engine/src/__tests__/main-actions.test.ts
+++ b/engine/src/__tests__/main-actions.test.ts
@@ -774,6 +774,166 @@ describe("attack", () => {
 });
 
 // ---------------------------------------------------------------------------
+// mid-combat suspension (#165)
+// ---------------------------------------------------------------------------
+//
+// A 1-vs-3 stack fights one pair per round (min(1,3) = 1), so a lone strong
+// attacker (str 100) deterministically kills one str-1 defender per round —
+// three rounds, with both sides still having uninjured combatants after rounds
+// 0 and 1. That gives a real between-rounds boundary for the suspension hook to
+// pause at. The `combat_suspend_between_rounds` config is the #165 test seam:
+// `combatDecisionPending` returns true, standing in for the real pause
+// conditions that arrive with #166–#168.
+describe("mid-combat suspension (#165)", () => {
+  function suspendingCombat(): {
+    state: MainGameState;
+    attackerId: string;
+    defenderIds: string[];
+  } {
+    const attacker = makeUnit({ ownerId: ACTIVE, strength: 100 });
+    const d1 = makeUnit({ ownerId: OTHER, strength: 1 });
+    const d2 = makeUnit({ ownerId: OTHER, strength: 1 });
+    const d3 = makeUnit({ ownerId: OTHER, strength: 1 });
+    const state = gameWith((d) => {
+      d.config["combat_suspend_between_rounds"] = 1;
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(attacker, d1, d2, d3);
+    });
+    return { state, attackerId: attacker.id, defenderIds: [d1.id, d2.id, d3.id] };
+  }
+
+  const attackAction = { type: "attack" as const, playerId: ACTIVE, row: 0, col: 0 };
+
+  it("suspends between rounds without resolving combat", () => {
+    const { state, attackerId } = suspendingCombat();
+
+    const { state: next, events } = applyAction(state, {
+      ...attackAction,
+      unitIds: [attackerId],
+    });
+    const ns = next as MainGameState;
+
+    // Combat began and paused: started but not resolved.
+    expect(events.map((e) => e.type)).toContain("combat_started");
+    expect(events.some((e) => e.type === "combat_resolved")).toBe(false);
+    // Exactly one pair (the opening round) resolved before the pause.
+    expect(events.filter((e) => e.type === "combat_pair_resolved")).toHaveLength(1);
+
+    // The prompt carries the resumable state, awaiting round 1.
+    expect(ns.combatPrompt).toBeDefined();
+    expect(ns.combatPrompt?.round).toBe(1);
+    expect(ns.combatPrompt?.playerId).toBe(ACTIVE);
+    expect(ns.combatPrompt?.attackerId).toBe(ACTIVE);
+    expect(ns.combatPrompt?.defenderId).toBe(OTHER);
+    expect(ns.combatPrompt?.attackerUnitIds).toEqual([attackerId]);
+
+    // AP was spent up front on the initiating attack (not on resume).
+    expect(ns.turn.actionPointsRemaining).toBe(2);
+  });
+
+  it("resumes via resolve_combat_round and eventually completes", () => {
+    const { state, attackerId } = suspendingCombat();
+
+    const first = applyAction(state, { ...attackAction, unitIds: [attackerId] });
+    let cur = first.state as MainGameState;
+    const allEvents: GameEvent[] = [...first.events];
+
+    // Drive resolve_combat_round until the fight terminates. Each resume fights
+    // exactly one more round then re-suspends (seam still on) until a side empties.
+    let guard = 0;
+    while (cur.combatPrompt) {
+      if (guard++ > 10) throw new Error("combat failed to terminate");
+      const r = applyAction(cur, { type: "resolve_combat_round", playerId: ACTIVE });
+      cur = r.state as MainGameState;
+      allEvents.push(...r.events);
+    }
+
+    // Emitted exactly once, at the true end, with the attacker as winner.
+    const resolved = allEvents.filter((e) => e.type === "combat_resolved");
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]).toMatchObject({ type: "combat_resolved", winnerId: ACTIVE });
+    // combat_started is emitted only once, never on resume.
+    expect(allEvents.filter((e) => e.type === "combat_started")).toHaveLength(1);
+    // All three defenders killed; the attacker holds the cell.
+    expect(cur.grid[0][0].units.map((u) => u.id)).toEqual([attackerId]);
+  });
+
+  it("rejects any non-resolver action while combat is suspended", () => {
+    const { state, attackerId } = suspendingCombat();
+    const { state: next } = applyAction(state, { ...attackAction, unitIds: [attackerId] });
+
+    expect(() =>
+      applyAction(next, { type: "pass", playerId: ACTIVE }),
+    ).toThrow("suspended combat must be resolved first");
+  });
+
+  it("rejects resolve_combat_round from a non-decider", () => {
+    // Construct a suspended combat whose decider is NOT the active player, so the
+    // active player's submit clears the turn-ownership check and reaches the
+    // handler's own decider guard. (In #165 the decider is always the attacker,
+    // i.e. the active player, so this mismatch is only reachable synthetically —
+    // but #166 hands the decision to the defender, where this guard bites.)
+    const state = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.combatPrompt = {
+        playerId: OTHER,
+        row: 0,
+        col: 0,
+        attackerId: ACTIVE,
+        defenderId: OTHER,
+        round: 1,
+        attackerUnitIds: [],
+        defenderUnitIds: [],
+      };
+    });
+
+    expect(() =>
+      applyAction(state, { type: "resolve_combat_round", playerId: ACTIVE }),
+    ).toThrow("pending combat decision is for");
+  });
+
+  it("rejects resolve_combat_round when no combat is suspended", () => {
+    const state = gameWith(() => {});
+    expect(() =>
+      applyAction(state, { type: "resolve_combat_round", playerId: ACTIVE }),
+    ).toThrow("no suspended combat");
+  });
+
+  it("offers only resolve_combat_round to the decider while suspended", () => {
+    const { state, attackerId } = suspendingCombat();
+    const { state: next } = applyAction(state, { ...attackAction, unitIds: [attackerId] });
+
+    expect(getValidActions(next as MainGameState, ACTIVE)).toEqual([
+      { type: "resolve_combat_round", playerId: ACTIVE },
+    ]);
+  });
+
+  it("auto-resolves atomically when the decision seam is off", () => {
+    // Same 1-vs-3 stack, but without the seam: combat must resolve in a single
+    // action with no lingering prompt — the #165 scope guard.
+    const attacker = makeUnit({ ownerId: ACTIVE, strength: 100 });
+    const defenders = [
+      makeUnit({ ownerId: OTHER, strength: 1 }),
+      makeUnit({ ownerId: OTHER, strength: 1 }),
+      makeUnit({ ownerId: OTHER, strength: 1 }),
+    ];
+    const state = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(attacker, ...defenders);
+    });
+
+    const { state: next, events } = applyAction(state, {
+      ...attackAction,
+      unitIds: [attacker.id],
+    });
+    const ns = next as MainGameState;
+
+    expect(ns.combatPrompt).toBeUndefined();
+    expect(events.some((e) => e.type === "combat_resolved")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // turn lifecycle
 // ---------------------------------------------------------------------------
 

--- a/engine/src/__tests__/valid-actions.test.ts
+++ b/engine/src/__tests__/valid-actions.test.ts
@@ -44,6 +44,7 @@ describe("getValidActions", () => {
         scores: {},
         pickPrompt: undefined,
         viewPrompt: undefined,
+        combatPrompt: undefined,
       };
       const actions = getValidActions(
         endedState,
@@ -78,6 +79,7 @@ describe("getValidActions", () => {
         scores: {},
         pickPrompt: undefined,
         viewPrompt: undefined,
+        combatPrompt: undefined,
       };
       expect(() => getActivePlayerId(endedState)).toThrow(
         "No active player in ended phase",

--- a/engine/src/__tests__/visible-state.test.ts
+++ b/engine/src/__tests__/visible-state.test.ts
@@ -223,6 +223,7 @@ describe("getVisibleState", () => {
         scores: {},
         pickPrompt: undefined,
         viewPrompt: undefined,
+        combatPrompt: undefined,
       };
       const vis = getVisibleState(endedState, "p1");
       expect(vis.phase).toBe("ended");

--- a/engine/src/__tests__/visible-state.test.ts
+++ b/engine/src/__tests__/visible-state.test.ts
@@ -231,6 +231,31 @@ describe("getVisibleState", () => {
     });
   });
 
+  describe("combatPrompt (public info)", () => {
+    const prompt = {
+      playerId: "p1",
+      row: 0,
+      col: 0,
+      attackerId: "p1",
+      defenderId: "p2",
+      round: 1,
+      attackerUnitIds: ["u1"],
+      defenderUnitIds: ["u2", "u3"],
+    };
+
+    it("surfaces the full prompt unredacted to every viewer, decider or not", () => {
+      const state = produce(createTestGame(), (d) => {
+        d.combatPrompt = prompt;
+      });
+      // Combat is open information, so both the decider (p1) and the opponent
+      // (p2) see the same unredacted prompt — unlike pickPrompt/viewPrompt,
+      // which are private to the acting player. A regression that copied the
+      // pick/view redaction pattern would hide the opponent's view and fail here.
+      expect(getVisibleState(state, "p1").combatPrompt).toEqual(prompt);
+      expect(getVisibleState(state, "p2").combatPrompt).toEqual(prompt);
+    });
+  });
+
   describe("reveals — Alexandria Harbor", () => {
     it("exposes top of own main deck to the owner", () => {
       const state = produce(createTestGame(), (d) => {

--- a/engine/src/__tests__/win-condition.test.ts
+++ b/engine/src/__tests__/win-condition.test.ts
@@ -136,6 +136,28 @@ describe("toEndedState", () => {
     const ended = toEndedState(withPrompt, base.turn.activePlayerId, []);
     expect(ended.pickPrompt).toBeUndefined();
   });
+
+  it("clears a populated combatPrompt when transitioning to ended", () => {
+    const base = createTestGame();
+    const opponentId = base.players.find(
+      (p) => p.id !== base.turn.activePlayerId,
+    )!.id;
+    const withPrompt = produce(base, (d) => {
+      d.combatPrompt = {
+        playerId: d.turn.activePlayerId,
+        row: 0,
+        col: 0,
+        attackerId: d.turn.activePlayerId,
+        defenderId: opponentId,
+        round: 1,
+        attackerUnitIds: [],
+        defenderUnitIds: [],
+      };
+    });
+
+    const ended = toEndedState(withPrompt, base.turn.activePlayerId, []);
+    expect(ended.combatPrompt).toBeUndefined();
+  });
 });
 
 // ---- Integration: game ends via applyAction ----

--- a/engine/src/apply-action.ts
+++ b/engine/src/apply-action.ts
@@ -24,6 +24,13 @@ export function applyAction<S extends GameState>(
 ): ApplyResult {
   const activePlayerId = getActivePlayerId(state);
 
+  // TODO(#166): this gate rejects every non-active player, so it will reject a
+  // defender-assigned `resolve_combat_round` (the defender is normally the
+  // non-active player). When #166 hands the combat decision to the defender,
+  // relax this to also admit the pending prompt's decider
+  // (`state.combatPrompt?.playerId === action.playerId`), and mirror the
+  // fall-through in `getValidActions`. Today decider == attacker == active, so
+  // the paths agree and this is inert.
   if (action.playerId !== activePlayerId) {
     throw new Error(
       `Action from player "${action.playerId}" rejected: it is player "${activePlayerId}"'s turn`,

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -13,6 +13,7 @@ import {
   isPerimeterCell,
 } from "./grid-helpers";
 import { extractRngState } from "./rng";
+import type { RandomGenerator } from "./rng";
 import { findSoleLeader, shouldEndGame, toEndedState } from "./win-condition";
 import {
   advanceTurn,
@@ -35,6 +36,7 @@ import type {
   CombatPrompt,
   CombatSide,
   GameEvent,
+  GridCell,
   ItemCard,
   MainAction,
   ModifierEntry,
@@ -691,8 +693,9 @@ function handleAttack(
 
   // Hand off to the resumable loop from round 0. In the default (auto-resolve)
   // path this runs the whole combat to completion synchronously and emits
-  // `combat_resolved` — a single `attack` yields `combat_started` +
-  // `combat_resolved` in one events array, exactly as before #165.
+  // `combat_resolved` — a single `attack` yields `combat_started`, the per-pair
+  // `combat_pair_resolved` events, and `combat_resolved` in one events array,
+  // exactly as before #165.
   runCombat(
     draft,
     {
@@ -722,7 +725,13 @@ function handleAttack(
  * suspend/resume machinery end-to-end while the real conditions don't exist yet.
  *
  * `round` is the round the decision would gate (always ≥ 1 — combat never pauses
- * before its opening round). Unused by the seam, but #166–#168 will branch on it.
+ * before its opening round; guaranteed by the sole caller, which passes
+ * `round + 1`). Unused by the seam, but #166–#168 will branch on it.
+ *
+ * The seam reads one global config key, so when set it suspends every
+ * between-round of every combat — there is no per-combat scoping. That is fine
+ * for a test-only seam; #166–#168 replace this body with per-combat decision
+ * logic rather than extending the flag.
  */
 function combatDecisionPending(draft: Draft<MainGameState>, round: number): boolean {
   void round;
@@ -730,10 +739,12 @@ function combatDecisionPending(draft: Draft<MainGameState>, round: number): bool
 }
 
 /**
- * Runs combat rounds from `state.round` onward, resuming an in-progress fight.
- * Either completes the combat (emitting `combat_resolved`) or, if a decision is
- * pending between rounds, sets `draft.combatPrompt` and returns without emitting
- * `combat_resolved` — leaving the fight suspended for `resolve_combat_round`.
+ * Runs combat rounds from `state.round` onward. Shared by both callers: the
+ * fresh run from `handleAttack` (round 0) and every `resolve_combat_round`
+ * resume of an in-progress fight. Either completes the combat (emitting
+ * `combat_resolved`) or, if a decision is pending between rounds, sets
+ * `draft.combatPrompt` and returns without emitting `combat_resolved` — leaving
+ * the fight suspended for `resolve_combat_round`.
  *
  * Living combatants are re-resolved from the cell by id each round rather than
  * held as references: units get killed/removed mid-combat, and on resume the
@@ -747,9 +758,9 @@ function runCombat(
   queries: QueryListener[],
 ): void {
   const { row, col, attackerId, defenderId, attackerUnitIds, defenderUnitIds } = state;
-  const cell = draft.grid[row][col];
+  const cell: Draft<GridCell> = draft.grid[row][col];
 
-  let rng = fromState(draft.rngState);
+  let rng: RandomGenerator = fromState(draft.rngState);
 
   // Auto-resolve combat rounds. Drop-out survivor semantics guarantee the loop
   // terminates regardless of this cap: every matchup removes its loser (killed,
@@ -758,7 +769,7 @@ function runCombat(
   // of N enemies per round takes N rounds — so this cap only bounds combats
   // with unusually large unit stacks; normal combats end well within it. See
   // rules/README.md Combat design note ([var:combat_round_cap:10]).
-  const maxRounds = getConfigNumber(draft, "combat_round_cap", 10);
+  const maxRounds: number = getConfigNumber(draft, "combat_round_cap", 10);
   for (let round = state.round; round < maxRounds; round++) {
     // Drop-out survivor semantics (rules/README.md Combat step 6, "Next round
     // or end"): the first round rolls all committed units, but subsequent
@@ -768,8 +779,8 @@ function runCombat(
     // out next round), the combined fighting pool strictly shrinks each round,
     // guaranteeing termination. Units are re-resolved from the cell by id so
     // this is correct whether the round starts fresh or resumes post-suspend.
-    const livingAttackers = livingCombatants(cell, attackerUnitIds, round);
-    const livingDefenders = livingCombatants(cell, defenderUnitIds, round);
+    const livingAttackers = livingCombatants(cell, attackerUnitIds, { ignoreInjured: round === 0 });
+    const livingDefenders = livingCombatants(cell, defenderUnitIds, { ignoreInjured: round === 0 });
 
     if (livingAttackers.length === 0 || livingDefenders.length === 0) break;
 
@@ -800,20 +811,23 @@ function runCombat(
 
     // Between-rounds suspension point (#165). Checked AFTER the round resolves
     // and only when a further round would actually be fought (both sides still
-    // have uninjured combatants) — so a finished combat falls through to
-    // `combat_resolved` instead of pausing, and a resumed combat fights its
-    // round before it can pause again. `combatDecisionPending` is a cheap
-    // config read that is false in every real game, so the next-round peek
-    // below never runs on the default auto-resolve path.
-    if (combatDecisionPending(draft, round + 1)) {
-      const nextAttackers = livingCombatants(cell, attackerUnitIds, round + 1);
-      const nextDefenders = livingCombatants(cell, defenderUnitIds, round + 1);
+    // have uninjured combatants AND the round cap is not reached) — so a
+    // finished or capped combat falls through to `combat_resolved` instead of
+    // pausing, and a resumed combat fights its round before it can pause again.
+    // The `round + 1 < maxRounds` guard prevents a phantom final suspend that
+    // would resume into a zero-iteration loop and silently finalize a draw.
+    // `combatDecisionPending` is a cheap config read that is false in every real
+    // game, so the next-round peek below never runs on the default auto-resolve
+    // path.
+    if (round + 1 < maxRounds && combatDecisionPending(draft, round + 1)) {
+      const nextAttackers = livingCombatants(cell, attackerUnitIds, { ignoreInjured: false });
+      const nextDefenders = livingCombatants(cell, defenderUnitIds, { ignoreInjured: false });
       if (nextAttackers.length > 0 && nextDefenders.length > 0) {
         // Persist rng so resume continues the same roll stream, then hand
         // control back. `combat_resolved` is deliberately NOT emitted — combat
         // is paused, not over.
         draft.rngState = extractRngState(rng) as number[];
-        draft.combatPrompt = { ...state, round: round + 1 };
+        draft.combatPrompt = castDraft({ ...state, round: round + 1 });
         return;
       }
     }
@@ -821,9 +835,11 @@ function runCombat(
 
   draft.rngState = extractRngState(rng) as number[];
 
-  // Determine winner
-  const remainingAttackers = livingCombatants(cell, attackerUnitIds, 0);
-  const remainingDefenders = livingCombatants(cell, defenderUnitIds, 0);
+  // Determine winner. `ignoreInjured` counts every unit still present in the
+  // cell (injured survivors included) — a side is beaten only when it has no
+  // units left at all.
+  const remainingAttackers = livingCombatants(cell, attackerUnitIds, { ignoreInjured: true });
+  const remainingDefenders = livingCombatants(cell, defenderUnitIds, { ignoreInjured: true });
 
   let winnerId: string | null = null;
   if (remainingAttackers.length > 0 && remainingDefenders.length === 0) {
@@ -836,20 +852,21 @@ function runCombat(
 }
 
 /**
- * The units from `unitIds` still fighting this `round`: present in the cell and,
- * on rounds after the first, not injured (drop-out survivor semantics — see
- * `runCombat`). Passing `round: 0` yields simply the units still present, used
- * for winner determination.
+ * The units from `unitIds` still present in the cell. With
+ * `ignoreInjured: false` (rounds after the first) injured units are dropped —
+ * drop-out survivor semantics, see `runCombat`. With `ignoreInjured: true`
+ * every present unit counts (round 0, and winner determination, where an
+ * injured survivor still holds the cell).
  */
 function livingCombatants(
   cell: Draft<{ units: UnitCard[] }>,
-  unitIds: string[],
-  round: number,
+  unitIds: readonly string[],
+  { ignoreInjured }: { ignoreInjured: boolean },
 ): Draft<UnitCard>[] {
   const living: Draft<UnitCard>[] = [];
   for (const id of unitIds) {
     const unit = cell.units.find((u) => u.id === id);
-    if (unit && (round === 0 || !unit.injured)) living.push(unit);
+    if (unit && (ignoreInjured || !unit.injured)) living.push(unit);
   }
   return living;
 }

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -32,6 +32,7 @@ import type {
   ActivePassiveEvent,
   ApplyResult,
   CombatPairOutcome,
+  CombatPrompt,
   CombatSide,
   GameEvent,
   ItemCard,
@@ -688,6 +689,66 @@ function handleAttack(
 
   emit({ type: "combat_started", row, col, attackerId: playerId, defenderId });
 
+  // Hand off to the resumable loop from round 0. In the default (auto-resolve)
+  // path this runs the whole combat to completion synchronously and emits
+  // `combat_resolved` — a single `attack` yields `combat_started` +
+  // `combat_resolved` in one events array, exactly as before #165.
+  runCombat(
+    draft,
+    {
+      playerId,
+      row,
+      col,
+      attackerId: playerId,
+      defenderId,
+      round: 0,
+      attackerUnitIds: attackers.map((u) => u.id),
+      defenderUnitIds: defenders.map((u) => u.id),
+    },
+    emit,
+    queries,
+  );
+}
+
+/**
+ * Whether combat must suspend before running `round` to await a player
+ * decision. This is the #165 suspension hook.
+ *
+ * Returns `false` for every real game today: no production ruleset sets the
+ * seam config, so combat always auto-resolves and no behaviour changes until a
+ * real pause condition lands. #166–#168 replace the body with the actual
+ * decision logic (defender-assigned matchups, sit-out, retreat). The
+ * `combat_suspend_between_rounds` key is a test-only seam — it exercises the
+ * suspend/resume machinery end-to-end while the real conditions don't exist yet.
+ *
+ * `round` is the round the decision would gate (always ≥ 1 — combat never pauses
+ * before its opening round). Unused by the seam, but #166–#168 will branch on it.
+ */
+function combatDecisionPending(draft: Draft<MainGameState>, round: number): boolean {
+  void round;
+  return getConfigNumber(draft, "combat_suspend_between_rounds", 0) === 1;
+}
+
+/**
+ * Runs combat rounds from `state.round` onward, resuming an in-progress fight.
+ * Either completes the combat (emitting `combat_resolved`) or, if a decision is
+ * pending between rounds, sets `draft.combatPrompt` and returns without emitting
+ * `combat_resolved` — leaving the fight suspended for `resolve_combat_round`.
+ *
+ * Living combatants are re-resolved from the cell by id each round rather than
+ * held as references: units get killed/removed mid-combat, and on resume the
+ * pre-suspend references are gone (a fresh `produce()` draft). The committed id
+ * lists in `state` are the durable handle.
+ */
+function runCombat(
+  draft: Draft<MainGameState>,
+  state: CombatPrompt,
+  emit: EmitFn,
+  queries: QueryListener[],
+): void {
+  const { row, col, attackerId, defenderId, attackerUnitIds, defenderUnitIds } = state;
+  const cell = draft.grid[row][col];
+
   let rng = fromState(draft.rngState);
 
   // Auto-resolve combat rounds. Drop-out survivor semantics guarantee the loop
@@ -698,16 +759,17 @@ function handleAttack(
   // with unusually large unit stacks; normal combats end well within it. See
   // rules/README.md Combat design note ([var:combat_round_cap:10]).
   const maxRounds = getConfigNumber(draft, "combat_round_cap", 10);
-  for (let round = 0; round < maxRounds; round++) {
+  for (let round = state.round; round < maxRounds; round++) {
     // Drop-out survivor semantics (rules/README.md Combat step 6, "Next round
     // or end"): the first round rolls all committed units, but subsequent
     // rounds continue only "surviving (non-injured, non-killed)" units. An
     // injured unit therefore fights the round in which it is hurt, then leaves
     // the pool. Because every matchup removes its loser (killed, or injured →
     // out next round), the combined fighting pool strictly shrinks each round,
-    // guaranteeing termination.
-    const livingAttackers = attackers.filter((u) => !isDeadOrRemoved(cell, u) && (round === 0 || !u.injured));
-    const livingDefenders = defenders.filter((u) => !isDeadOrRemoved(cell, u) && (round === 0 || !u.injured));
+    // guaranteeing termination. Units are re-resolved from the cell by id so
+    // this is correct whether the round starts fresh or resumes post-suspend.
+    const livingAttackers = livingCombatants(cell, attackerUnitIds, round);
+    const livingDefenders = livingCombatants(cell, defenderUnitIds, round);
 
     if (livingAttackers.length === 0 || livingDefenders.length === 0) break;
 
@@ -735,17 +797,37 @@ function handleAttack(
       const def = defRolls[i];
       resolveCombatPair(draft, cell, atk, def, row, col, emit);
     }
+
+    // Between-rounds suspension point (#165). Checked AFTER the round resolves
+    // and only when a further round would actually be fought (both sides still
+    // have uninjured combatants) — so a finished combat falls through to
+    // `combat_resolved` instead of pausing, and a resumed combat fights its
+    // round before it can pause again. `combatDecisionPending` is a cheap
+    // config read that is false in every real game, so the next-round peek
+    // below never runs on the default auto-resolve path.
+    if (combatDecisionPending(draft, round + 1)) {
+      const nextAttackers = livingCombatants(cell, attackerUnitIds, round + 1);
+      const nextDefenders = livingCombatants(cell, defenderUnitIds, round + 1);
+      if (nextAttackers.length > 0 && nextDefenders.length > 0) {
+        // Persist rng so resume continues the same roll stream, then hand
+        // control back. `combat_resolved` is deliberately NOT emitted — combat
+        // is paused, not over.
+        draft.rngState = extractRngState(rng) as number[];
+        draft.combatPrompt = { ...state, round: round + 1 };
+        return;
+      }
+    }
   }
 
   draft.rngState = extractRngState(rng) as number[];
 
   // Determine winner
-  const remainingAttackers = attackers.filter((u) => !isDeadOrRemoved(cell, u));
-  const remainingDefenders = defenders.filter((u) => !isDeadOrRemoved(cell, u));
+  const remainingAttackers = livingCombatants(cell, attackerUnitIds, 0);
+  const remainingDefenders = livingCombatants(cell, defenderUnitIds, 0);
 
   let winnerId: string | null = null;
   if (remainingAttackers.length > 0 && remainingDefenders.length === 0) {
-    winnerId = playerId;
+    winnerId = attackerId;
   } else if (remainingDefenders.length > 0 && remainingAttackers.length === 0) {
     winnerId = defenderId;
   }
@@ -753,12 +835,23 @@ function handleAttack(
   emit({ type: "combat_resolved", row, col, winnerId });
 }
 
-/** Check if a unit has been removed from the cell (killed/discarded). */
-function isDeadOrRemoved(
+/**
+ * The units from `unitIds` still fighting this `round`: present in the cell and,
+ * on rounds after the first, not injured (drop-out survivor semantics — see
+ * `runCombat`). Passing `round: 0` yields simply the units still present, used
+ * for winner determination.
+ */
+function livingCombatants(
   cell: Draft<{ units: UnitCard[] }>,
-  unit: Draft<UnitCard>,
-): boolean {
-  return !cell.units.some((u) => u.id === unit.id);
+  unitIds: string[],
+  round: number,
+): Draft<UnitCard>[] {
+  const living: Draft<UnitCard>[] = [];
+  for (const id of unitIds) {
+    const unit = cell.units.find((u) => u.id === id);
+    if (unit && (round === 0 || !unit.injured)) living.push(unit);
+  }
+  return living;
 }
 
 interface CombatantRoll {
@@ -1158,6 +1251,31 @@ function handleDismissView(
   draft.viewPrompt = undefined;
 }
 
+function handleResolveCombatRound(
+  draft: Draft<MainGameState>,
+  playerId: string,
+  emit: EmitFn,
+  queries: QueryListener[],
+): void {
+  const prompt = draft.combatPrompt;
+  if (!prompt) {
+    throw new Error(`resolve_combat_round rejected: no suspended combat (by player "${playerId}")`);
+  }
+  if (prompt.playerId !== playerId) {
+    throw new Error(
+      `resolve_combat_round rejected: pending combat decision is for "${prompt.playerId}", not "${playerId}"`,
+    );
+  }
+  // #165: the decision is empty — nothing to apply, just resume. #166–#168 will
+  // apply the submitted matchup/sit-out/retreat here before resuming.
+  //
+  // Clear the prompt before resuming: `runCombat` re-sets it if the fight
+  // suspends again on a later round, so clearing first keeps a single source of
+  // truth (an unresolved fight always has exactly one live `combatPrompt`).
+  draft.combatPrompt = undefined;
+  runCombat(draft, prompt, emit, queries);
+}
+
 // ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
@@ -1169,16 +1287,30 @@ export function applyMainAction(
   const events: GameEvent[] = [];
   let roundIncremented = false;
 
-  // Invariant: pickPrompt and viewPrompt are mutually exclusive. The
-  // executor's suspend guard in `effect-dsl/executor.ts` ensures producers
-  // never co-set them, but assert here so a future producer that bypasses the
-  // executor (e.g. a listener mutating state directly) fails loud instead of
-  // deadlocking the dispatcher.
-  if (state.pickPrompt && state.viewPrompt) {
+  // Invariant: pickPrompt, viewPrompt and combatPrompt are mutually exclusive.
+  // The executor's suspend guard in `effect-dsl/executor.ts` ensures the DSL
+  // producers never co-set pick/view; combat only suspends via `runCombat`,
+  // which never runs while a pick/view is pending (combat spends no AP through
+  // the DSL). Assert here so a future producer that bypasses these paths fails
+  // loud instead of deadlocking the dispatcher.
+  const pending: string[] = [];
+  if (state.pickPrompt) pending.push(`pick(picker="${state.pickPrompt.playerId}")`);
+  if (state.viewPrompt) pending.push(`view(viewer="${state.viewPrompt.playerId}")`);
+  if (state.combatPrompt) pending.push(`combat(decider="${state.combatPrompt.playerId}")`);
+  if (pending.length > 1) {
     throw new Error(
-      `applyMainAction invariant: both pickPrompt and viewPrompt are set ` +
-        `(picker="${state.pickPrompt.playerId}", viewer="${state.viewPrompt.playerId}") — ` +
+      `applyMainAction invariant: multiple prompts are set [${pending.join(", ")}] — ` +
         `at most one prompt may be pending at a time`,
+    );
+  }
+
+  if (state.combatPrompt && action.type !== "resolve_combat_round") {
+    throw new Error(
+      `Action "${action.type}" by "${action.playerId}" rejected: ` +
+        `suspended combat must be resolved first ` +
+        `(decider="${state.combatPrompt.playerId}", ` +
+        `cell=(${state.combatPrompt.row},${state.combatPrompt.col}), ` +
+        `round=${state.combatPrompt.round})`,
     );
   }
 
@@ -1271,6 +1403,10 @@ export function applyMainAction(
 
       case "dismiss_view":
         handleDismissView(draft, action.playerId);
+        break;
+
+      case "resolve_combat_round":
+        handleResolveCombatRound(draft, action.playerId, emit, queries);
         break;
 
       default: {

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -357,6 +357,19 @@ interface GameStateBase {
    * the same surface as main-phase `pick` verbs.
    */
   pickPrompt?: PickPrompt;
+  /**
+   * Set when combat suspends between rounds to await a player decision, cleared
+   * by `resolve_combat_round`. Combat is main-phase only today, but this lives
+   * on the base to mirror the `pickPrompt` precedent (a single suspend surface
+   * shared across phases). The prompt carries the full resumable loop state
+   * inline — the same Option-A pattern `pickPrompt`/`viewPrompt` use.
+   *
+   * Dormant in #165: no production combat ever pauses (see
+   * `combatDecisionPending` in `apply-main.ts`). The real pause conditions —
+   * defender-assigned matchups (#166), sit-out (#167), retreat (#168) — arrive
+   * later.
+   */
+  combatPrompt?: CombatPrompt;
 }
 
 export interface SeedingGameState extends GameStateBase {
@@ -433,6 +446,36 @@ export interface ViewPrompt {
   sourcePlayerId: string;
 }
 
+/**
+ * Set on `GameStateBase.combatPrompt` when a combat suspends between rounds.
+ * Stores the resumable loop state inline so `resolve_combat_round` can pick the
+ * fight back up: which cell, the two sides' committed unit instance ids, and the
+ * next round index. Living combatants are recomputed from the cell each round
+ * (units may have been killed/injured), so only the *committed* id lists are
+ * stored — not live unit references, which cannot survive the `produce()`
+ * boundary between suspend and resume.
+ *
+ * `playerId` is who must submit `resolve_combat_round`. For #165 (no real
+ * decision) that is the attacker; #166 will hand the decision to the defender.
+ * Revealed rolls / matchup payloads are deferred to #166–#168.
+ */
+export interface CombatPrompt {
+  /** Player expected to submit `resolve_combat_round`. */
+  playerId: string;
+  row: number;
+  col: number;
+  /** Attacking player id (the one who issued `attack`). */
+  attackerId: string;
+  /** Defending player id. */
+  defenderId: string;
+  /** Next round index to run on resume (0-based; `combat_round_cap` bounds it). */
+  round: number;
+  /** Committed attacker unit instance ids. */
+  attackerUnitIds: string[];
+  /** Committed defender unit instance ids. */
+  defenderUnitIds: string[];
+}
+
 export interface MainGameState extends GameStateBase {
   phase: "main";
   turn: TurnState;
@@ -456,6 +499,8 @@ export interface EndedGameState extends GameStateBase {
   pickPrompt?: never;
   /** Ended games never carry a pending view either. */
   viewPrompt?: never;
+  /** Ended games never carry a suspended combat either. */
+  combatPrompt?: never;
 }
 
 export type GameState = SeedingGameState | MainGameState | EndedGameState;
@@ -559,7 +604,8 @@ export type MainAction =
   | { type: "attempt_mission"; playerId: string; row: number; col: number }
   | { type: "pass"; playerId: string }
   | ResolvePickAction
-  | DismissViewAction;
+  | DismissViewAction
+  | ResolveCombatRoundAction;
 
 /**
  * Submitted by the viewer to dismiss a pending `viewPrompt`. The view is
@@ -569,6 +615,18 @@ export type MainAction =
  */
 export interface DismissViewAction {
   type: "dismiss_view";
+  playerId: string;
+}
+
+/**
+ * Submitted to resume a combat suspended between rounds (pending
+ * `combatPrompt`). For #165 the decision is empty — combat merely resumes its
+ * auto-resolve loop. The real payloads (matchup assignment #166, sit-out #167,
+ * retreat #168) will extend this interface. AP is not spent here (already spent
+ * on the initiating `attack`).
+ */
+export interface ResolveCombatRoundAction {
+  type: "resolve_combat_round";
   playerId: string;
 }
 
@@ -844,6 +902,8 @@ export interface VisibleState {
   pickPrompt?: PickPrompt;
   /** Set during main phase when this viewer is the active player on a `peek(opponent + hand)`. */
   viewPrompt?: ViewPrompt;
+  /** Set when combat is suspended between rounds. Public — combat is fully open, so surfaced to every viewer unredacted. */
+  combatPrompt?: CombatPrompt;
   winner?: string;
   scores?: Record<string, number>;
   /** Conditional reveals granted by active passives for this viewer. */

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -455,9 +455,16 @@ export interface ViewPrompt {
  * stored — not live unit references, which cannot survive the `produce()`
  * boundary between suspend and resume.
  *
+ * The duplicated cell coordinates and player ids cannot drift because the
+ * dispatch gate (`applyMainAction`) freezes every other mutation while a
+ * `combatPrompt` is live — do not reuse this type outside that suspend guard.
+ *
  * `playerId` is who must submit `resolve_combat_round`. For #165 (no real
- * decision) that is the attacker; #166 will hand the decision to the defender.
- * Revealed rolls / matchup payloads are deferred to #166–#168.
+ * decision) that is the attacker (also the active player). #166 will hand the
+ * decision to the defender — normally the *non-active* player — which must also
+ * relax the active-player gate in `apply-action.ts` (see the TODO there); today
+ * that gate would reject a non-active decider. Revealed rolls / matchup payloads
+ * are deferred to #166–#168.
  */
 export interface CombatPrompt {
   /** Player expected to submit `resolve_combat_round`. */
@@ -470,10 +477,10 @@ export interface CombatPrompt {
   defenderId: string;
   /** Next round index to run on resume (0-based; `combat_round_cap` bounds it). */
   round: number;
-  /** Committed attacker unit instance ids. */
-  attackerUnitIds: string[];
-  /** Committed defender unit instance ids. */
-  defenderUnitIds: string[];
+  /** Committed attacker unit instance ids (never mutated after suspend). */
+  attackerUnitIds: readonly string[];
+  /** Committed defender unit instance ids (never mutated after suspend). */
+  defenderUnitIds: readonly string[];
 }
 
 export interface MainGameState extends GameStateBase {
@@ -621,9 +628,11 @@ export interface DismissViewAction {
 /**
  * Submitted to resume a combat suspended between rounds (pending
  * `combatPrompt`). For #165 the decision is empty — combat merely resumes its
- * auto-resolve loop. The real payloads (matchup assignment #166, sit-out #167,
- * retreat #168) will extend this interface. AP is not spent here (already spent
- * on the initiating `attack`).
+ * auto-resolve loop. The heterogeneous real payloads (matchup assignment #166,
+ * sit-out #167, retreat #168) should arrive as a discriminated `decision`
+ * sub-union (mirroring `PickPrompt`'s `kind` split) rather than a flat bag of
+ * optional fields, so a retreat payload cannot structurally carry matchup data.
+ * AP is not spent here (already spent on the initiating `attack`).
  */
 export interface ResolveCombatRoundAction {
   type: "resolve_combat_round";

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -357,19 +357,6 @@ interface GameStateBase {
    * the same surface as main-phase `pick` verbs.
    */
   pickPrompt?: PickPrompt;
-  /**
-   * Set when combat suspends between rounds to await a player decision, cleared
-   * by `resolve_combat_round`. Combat is main-phase only today, but this lives
-   * on the base to mirror the `pickPrompt` precedent (a single suspend surface
-   * shared across phases). The prompt carries the full resumable loop state
-   * inline — the same Option-A pattern `pickPrompt`/`viewPrompt` use.
-   *
-   * Dormant in #165: no production combat ever pauses (see
-   * `combatDecisionPending` in `apply-main.ts`). The real pause conditions —
-   * defender-assigned matchups (#166), sit-out (#167), retreat (#168) — arrive
-   * later.
-   */
-  combatPrompt?: CombatPrompt;
 }
 
 export interface SeedingGameState extends GameStateBase {
@@ -490,11 +477,24 @@ export interface MainGameState extends GameStateBase {
    * Set by `peek(opponent + hand)` to surface opponent hand contents to the
    * active player. Cleared by `dismiss_view`. Main-phase only.
    *
-   * Invariant: at most one of `pickPrompt` / `viewPrompt` is set at a time
-   * (enforced by the executor's early-pause guard in `effect-dsl/executor.ts`
-   * and asserted at the top of `applyMainAction`).
+   * Invariant: at most one of `pickPrompt` / `viewPrompt` / `combatPrompt` is
+   * set at a time (enforced by the executor's early-pause guard in
+   * `effect-dsl/executor.ts` and asserted at the top of `applyMainAction`).
    */
   viewPrompt?: ViewPrompt;
+  /**
+   * Set when combat suspends between rounds to await a player decision, cleared
+   * by `resolve_combat_round`. Main-phase only — placed here (not on
+   * `GameStateBase`) so a seeding or ended state cannot structurally carry one,
+   * mirroring `viewPrompt`. The prompt carries the full resumable loop state
+   * inline — the same Option-A pattern `pickPrompt`/`viewPrompt` use.
+   *
+   * Dormant in #165: no production combat ever pauses (see
+   * `combatDecisionPending` in `apply-main.ts`). The real pause conditions —
+   * defender-assigned matchups (#166), sit-out (#167), retreat (#168) — arrive
+   * later.
+   */
+  combatPrompt?: CombatPrompt;
 }
 
 export interface EndedGameState extends GameStateBase {

--- a/engine/src/valid-actions.ts
+++ b/engine/src/valid-actions.ts
@@ -139,6 +139,9 @@ function getMainValidActions(
   state: MainGameState,
   playerId: string,
 ): MainAction[] {
+  if (state.combatPrompt && state.combatPrompt.playerId === playerId) {
+    return [{ type: "resolve_combat_round", playerId }];
+  }
   if (state.pickPrompt && state.pickPrompt.playerId === playerId) {
     return getResolvePickActions(state.pickPrompt, playerId);
   }

--- a/engine/src/visible-state.ts
+++ b/engine/src/visible-state.ts
@@ -88,7 +88,9 @@ export function getVisibleState(
         : undefined,
     // combatPrompt is public — combat is fully open information, so it surfaces
     // to every viewer unredacted (unlike pick/view, which are private to the
-    // acting player). The `phase === "main"` guard is for type narrowing.
+    // acting player). The `phase === "main"` guard is domain scoping, not type
+    // narrowing: combatPrompt lives on GameStateBase (so it reads on the whole
+    // union without narrowing), but combat only ever suspends in the main phase.
     combatPrompt: state.phase === "main" ? state.combatPrompt : undefined,
     winner: state.phase === "ended" ? state.winner : undefined,
     scores: state.phase === "ended" ? state.scores : undefined,

--- a/engine/src/visible-state.ts
+++ b/engine/src/visible-state.ts
@@ -88,9 +88,8 @@ export function getVisibleState(
         : undefined,
     // combatPrompt is public — combat is fully open information, so it surfaces
     // to every viewer unredacted (unlike pick/view, which are private to the
-    // acting player). The `phase === "main"` guard is domain scoping, not type
-    // narrowing: combatPrompt lives on GameStateBase (so it reads on the whole
-    // union without narrowing), but combat only ever suspends in the main phase.
+    // acting player). The `phase === "main"` guard is required for type
+    // narrowing (combatPrompt only exists on MainGameState).
     combatPrompt: state.phase === "main" ? state.combatPrompt : undefined,
     winner: state.phase === "ended" ? state.winner : undefined,
     scores: state.phase === "ended" ? state.scores : undefined,

--- a/engine/src/visible-state.ts
+++ b/engine/src/visible-state.ts
@@ -86,6 +86,10 @@ export function getVisibleState(
       state.phase === "main" && state.viewPrompt?.playerId === playerId
         ? state.viewPrompt
         : undefined,
+    // combatPrompt is public — combat is fully open information, so it surfaces
+    // to every viewer unredacted (unlike pick/view, which are private to the
+    // acting player). The `phase === "main"` guard is for type narrowing.
+    combatPrompt: state.phase === "main" ? state.combatPrompt : undefined,
     winner: state.phase === "ended" ? state.winner : undefined,
     scores: state.phase === "ended" ? state.scores : undefined,
     reveals,

--- a/engine/src/win-condition.ts
+++ b/engine/src/win-condition.ts
@@ -62,5 +62,6 @@ export function toEndedState(
     scores,
     pickPrompt: undefined,
     viewPrompt: undefined,
+    combatPrompt: undefined,
   };
 }


### PR DESCRIPTION
## Summary

Rework the combat handler so the engine can **pause between rounds** to await player decisions, then resume — the architectural prerequisite for the rest of the #164 multi-unit combat tree.

- Combat currently resolves **atomically** in a single handler (`engine/src/apply-main.ts`, a for-loop of up to 10 rounds, post-#169 refactor) — there's no point to hand control back to players between rounds.
- Introduce a **suspended / awaiting-decision** combat state the engine can enter and resume from.
- **Preserve current auto-resolve behaviour** where no interactive decision is pending — no behaviour change until #166 (defender-assigned matchups) / #167 (sit-out) / #168 (retreat) land.

Enables: #166, #167, #168 — each needs a suspension point after rolls are revealed and/or before the next round.

Closes #165