### PR TITLE
#166 — Engine + client: defender-assigned combat matchups

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
         "@tailwindcss/vite": "^4.2.2",
         "svelte": "^5.0.0",
+        "svelte-check": "^4.0.0",
         "tailwindcss": "^4.2.2",
         "typescript": "^5.7.0",
         "vite": "^6.0.0",
@@ -186,6 +187,8 @@
 
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.9", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA=="],
 
+    "@sveltejs/load-config": ["@sveltejs/load-config@0.2.0", "", {}, "sha512-1LgZ/qUqSoq+QorD83lk2hka79Px0wXNW2q5V1nZlxGhQgw1jrsIbVz5YiCeucVLo4XvFLjXukUaQjIiqowkcg=="],
+
     "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@5.1.1", "", { "dependencies": { "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1", "debug": "^4.4.1", "deepmerge": "^4.3.1", "kleur": "^4.1.5", "magic-string": "^0.30.17", "vitefu": "^1.0.6" }, "peerDependencies": { "svelte": "^5.0.0", "vite": "^6.0.0" } }, "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ=="],
 
     "@sveltejs/vite-plugin-svelte-inspector": ["@sveltejs/vite-plugin-svelte-inspector@4.0.1", "", { "dependencies": { "debug": "^4.3.7" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^5.0.0", "svelte": "^5.0.0", "vite": "^6.0.0" } }, "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw=="],
@@ -243,6 +246,8 @@
     "cards-web": ["cards-web@workspace:clients/web"],
 
     "chevrotain": ["chevrotain@12.0.0", "", { "dependencies": { "@chevrotain/cst-dts-gen": "12.0.0", "@chevrotain/gast": "12.0.0", "@chevrotain/regexp-to-ast": "12.0.0", "@chevrotain/types": "12.0.0", "@chevrotain/utils": "12.0.0" } }, "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ=="],
+
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
@@ -306,6 +311,8 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
@@ -318,11 +325,17 @@
 
     "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
     "rollup": ["rollup@4.60.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.0", "@rollup/rollup-android-arm64": "4.60.0", "@rollup/rollup-darwin-arm64": "4.60.0", "@rollup/rollup-darwin-x64": "4.60.0", "@rollup/rollup-freebsd-arm64": "4.60.0", "@rollup/rollup-freebsd-x64": "4.60.0", "@rollup/rollup-linux-arm-gnueabihf": "4.60.0", "@rollup/rollup-linux-arm-musleabihf": "4.60.0", "@rollup/rollup-linux-arm64-gnu": "4.60.0", "@rollup/rollup-linux-arm64-musl": "4.60.0", "@rollup/rollup-linux-loong64-gnu": "4.60.0", "@rollup/rollup-linux-loong64-musl": "4.60.0", "@rollup/rollup-linux-ppc64-gnu": "4.60.0", "@rollup/rollup-linux-ppc64-musl": "4.60.0", "@rollup/rollup-linux-riscv64-gnu": "4.60.0", "@rollup/rollup-linux-riscv64-musl": "4.60.0", "@rollup/rollup-linux-s390x-gnu": "4.60.0", "@rollup/rollup-linux-x64-gnu": "4.60.0", "@rollup/rollup-linux-x64-musl": "4.60.0", "@rollup/rollup-openbsd-x64": "4.60.0", "@rollup/rollup-openharmony-arm64": "4.60.0", "@rollup/rollup-win32-arm64-msvc": "4.60.0", "@rollup/rollup-win32-ia32-msvc": "4.60.0", "@rollup/rollup-win32-x64-gnu": "4.60.0", "@rollup/rollup-win32-x64-msvc": "4.60.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ=="],
+
+    "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "svelte": ["svelte@5.55.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.6.4", "esm-env": "^1.2.1", "esrap": "^2.2.2", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-SThllKq6TRMBwPtat7ASnm/9CDXnIhBR0NPGw0ujn2DVYx9rVwsPZxDaDQcYGdUz/3BYVsCzdq7pZarRQoGvtw=="],
+
+    "svelte-check": ["svelte-check@4.7.1", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "@sveltejs/load-config": "^0.2.0", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": ">=5.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-FGUOmAqxXdN/H9Zm8slrqO7SLtFisXRB7rfOsHNJ3MLTD2po/+Stg8XyErkpumPHbuUiYTcqrEIzxpVWKTLqtg=="],
 
     "tailwindcss": ["tailwindcss@4.2.2", "", {}, "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q=="],
 

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "bun test src",
-    "typecheck": "tsc -b tsconfig.json && tsc -b tsconfig.test.json"
+    "check": "svelte-check --threshold error",
+    "typecheck": "tsc -b tsconfig.json && tsc -b tsconfig.test.json && svelte-check --threshold error"
   },
   "dependencies": {
     "cards-engine": "workspace:*",
@@ -18,6 +19,7 @@
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "@tailwindcss/vite": "^4.2.2",
     "svelte": "^5.0.0",
+    "svelte-check": "^4.0.0",
     "tailwindcss": "^4.2.2",
     "typescript": "^5.7.0",
     "vite": "^6.0.0"

--- a/clients/web/src/App.svelte
+++ b/clients/web/src/App.svelte
@@ -18,6 +18,7 @@
   import ContestResultPopup from "./components/ContestResultPopup.svelte";
   import PickPromptOverlay from "./components/PickPromptOverlay.svelte";
   import ViewPromptOverlay from "./components/ViewPromptOverlay.svelte";
+  import CombatPromptOverlay from "./components/CombatPromptOverlay.svelte";
   // TODO: Remove DevPreview import and /#dev route once quick-start variant (#82) lands
   import DevPreview from "./DevPreview.svelte";
 
@@ -78,6 +79,10 @@
 
     {#if vs?.viewPrompt}
       <ViewPromptOverlay />
+    {/if}
+
+    {#if vs?.combatPrompt}
+      <CombatPromptOverlay />
     {/if}
 
     {#if vs}

--- a/clients/web/src/DevPreview.svelte
+++ b/clients/web/src/DevPreview.svelte
@@ -22,6 +22,7 @@
     type TurnState,
     type GameConfig,
     type LocationEdges,
+    type Action,
   } from "cards-engine";
   import cardDefsJson from "@library/all.json";
   import GridBoard from "./components/GridBoard.svelte";
@@ -129,6 +130,7 @@
     hq: [p2Units[2]],
     activePolicies: p2Policies,
     activeTraps: [{ targetId: locations[1]?.id, cardId: "preview-trap-1" }],
+    passiveEvents: [],
   };
 
   const turn: TurnState = { activePlayerId: p1, actionPointsRemaining: 2, round: 3 };
@@ -145,12 +147,12 @@
     reveals: { revealedTrapIds: [] },
   };
 
-  const mockActions = [
+  const mockActions: Action[] = [
     { type: "move", playerId: p1, unitId: p1Units[0].id, row: 1, col: 0 },
     { type: "move", playerId: p1, unitId: p1Units[0].id, row: 0, col: 1 },
     { type: "attack", playerId: p1, unitIds: [p1Units[0].id], row: 0, col: 1 },
     { type: "deploy", playerId: p1, cardId: handCards[0].id },
-    { type: "buy", playerId: p1, cardId: marketCards[0]?.id },
+    { type: "buy", playerId: p1, cardId: marketCards[0].id },
     { type: "pass", playerId: p1 },
   ];
 

--- a/clients/web/src/components/CombatPromptOverlay.svelte
+++ b/clients/web/src/components/CombatPromptOverlay.svelte
@@ -88,6 +88,27 @@
   }
 </script>
 
+{#snippet rollLine(side: CombatSide)}
+  <div class="flex flex-wrap items-center gap-1 text-xs text-text-secondary">
+    <span class="font-semibold text-text-primary">{resolveCardName(side.unitId)}</span>
+    <span class="font-mono">{side.baseStrength}</span>
+    {#each side.modifiers as mod}
+      <span
+        class="rounded bg-surface px-1.5 py-0.5 font-mono {mod.delta > 0
+          ? 'text-success'
+          : mod.delta < 0
+            ? 'text-error'
+            : 'text-text-secondary'}"
+        title="{mod.source.type}: {mod.source.definitionId}"
+      >
+        {signed(mod.delta)} {mod.source.definitionId}
+      </span>
+    {/each}
+    <span class="font-mono">+ {side.roll}🎲</span>
+    <span class="ml-auto font-mono font-semibold text-text-primary">= {side.power}</span>
+  </div>
+{/snippet}
+
 {#if prompt}
   {@const defenderName = resolvePlayerName(prompt.defenderId)}
   {@const attackerName = resolvePlayerName(prompt.attackerId)}
@@ -99,27 +120,6 @@
       {defenderName} is defending against {attackerName}. Pair each attacker
       against one of your units — you choose after seeing every roll.
     </p>
-
-    {#snippet rollLine(side: CombatSide)}
-      <div class="flex flex-wrap items-center gap-1 text-xs text-text-secondary">
-        <span class="font-semibold text-text-primary">{resolveCardName(side.unitId)}</span>
-        <span class="font-mono">{side.baseStrength}</span>
-        {#each side.modifiers as mod}
-          <span
-            class="rounded bg-surface px-1.5 py-0.5 font-mono {mod.delta > 0
-              ? 'text-success'
-              : mod.delta < 0
-                ? 'text-error'
-                : 'text-text-secondary'}"
-            title="{mod.source.type}: {mod.source.definitionId}"
-          >
-            {signed(mod.delta)} {mod.source.definitionId}
-          </span>
-        {/each}
-        <span class="font-mono">+ {side.roll}🎲</span>
-        <span class="ml-auto font-mono font-semibold text-text-primary">= {side.power}</span>
-      </div>
-    {/snippet}
 
     <div class="mb-4 space-y-2">
       {#each prompt.atkRolls as atk (atk.unitId)}

--- a/clients/web/src/components/CombatPromptOverlay.svelte
+++ b/clients/web/src/components/CombatPromptOverlay.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+  import type { CombatSide } from "cards-engine";
+  import {
+    getError,
+    getVisibleState,
+    resolveCardName,
+    resolvePlayerName,
+    selectAction,
+  } from "../lib/gameStore.svelte";
+  import Modal from "./Modal.svelte";
+
+  const vs = $derived(getVisibleState());
+  const prompt = $derived(vs?.combatPrompt);
+
+  function signed(delta: number): string {
+    return delta >= 0 ? `+${delta}` : `${delta}`;
+  }
+
+  // assignment[attackerUnitId] = defenderUnitId. Seeded to the greedy default
+  // (participants are stored highest-power-first, so index-pairing matches
+  // highest-vs-highest — the engine's auto-resolve fallback). The defender may
+  // re-pair before confirming.
+  let assignment = $state<Record<string, string>>({});
+  let submitted = $state(false);
+
+  // Reseed when the prompt content changes. Today the outer `{#if vs?.combatPrompt}`
+  // unmounts and remounts on every prompt transition, so this is defensive.
+  $effect(() => {
+    if (!prompt) return;
+    void prompt.atkRolls.map((r) => r.unitId).join(",");
+    const seed: Record<string, string> = {};
+    prompt.atkRolls.forEach((atk, i) => {
+      seed[atk.unitId] = prompt.defRolls[i]?.unitId ?? "";
+    });
+    assignment = seed;
+    submitted = false;
+  });
+
+  // Unlock the confirm button if the engine surfaces an error mid-submit, so the
+  // defender can retry. Mirrors PickPromptOverlay's recovery pattern.
+  const error = $derived(getError());
+  $effect(() => {
+    if (error && submitted) submitted = false;
+  });
+
+  // A valid assignment is a bijection: every defender participant used exactly
+  // once (equivalently, no two attackers share a defender).
+  const isBijection = $derived.by(() => {
+    if (!prompt) return false;
+    const chosen = Object.values(assignment).filter(Boolean);
+    return (
+      chosen.length === prompt.atkRolls.length &&
+      new Set(chosen).size === prompt.defRolls.length
+    );
+  });
+
+  function confirm(): void {
+    if (!prompt || submitted || !isBijection) return;
+    submitted = true;
+    selectAction({
+      type: "resolve_combat_round",
+      playerId: prompt.playerId,
+      decision: {
+        kind: "assign_matchups",
+        pairs: prompt.atkRolls.map((atk) => ({
+          attackerUnitId: atk.unitId,
+          defenderUnitId: assignment[atk.unitId],
+        })),
+      },
+    });
+  }
+</script>
+
+{#if prompt}
+  {@const defenderName = resolvePlayerName(prompt.defenderId)}
+  {@const attackerName = resolvePlayerName(prompt.attackerId)}
+  <Modal width="w-auto max-w-2xl">
+    <h3 class="mb-1 text-center text-lg font-bold text-text-primary">
+      Assign combat matchups — round {prompt.round + 1}
+    </h3>
+    <p class="mb-4 text-center text-sm text-text-muted">
+      {defenderName} is defending against {attackerName}. Pair each attacker
+      against one of your units — you choose after seeing every roll.
+    </p>
+
+    {#snippet rollLine(side: CombatSide)}
+      <div class="flex flex-wrap items-center gap-1 text-xs text-text-secondary">
+        <span class="font-semibold text-text-primary">{resolveCardName(side.unitId)}</span>
+        <span class="font-mono">{side.baseStrength}</span>
+        {#each side.modifiers as mod}
+          <span
+            class="rounded bg-surface px-1.5 py-0.5 font-mono {mod.delta > 0
+              ? 'text-success'
+              : 'text-error'}"
+            title="{mod.source.type}: {mod.source.definitionId}"
+          >
+            {signed(mod.delta)} {mod.source.definitionId}
+          </span>
+        {/each}
+        <span class="font-mono">+ {side.roll}🎲</span>
+        <span class="ml-auto font-mono font-semibold text-text-primary">= {side.power}</span>
+      </div>
+    {/snippet}
+
+    <div class="mb-4 space-y-2">
+      {#each prompt.atkRolls as atk (atk.unitId)}
+        <div class="rounded border border-border bg-surface p-2">
+          <div class="mb-2 rounded bg-surface-raised p-2">
+            {@render rollLine(atk)}
+          </div>
+          <div class="flex items-center gap-2">
+            <span class="text-xs text-text-faint">faces</span>
+            <select
+              bind:value={assignment[atk.unitId]}
+              class="flex-1 rounded border border-border bg-surface-raised px-2 py-1 text-sm text-text-primary"
+            >
+              {#each prompt.defRolls as def (def.unitId)}
+                <option value={def.unitId}>
+                  {resolveCardName(def.unitId)} (power {def.power}{def.injuredBefore ? ", injured" : ""})
+                </option>
+              {/each}
+            </select>
+          </div>
+        </div>
+      {/each}
+    </div>
+
+    {#if !isBijection}
+      <p class="mb-3 text-center text-xs text-error">
+        Each of your units must face exactly one attacker.
+      </p>
+    {/if}
+
+    <button
+      onclick={confirm}
+      disabled={submitted || !isBijection}
+      class="w-full rounded bg-amber-600 py-2 font-semibold text-white hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {submitted ? "Resolving…" : "Confirm matchups"}
+    </button>
+  </Modal>
+{/if}

--- a/clients/web/src/components/CombatPromptOverlay.svelte
+++ b/clients/web/src/components/CombatPromptOverlay.svelte
@@ -22,12 +22,26 @@
   // re-pair before confirming.
   let assignment = $state<Record<string, string>>({});
   let submitted = $state(false);
+  // The error banner present at submit time, so the recovery effect below can
+  // tell a NEW mid-submit error (which should re-enable Confirm) from a stale,
+  // unrelated banner (which must not).
+  let errorAtSubmit = $state<string | null>(null);
 
   // Reseed when the prompt content changes. Today the outer `{#if vs?.combatPrompt}`
   // unmounts and remounts on every prompt transition, so this is defensive.
   $effect(() => {
     if (!prompt) return;
     void prompt.atkRolls.map((r) => r.unitId).join(",");
+    // The engine guarantees equal-length participant lists (the greedy sit-out
+    // trims both sides to `min`). If they ever desync, surface it rather than
+    // silently seeding `""` — an unseeded attacker would leave `isBijection`
+    // false forever with no explanation.
+    if (prompt.atkRolls.length !== prompt.defRolls.length) {
+      console.warn(
+        "CombatPromptOverlay: atkRolls/defRolls length mismatch — participant lists should be equal",
+        { atk: prompt.atkRolls.length, def: prompt.defRolls.length },
+      );
+    }
     const seed: Record<string, string> = {};
     prompt.atkRolls.forEach((atk, i) => {
       seed[atk.unitId] = prompt.defRolls[i]?.unitId ?? "";
@@ -36,11 +50,13 @@
     submitted = false;
   });
 
-  // Unlock the confirm button if the engine surfaces an error mid-submit, so the
-  // defender can retry. Mirrors PickPromptOverlay's recovery pattern.
+  // Unlock the confirm button if the engine surfaces a NEW error mid-submit, so
+  // the defender can retry. Gating on a fresh error (not merely any error
+  // present) avoids a stale banner re-enabling Confirm and inviting a second,
+  // dropped click. Mirrors PickPromptOverlay's recovery pattern.
   const error = $derived(getError());
   $effect(() => {
-    if (error && submitted) submitted = false;
+    if (submitted && error && error !== errorAtSubmit) submitted = false;
   });
 
   // A valid assignment is a bijection: every defender participant used exactly
@@ -56,6 +72,7 @@
 
   function confirm(): void {
     if (!prompt || submitted || !isBijection) return;
+    errorAtSubmit = error;
     submitted = true;
     selectAction({
       type: "resolve_combat_round",
@@ -91,7 +108,9 @@
           <span
             class="rounded bg-surface px-1.5 py-0.5 font-mono {mod.delta > 0
               ? 'text-success'
-              : 'text-error'}"
+              : mod.delta < 0
+                ? 'text-error'
+                : 'text-text-secondary'}"
             title="{mod.source.type}: {mod.source.definitionId}"
           >
             {signed(mod.delta)} {mod.source.definitionId}

--- a/clients/web/src/components/ContestResultPopup.svelte
+++ b/clients/web/src/components/ContestResultPopup.svelte
@@ -14,14 +14,15 @@
     return delta >= 0 ? `+${delta}` : `${delta}`;
   }
 
-  // Which player owns the unit in an outcome, so the row can align to that
-  // side (attacker/Player 1 → left, defender/Player 2 → right). Names come from
-  // the same resolver as attacker/defenderName, so equality is exact.
+  // Which player owns the unit in an outcome, so the row can align to that side
+  // (attacker/Player 1 → left, defender/Player 2 → right). Compares player ids
+  // (not display names, which can collide). Only combat results carry the side
+  // ids and the multi-pair layout this mirrors.
   function outcomeSide(outcome: ContestOutcome): "attacker" | "defender" | null {
-    if (!result) return null;
+    if (!result || result.source !== "combat") return null;
     if (outcome.type === "injured" || outcome.type === "killed") {
-      if (outcome.ownerName === result.attackerName) return "attacker";
-      if (outcome.ownerName === result.defenderName) return "defender";
+      if (outcome.ownerId === result.attackerId) return "attacker";
+      if (outcome.ownerId === result.defenderId) return "defender";
     }
     return null;
   }
@@ -45,7 +46,9 @@
         <span
           class="rounded bg-surface px-1.5 py-0.5 font-mono {mod.delta > 0
             ? 'text-success'
-            : 'text-error'}"
+            : mod.delta < 0
+              ? 'text-error'
+              : 'text-text-secondary'}"
           title="{mod.source.type}: {mod.source.definitionId}"
         >
           {signed(mod.delta)} {mod.source.definitionId}

--- a/clients/web/src/components/ContestResultPopup.svelte
+++ b/clients/web/src/components/ContestResultPopup.svelte
@@ -17,6 +17,34 @@
   const view: DialogView | null = $derived(result ? buildDialogView(result) : null);
 </script>
 
+{#snippet sideBreakdown(side: PairSideView, isWinner: boolean)}
+  <div
+    class="flex-1 rounded p-2 text-xs {isWinner
+      ? 'bg-highlight/15 ring-1 ring-highlight'
+      : 'bg-surface-raised'}"
+  >
+    <div class="mb-1 font-semibold text-text-primary">
+      {side.unitName}
+      <span class="text-text-muted">({side.ownerName})</span>
+    </div>
+    <div class="flex flex-wrap items-center gap-1 text-text-secondary">
+      <span class="font-mono">{side.baseStat}</span>
+      {#each side.modifiers as mod}
+        <span
+          class="rounded bg-surface px-1.5 py-0.5 font-mono {mod.delta > 0
+            ? 'text-success'
+            : 'text-error'}"
+          title="{mod.source.type}: {mod.source.definitionId}"
+        >
+          {signed(mod.delta)} {mod.source.definitionId}
+        </span>
+      {/each}
+      <span class="font-mono">+ {side.roll}🎲</span>
+      <span class="ml-auto font-mono font-semibold text-text-primary">= {side.power}</span>
+    </div>
+  </div>
+{/snippet}
+
 {#if result && view}
   <Modal>
     <h3 class="mb-3 text-center text-lg font-bold text-text-primary">
@@ -32,34 +60,6 @@
         {result.defenderName}
       </span>
     </div>
-
-    {#snippet sideBreakdown(side: PairSideView, isWinner: boolean)}
-      <div
-        class="flex-1 rounded p-2 text-xs {isWinner
-          ? 'bg-highlight/15 ring-1 ring-highlight'
-          : 'bg-surface-raised'}"
-      >
-        <div class="mb-1 font-semibold text-text-primary">
-          {side.unitName}
-          <span class="text-text-muted">({side.ownerName})</span>
-        </div>
-        <div class="flex flex-wrap items-center gap-1 text-text-secondary">
-          <span class="font-mono">{side.baseStat}</span>
-          {#each side.modifiers as mod}
-            <span
-              class="rounded bg-surface px-1.5 py-0.5 font-mono {mod.delta > 0
-                ? 'text-success'
-                : 'text-error'}"
-              title="{mod.source.type}: {mod.source.definitionId}"
-            >
-              {signed(mod.delta)} {mod.source.definitionId}
-            </span>
-          {/each}
-          <span class="font-mono">+ {side.roll}🎲</span>
-          <span class="ml-auto font-mono font-semibold text-text-primary">= {side.power}</span>
-        </div>
-      </div>
-    {/snippet}
 
     {#if result.pairs.length > 0}
       <div class="mb-4 space-y-2">

--- a/clients/web/src/components/ContestResultPopup.svelte
+++ b/clients/web/src/components/ContestResultPopup.svelte
@@ -5,13 +5,25 @@
     type ContestResult,
     type PairSideView,
   } from "../lib/gameStore.svelte";
-  import { buildDialogView, type DialogView } from "../lib/contestResult";
+  import { buildDialogView, type ContestOutcome, type DialogView } from "../lib/contestResult";
   import Modal from "./Modal.svelte";
 
   const result: ContestResult | null = $derived(getContestResult());
 
   function signed(delta: number): string {
     return delta >= 0 ? `+${delta}` : `${delta}`;
+  }
+
+  // Which player owns the unit in an outcome, so the row can align to that
+  // side (attacker/Player 1 → left, defender/Player 2 → right). Names come from
+  // the same resolver as attacker/defenderName, so equality is exact.
+  function outcomeSide(outcome: ContestOutcome): "attacker" | "defender" | null {
+    if (!result) return null;
+    if (outcome.type === "injured" || outcome.type === "killed") {
+      if (outcome.ownerName === result.attackerName) return "attacker";
+      if (outcome.ownerName === result.defenderName) return "defender";
+    }
+    return null;
   }
 
   const view: DialogView | null = $derived(result ? buildDialogView(result) : null);
@@ -81,7 +93,13 @@
     {#if result.outcomes.length > 0}
       <div class="mb-4 space-y-1">
         {#each result.outcomes as outcome}
-          <div class="flex items-center gap-2 rounded bg-surface-raised px-3 py-1.5 text-sm">
+          {@const side = outcomeSide(outcome)}
+          <div
+            class="flex w-fit max-w-[90%] items-center gap-2 rounded bg-surface-raised px-3 py-1.5 text-sm {side ===
+            'defender'
+              ? 'ml-auto flex-row-reverse text-right'
+              : ''}"
+          >
             {#if outcome.type === "injured"}
               <span>🩸</span>
               <span class="text-text-secondary">
@@ -111,15 +129,13 @@
       <p class="mb-4 text-center text-sm text-text-muted">{view.emptyOutcomesMsg}</p>
     {/if}
 
-    <div class="mb-4 text-center text-sm font-semibold">
-      {#if result.winnerName}
+    {#if result.winnerName}
+      <div class="mb-4 text-center text-sm font-semibold">
         <span class="text-highlight">
           {result.winnerName} wins!
         </span>
-      {:else}
-        <span class="text-text-muted">Draw — no clear winner</span>
-      {/if}
-    </div>
+      </div>
+    {/if}
 
     <button
       onclick={dismissContest}

--- a/clients/web/src/components/Modal.svelte
+++ b/clients/web/src/components/Modal.svelte
@@ -21,7 +21,7 @@
   role="dialog"
   aria-modal="true"
 >
-  <div class={`${width} rounded-lg bg-surface p-5`}>
+  <div class={`${width} max-h-[90vh] overflow-y-auto rounded-lg bg-surface p-5`}>
     {@render children()}
   </div>
 </div>

--- a/clients/web/src/components/PickPromptOverlay.svelte
+++ b/clients/web/src/components/PickPromptOverlay.svelte
@@ -5,7 +5,13 @@
   import Modal from "./Modal.svelte";
 
   const vs = $derived(getVisibleState());
-  const prompt = $derived(vs?.pickPrompt);
+  // This overlay is the `deck_pick` "choose N to keep" UI; `scholar_reorder`
+  // (no `count`, needs an ordering UI) is not handled here. Narrow to the
+  // deck_pick variant so `count` is well-typed and a scholar prompt renders
+  // nothing rather than a broken count-less dialog.
+  const prompt = $derived(
+    vs?.pickPrompt?.kind === "deck_pick" ? vs.pickPrompt : undefined,
+  );
   const resolution = $derived(
     prompt && vs ? resolvePickOptions(prompt, vs.self.mainDeck) : null,
   );
@@ -24,7 +30,7 @@
     }
   });
 
-  let selected = $state(new Set<string>());
+  let selected = $state<ReadonlySet<string>>(new Set<string>());
   let submitted = $state(false);
 
   // If the engine surfaces an error while we're mid-submit, unlock the

--- a/clients/web/src/lib/__tests__/contestResult.test.ts
+++ b/clients/web/src/lib/__tests__/contestResult.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "bun:test";
+import type { GameEvent } from "cards-engine";
 import {
   buildDialogView,
   buildPairDetail,
   buildPairDetailFromContest,
+  stepCombatBuffer,
   type CombatPairResolved,
   type ContestResolved,
   type ContestResult,
@@ -64,6 +66,58 @@ describe("buildPairDetail", () => {
     const detail = buildPairDetail(makeEvent("injure_defender"), RESOLVERS);
     expect(detail.attacker.baseStat).toBe(5);
     expect(detail.defender.baseStat).toBe(5);
+  });
+});
+
+describe("stepCombatBuffer", () => {
+  const started: GameEvent = { type: "combat_started", row: 0, col: 0, attackerId: "p1", defenderId: "p2" };
+  const resolved: GameEvent = { type: "combat_resolved", row: 0, col: 0, winnerId: "p1" };
+  const pair: GameEvent = makeEvent("kill_defender");
+  const injured: GameEvent = { type: "unit_injured", unitId: "def", controllerId: "p2" };
+  const unrelated: GameEvent = { type: "turn_started", playerId: "p1", round: 1 };
+
+  it("atomic combat (start+pair+resolved in one batch) completes with all events, empty buffer", () => {
+    const step = stepCombatBuffer([], [started, pair, injured, resolved]);
+    expect(step.outcome.kind).toBe("complete");
+    if (step.outcome.kind !== "complete") return;
+    expect(step.outcome.dialogEvents).toEqual([started, pair, injured, resolved]);
+    expect(step.buffer).toEqual([]);
+  });
+
+  it("start with no resolve → suspended, buffering the started context", () => {
+    const step = stepCombatBuffer([], [started]);
+    expect(step.outcome.kind).toBe("suspended");
+    expect(step.buffer).toEqual([started]);
+  });
+
+  it("resume batch completes the fight using the buffered start", () => {
+    const step = stepCombatBuffer([started], [pair, injured, resolved]);
+    expect(step.outcome.kind).toBe("complete");
+    if (step.outcome.kind !== "complete") return;
+    // Whole fight, start (buffered) through resolved (this batch).
+    expect(step.outcome.dialogEvents).toEqual([started, pair, injured, resolved]);
+    expect(step.buffer).toEqual([]);
+  });
+
+  it("multi-round: a resume that resolves a round and suspends again accumulates, no dialog yet", () => {
+    const step = stepCombatBuffer([started], [pair]);
+    expect(step.outcome.kind).toBe("none");
+    expect(step.buffer).toEqual([started, pair]);
+    // The next resume finally resolves — dialog carries both rounds' pairs.
+    const final = stepCombatBuffer(step.buffer, [pair, resolved]);
+    expect(final.outcome.kind).toBe("complete");
+    if (final.outcome.kind !== "complete") return;
+    expect(final.outcome.dialogEvents).toEqual([started, pair, pair, resolved]);
+  });
+
+  it("a pair with no buffered start is a true orphan", () => {
+    const step = stepCombatBuffer([], [pair]);
+    expect(step.outcome.kind).toBe("orphan");
+  });
+
+  it("a batch with no combat activity is 'none' and leaves the buffer untouched", () => {
+    expect(stepCombatBuffer([], [unrelated]).outcome.kind).toBe("none");
+    expect(stepCombatBuffer([started], [unrelated]).buffer).toEqual([started]);
   });
 });
 

--- a/clients/web/src/lib/__tests__/contestResult.test.ts
+++ b/clients/web/src/lib/__tests__/contestResult.test.ts
@@ -119,6 +119,25 @@ describe("stepCombatBuffer", () => {
     expect(stepCombatBuffer([], [unrelated]).outcome.kind).toBe("none");
     expect(stepCombatBuffer([started], [unrelated]).buffer).toEqual([started]);
   });
+
+  it("a fresh combat_started discards a stale non-empty buffer (no cross-fight leak)", () => {
+    const started2: GameEvent = { type: "combat_started", row: 1, col: 1, attackerId: "p2", defenderId: "p1" };
+    const pair2: GameEvent = makeEvent("kill_attacker");
+    const resolved2: GameEvent = { type: "combat_resolved", row: 1, col: 1, winnerId: "p2" };
+    // Previous fight left [started, pair] buffered; a new atomic fight arrives.
+    const step = stepCombatBuffer([started, pair], [started2, pair2, resolved2]);
+    expect(step.outcome.kind).toBe("complete");
+    if (step.outcome.kind !== "complete") return;
+    // Only the second fight's events — the stale buffer is dropped, not leaked.
+    expect(step.outcome.dialogEvents).toEqual([started2, pair2, resolved2]);
+  });
+
+  it("a resolve with no buffered start is orphan, not a silent empty completion", () => {
+    // Reachable after a save/load mid-suspended-combat that reset the buffer: the
+    // resume batch resolves the fight but carries no combat_started.
+    const step = stepCombatBuffer([], [pair, resolved]);
+    expect(step.outcome.kind).toBe("orphan");
+  });
 });
 
 describe("buildPairDetailFromContest", () => {
@@ -166,6 +185,8 @@ describe("buildDialogView", () => {
       locationName: "Marketplace",
       attackerName: "Alice",
       defenderName: "Bob",
+      attackerId: "p1",
+      defenderId: "p2",
       pairs: [],
       outcomes: [],
       winnerName: null,

--- a/clients/web/src/lib/actionGroups.ts
+++ b/clients/web/src/lib/actionGroups.ts
@@ -47,7 +47,7 @@ export function groupActions(actions: Action[]): ActionGroup[] {
 }
 
 type NameResolver = (id: string) => string;
-type CellNameResolver = (row: number, col: number) => string | undefined;
+type CellNameResolver = (row: number, col: number) => string | null | undefined;
 
 function idOrName(id: string, n?: NameResolver): string {
   return n?.(id) ?? id;

--- a/clients/web/src/lib/contestResult.ts
+++ b/clients/web/src/lib/contestResult.ts
@@ -210,6 +210,73 @@ export interface ContestResultBuild {
   error: string | null;
 }
 
+/** Combat events the result dialog is built from — accumulated across batches. */
+const COMBAT_DIALOG_EVENT_TYPES: ReadonlySet<GameEvent["type"]> = new Set([
+  "combat_started",
+  "combat_pair_resolved",
+  "unit_injured",
+  "unit_killed",
+  "combat_resolved",
+]);
+
+/** What a freshly-processed event batch means for the combat result dialog. */
+export type CombatBatchOutcome =
+  /** The fight finished this batch — build the dialog from `dialogEvents`. */
+  | { kind: "complete"; dialogEvents: GameEvent[] }
+  /** Combat began but suspended for the defender's matchup decision (#166) —
+   *  the overlay takes over; keep buffering, show nothing yet. */
+  | { kind: "suspended" }
+  /** A `combat_pair_resolved` with no buffered `combat_started` — genuinely
+   *  orphaned (the caller warns and clears any stale dialog). */
+  | { kind: "orphan" }
+  /** No combat activity in this batch. */
+  | { kind: "none" };
+
+export interface CombatBufferStep {
+  /** Events to carry into the next batch (empty once a fight completes). */
+  buffer: GameEvent[];
+  outcome: CombatBatchOutcome;
+}
+
+/** Fold a new event batch into the running combat buffer. Combat spans multiple
+ *  batches when the defender assigns matchups (#166): `combat_started` arrives
+ *  with the `attack`, and the pair/resolution events with each later
+ *  `resolve_combat_round`. Accumulate the fight's events from `combat_started`
+ *  until `combat_resolved`, so the dialog is built once from the whole combat
+ *  rather than warning on each half. Pure so the batch-splitting edge cases
+ *  (suspend, multi-round resume, orphan pair) are testable without a store. */
+export function stepCombatBuffer(
+  prevBuffer: readonly GameEvent[],
+  batch: readonly GameEvent[],
+): CombatBufferStep {
+  const started: boolean = batch.some((e) => e.type === "combat_started");
+  const ended: boolean = batch.some((e) => e.type === "combat_resolved");
+
+  // A fresh `combat_started` begins a new fight; otherwise continue the running
+  // one. Only collect while a fight is in flight (started now, or already buffered).
+  const buffer: GameEvent[] = started ? [] : [...prevBuffer];
+  if (started || buffer.length > 0) {
+    for (const e of batch) {
+      if (COMBAT_DIALOG_EVENT_TYPES.has(e.type)) buffer.push(e);
+    }
+  }
+
+  if (ended) {
+    return { buffer: [], outcome: { kind: "complete", dialogEvents: buffer } };
+  }
+  if (started) {
+    return { buffer, outcome: { kind: "suspended" } };
+  }
+  if (batch.some((e) => e.type === "combat_pair_resolved")) {
+    // A pair with a live buffer is a mid-combat resume round (already collected);
+    // a pair with no buffer is a true orphan.
+    return prevBuffer.length > 0
+      ? { buffer, outcome: { kind: "none" } }
+      : { buffer, outcome: { kind: "orphan" } };
+  }
+  return { buffer, outcome: { kind: "none" } };
+}
+
 /** Build the combat-source dialog state from an event batch containing a
  *  `combat_started` (combat is multi-pair strength). Returns `null` result
  *  if `combat_started` is missing from the batch. */

--- a/clients/web/src/lib/contestResult.ts
+++ b/clients/web/src/lib/contestResult.ts
@@ -42,8 +42,8 @@ export interface NameResolvers {
  *  contests (Cleopatra's diplomacy). Splitting the union by source is what
  *  makes "no controlled in combat" a compile-time fact. */
 export type CombatOutcome =
-  | { type: "injured"; unitName: string; ownerName: string }
-  | { type: "killed"; unitName: string; ownerName: string };
+  | { type: "injured"; unitName: string; ownerName: string; ownerId: string }
+  | { type: "killed"; unitName: string; ownerName: string; ownerId: string };
 
 export type ContestOutcome =
   | CombatOutcome
@@ -74,6 +74,10 @@ export type ContestResult =
       locationName: string;
       attackerName: string;
       defenderName: string;
+      /** Player ids for the two sides, so outcome rows can be aligned by owner
+       *  without relying on (possibly duplicate) display names. */
+      attackerId: string;
+      defenderId: string;
       pairs: PairDetail[];
       outcomes: CombatOutcome[];
       winnerName: string | null;
@@ -222,19 +226,20 @@ const COMBAT_DIALOG_EVENT_TYPES: ReadonlySet<GameEvent["type"]> = new Set([
 /** What a freshly-processed event batch means for the combat result dialog. */
 export type CombatBatchOutcome =
   /** The fight finished this batch — build the dialog from `dialogEvents`. */
-  | { kind: "complete"; dialogEvents: GameEvent[] }
+  | { kind: "complete"; dialogEvents: readonly GameEvent[] }
   /** Combat began but suspended for the defender's matchup decision (#166) —
    *  the overlay takes over; keep buffering, show nothing yet. */
   | { kind: "suspended" }
-  /** A `combat_pair_resolved` with no buffered `combat_started` — genuinely
+  /** A combat resolution / pair with no buffered `combat_started` — genuinely
    *  orphaned (the caller warns and clears any stale dialog). */
   | { kind: "orphan" }
-  /** No combat activity in this batch. */
+  /** Nothing to surface this batch: either no combat events at all, or a
+   *  mid-combat resume round still buffering (pairs resolved, fight not over). */
   | { kind: "none" };
 
 export interface CombatBufferStep {
   /** Events to carry into the next batch (empty once a fight completes). */
-  buffer: GameEvent[];
+  buffer: readonly GameEvent[];
   outcome: CombatBatchOutcome;
 }
 
@@ -262,6 +267,14 @@ export function stepCombatBuffer(
   }
 
   if (ended) {
+    // A completion with no buffered `combat_started` can't build a meaningful
+    // dialog (e.g. a combat resolved right after a save/load that reset the
+    // buffer). Treat it as orphaned so the caller warns rather than silently
+    // dropping the popup. The normal paths — atomic, or a load that re-seeds the
+    // buffer from `combatPrompt` — always carry the start.
+    if (!buffer.some((e) => e.type === "combat_started")) {
+      return { buffer: [], outcome: { kind: "orphan" } };
+    }
     return { buffer: [], outcome: { kind: "complete", dialogEvents: buffer } };
   }
   if (started) {
@@ -281,7 +294,7 @@ export function stepCombatBuffer(
  *  `combat_started` (combat is multi-pair strength). Returns `null` result
  *  if `combat_started` is missing from the batch. */
 export function buildCombatContestResult(
-  events: GameEvent[],
+  events: readonly GameEvent[],
   visibleState: VisibleState | null,
   resolvers: NameResolvers,
 ): ContestResultBuild {
@@ -299,9 +312,9 @@ export function buildCombatContestResult(
   const pairs: PairDetail[] = [];
   for (const e of events) {
     if (e.type === "unit_injured") {
-      outcomes.push({ type: "injured", unitName: resolvers.card(e.unitId), ownerName: resolvers.player(e.controllerId) });
+      outcomes.push({ type: "injured", unitName: resolvers.card(e.unitId), ownerName: resolvers.player(e.controllerId), ownerId: e.controllerId });
     } else if (e.type === "unit_killed") {
-      outcomes.push({ type: "killed", unitName: resolvers.card(e.unitId), ownerName: resolvers.player(e.controllerId) });
+      outcomes.push({ type: "killed", unitName: resolvers.card(e.unitId), ownerName: resolvers.player(e.controllerId), ownerId: e.controllerId });
     } else if (e.type === "combat_pair_resolved") {
       pairs.push(buildPairDetail(e, resolvers));
     }
@@ -317,6 +330,8 @@ export function buildCombatContestResult(
       locationName: cell?.location?.name ?? `(${combatStart.row},${combatStart.col})`,
       attackerName: resolvers.player(combatStart.attackerId),
       defenderName: resolvers.player(combatStart.defenderId),
+      attackerId: combatStart.attackerId,
+      defenderId: combatStart.defenderId,
       pairs,
       outcomes,
       winnerName: combatEnd?.type === "combat_resolved" && combatEnd.winnerId
@@ -367,9 +382,9 @@ export function buildDslContestResult(
   for (let i = contestIdx + 1; i < events.length; i++) {
     const e = events[i];
     if (e.type === "unit_killed" && unitIds.has(e.unitId)) {
-      contestOutcomes.push({ type: "killed", unitName: resolvers.card(e.unitId), ownerName: resolvers.player(e.controllerId) });
+      contestOutcomes.push({ type: "killed", unitName: resolvers.card(e.unitId), ownerName: resolvers.player(e.controllerId), ownerId: e.controllerId });
     } else if (e.type === "unit_injured" && unitIds.has(e.unitId)) {
-      contestOutcomes.push({ type: "injured", unitName: resolvers.card(e.unitId), ownerName: resolvers.player(e.controllerId) });
+      contestOutcomes.push({ type: "injured", unitName: resolvers.card(e.unitId), ownerName: resolvers.player(e.controllerId), ownerId: e.controllerId });
     } else if (e.type === "unit_controlled" && unitIds.has(e.unitId)) {
       contestOutcomes.push({
         type: "controlled",

--- a/clients/web/src/lib/gameStore.svelte.ts
+++ b/clients/web/src/lib/gameStore.svelte.ts
@@ -18,6 +18,7 @@ import {
   buildCombatContestResult,
   buildDslContestResult,
   stepCombatBuffer,
+  type CombatBufferStep,
   type ContestResult,
 } from "./contestResult";
 
@@ -56,8 +57,8 @@ let _contestResult = $state<ContestResult | null>(null);
 // `combat_started` arrives with the `attack`, and the pair/resolution events with
 // the later `resolve_combat_round`. Buffer the fight's events from `combat_started`
 // until `combat_resolved` so the result dialog is built once, from the whole
-// combat, rather than warning on each half-batch. Non-null only mid-combat.
-let _combatEvents: GameEvent[] = [];
+// combat, rather than warning on each half-batch. Non-empty only mid-combat.
+let _combatEvents: readonly GameEvent[] = [];
 
 export function getScreen() {
   return _screen;
@@ -267,6 +268,12 @@ function waitForAction(): Promise<Action> {
   });
 }
 
+/** Compile-time exhaustiveness guard: a new `CombatBatchOutcome` kind that
+ *  isn't handled above becomes a type error here rather than a silent fall-through. */
+function assertNever(x: never): never {
+  throw new Error(`Unhandled combat outcome: ${JSON.stringify(x)}`);
+}
+
 function onEvent(events: GameEvent[], state: GameState): void {
   const baseIndex = _eventLog.length;
   _eventLog = [..._eventLog, ...events];
@@ -283,53 +290,62 @@ function onEvent(events: GameEvent[], state: GameState): void {
   // visible state before the popup renders. Factories live in contestResult.ts
   // so the construction invariants are testable in isolation.
   const resolvers = { card: resolveCardName, player: resolvePlayerName };
-  const combatStart = events.find((e) => e.type === "combat_started");
   const contestEvents = events.filter((e) => e.type === "contest_resolved");
 
   // Fold this batch into the running combat buffer — combat spans multiple
   // batches once the defender assigns matchups (#166). See `stepCombatBuffer`.
-  const combat = stepCombatBuffer(_combatEvents, events);
+  const combat: CombatBufferStep = stepCombatBuffer(_combatEvents, events);
   _combatEvents = combat.buffer;
 
-  // Collision warnings — both fire as their own pushError; the final dialog
-  // wins (combat takes priority over contest), but both warnings stay visible.
-  if (combatStart && contestEvents.length > 0) {
-    pushError("Both combat and a contest resolved in the same batch — only the combat popup is shown.");
-  }
   if (contestEvents.length > 1) {
     pushError("Multiple contest_resolved events in one batch — only the first is shown.");
   }
 
-  if (combat.outcome.kind === "complete") {
-    // The fight finished (atomically, or on the final resume batch). Build the
-    // dialog from the whole accumulated combat.
-    const { result: combatResult, error: combatError } = buildCombatContestResult(
-      combat.outcome.dialogEvents, _visibleState, resolvers,
-    );
-    if (combatError) pushError(combatError);
-    _contestResult = combatResult;
-  } else if (combat.outcome.kind === "suspended") {
-    // Combat paused for the defender's matchup decision — the overlay takes
-    // over. Show no dialog and don't warn about a "missing" resolution.
-  } else if (combat.outcome.kind === "orphan") {
-    _contestResult = null;
-    pushError("Combat pair event arrived without combat_started — popup skipped.");
-  } else {
-    // No combat this batch — handle a DSL stat contest, if any.
-    const contestResolved = contestEvents[0];
-    if (contestResolved && contestResolved.type === "contest_resolved") {
-      const contestIdx = events.indexOf(contestResolved);
-      const { result: contestResult, error: contestError } = buildDslContestResult(
-        contestResolved, contestIdx, events, _visibleState, resolvers,
-      );
-      if (contestResult) {
-        _contestResult = contestResult;
-      } else if (contestError) {
-        // Skip path: clear any stale popup before surfacing the error.
-        _contestResult = null;
-        pushError(contestError);
+  switch (combat.outcome.kind) {
+    case "complete": {
+      // The fight finished (atomically, or on the final resume batch). Build the
+      // dialog from the whole accumulated combat. A co-batched contest loses to
+      // the combat popup, so warn only here — where a dialog is actually shown.
+      if (contestEvents.length > 0) {
+        pushError("Both combat and a contest resolved in the same batch — only the combat popup is shown.");
       }
+      const { result: combatResult, error: combatError } = buildCombatContestResult(
+        combat.outcome.dialogEvents, _visibleState, resolvers,
+      );
+      if (combatError) pushError(combatError);
+      _contestResult = combatResult;
+      break;
     }
+    case "suspended":
+      // Combat paused for the defender's matchup decision — the overlay takes
+      // over. Clear any stale dialog so it can't linger under the overlay.
+      _contestResult = null;
+      break;
+    case "orphan":
+      _contestResult = null;
+      pushError("Combat pair event arrived without combat_started — popup skipped.");
+      break;
+    case "none": {
+      // No combat dialog to build (no combat events, or a multi-round fight
+      // still buffering) — handle a DSL stat contest, if any.
+      const contestResolved = contestEvents[0];
+      if (contestResolved && contestResolved.type === "contest_resolved") {
+        const contestIdx = events.indexOf(contestResolved);
+        const { result: contestResult, error: contestError } = buildDslContestResult(
+          contestResolved, contestIdx, events, _visibleState, resolvers,
+        );
+        if (contestResult) {
+          _contestResult = contestResult;
+        } else if (contestError) {
+          // Skip path: clear any stale popup before surfacing the error.
+          _contestResult = null;
+          pushError(contestError);
+        }
+      }
+      break;
+    }
+    default:
+      assertNever(combat.outcome);
   }
 
   if (state.phase === "ended" && players.length > 0) {
@@ -477,6 +493,18 @@ export async function loadGame(key: string): Promise<void> {
 
   const state = controller.getState();
   _gamePhase = state.phase;
+
+  // If we resumed into a suspended combat, seed the combat buffer with a
+  // synthesized `combat_started` reconstructed from the live `combatPrompt`. The
+  // real `combat_started` lived in the pre-load event log (which we don't
+  // replay), so without this the resume's pair/resolution events would look
+  // orphaned and the result dialog would be skipped.
+  if (state.phase === "main" && state.combatPrompt) {
+    const cp = state.combatPrompt;
+    _combatEvents = [
+      { type: "combat_started", row: cp.row, col: cp.col, attackerId: cp.attackerId, defenderId: cp.defenderId },
+    ];
+  }
 
   if (state.phase === "ended" && players.length > 0) {
     _visibleState = engineGetVisibleState(state, players[0].id);

--- a/clients/web/src/lib/gameStore.svelte.ts
+++ b/clients/web/src/lib/gameStore.svelte.ts
@@ -17,6 +17,7 @@ import { autoSave, listSessions, loadSession, saveSession } from "./persistence"
 import {
   buildCombatContestResult,
   buildDslContestResult,
+  stepCombatBuffer,
   type ContestResult,
 } from "./contestResult";
 
@@ -51,6 +52,12 @@ let _lastTurnStartIndex = $state(0);
 let _incomingPlayerId = $state<string | null>(null);
 
 let _contestResult = $state<ContestResult | null>(null);
+// Combat spans multiple event batches when the defender assigns matchups (#166):
+// `combat_started` arrives with the `attack`, and the pair/resolution events with
+// the later `resolve_combat_round`. Buffer the fight's events from `combat_started`
+// until `combat_resolved` so the result dialog is built once, from the whole
+// combat, rather than warning on each half-batch. Non-null only mid-combat.
+let _combatEvents: GameEvent[] = [];
 
 export function getScreen() {
   return _screen;
@@ -279,6 +286,11 @@ function onEvent(events: GameEvent[], state: GameState): void {
   const combatStart = events.find((e) => e.type === "combat_started");
   const contestEvents = events.filter((e) => e.type === "contest_resolved");
 
+  // Fold this batch into the running combat buffer — combat spans multiple
+  // batches once the defender assigns matchups (#166). See `stepCombatBuffer`.
+  const combat = stepCombatBuffer(_combatEvents, events);
+  _combatEvents = combat.buffer;
+
   // Collision warnings — both fire as their own pushError; the final dialog
   // wins (combat takes priority over contest), but both warnings stay visible.
   if (combatStart && contestEvents.length > 0) {
@@ -288,26 +300,22 @@ function onEvent(events: GameEvent[], state: GameState): void {
     pushError("Multiple contest_resolved events in one batch — only the first is shown.");
   }
 
-  if (combatStart) {
-    const { result: combatResult, error: combatError } = buildCombatContestResult(events, _visibleState, resolvers);
+  if (combat.outcome.kind === "complete") {
+    // The fight finished (atomically, or on the final resume batch). Build the
+    // dialog from the whole accumulated combat.
+    const { result: combatResult, error: combatError } = buildCombatContestResult(
+      combat.outcome.dialogEvents, _visibleState, resolvers,
+    );
     if (combatError) pushError(combatError);
-    if (combatResult) {
-      _contestResult = combatResult;
-    } else {
-      // Factory returned null with no error — couldn't find combat_started.
-      // Shouldn't happen since we just checked combatStart above; defensive.
-      _contestResult = null;
-    }
+    _contestResult = combatResult;
+  } else if (combat.outcome.kind === "suspended") {
+    // Combat paused for the defender's matchup decision — the overlay takes
+    // over. Show no dialog and don't warn about a "missing" resolution.
+  } else if (combat.outcome.kind === "orphan") {
+    _contestResult = null;
+    pushError("Combat pair event arrived without combat_started — popup skipped.");
   } else {
-    // Orphan-pair guard: any `combat_pair_resolved` without a matching
-    // `combat_started` in the same batch would silently disappear from
-    // the popup. Clear stale popup state too — see Finding #2.
-    const orphanPair = events.find((e) => e.type === "combat_pair_resolved");
-    if (orphanPair) {
-      _contestResult = null;
-      pushError("Combat pair event arrived without combat_started — popup skipped.");
-    }
-
+    // No combat this batch — handle a DSL stat contest, if any.
     const contestResolved = contestEvents[0];
     if (contestResolved && contestResolved.type === "contest_resolved") {
       const contestIdx = events.indexOf(contestResolved);
@@ -396,6 +404,7 @@ export function startNewGame(
   _prevTurnStartIndex = 0;
   _lastTurnStartIndex = 0;
   _contestResult = null;
+  _combatEvents = [];
   lastActivePlayerId = null;
   autoSaveFailCount = 0;
 
@@ -449,6 +458,7 @@ export async function loadGame(key: string): Promise<void> {
   _prevTurnStartIndex = 0;
   _lastTurnStartIndex = 0;
   _contestResult = null;
+  _combatEvents = [];
   lastActivePlayerId = null;
   autoSaveFailCount = 0;
 
@@ -548,6 +558,7 @@ export function returnToMenu(): void {
   _prevTurnStartIndex = 0;
   _lastTurnStartIndex = 0;
   _contestResult = null;
+  _combatEvents = [];
   _gamePhase = null;
   _currentPlayerName = "";
   _error = null;

--- a/clients/web/src/vite-env.d.ts
+++ b/clients/web/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="svelte" />
+/// <reference types="vite/client" />

--- a/clients/web/svelte.config.js
+++ b/clients/web/svelte.config.js
@@ -2,8 +2,9 @@ import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 
 // Consumed by both `@sveltejs/vite-plugin-svelte` (at build/dev time) and
 // `svelte-check` (for type-checking `.svelte` files). Without this file
-// svelte-check cannot locate the Svelte configuration and errors on every
-// component, silently bypassing component type-checking.
+// svelte-check cannot locate the Svelte configuration and errors out on every
+// component before type-checking them — so real component type errors go
+// unreported.
 export default {
   preprocess: vitePreprocess(),
 };

--- a/clients/web/svelte.config.js
+++ b/clients/web/svelte.config.js
@@ -1,0 +1,9 @@
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+
+// Consumed by both `@sveltejs/vite-plugin-svelte` (at build/dev time) and
+// `svelte-check` (for type-checking `.svelte` files). Without this file
+// svelte-check cannot locate the Svelte configuration and errors on every
+// component, silently bypassing component type-checking.
+export default {
+  preprocess: vitePreprocess(),
+};

--- a/engine/VISIBILITY.md
+++ b/engine/VISIBILITY.md
@@ -38,8 +38,9 @@ Teammates are treated as **self** — they share full visibility (see
 - `winner`, `scores` (ended phase)
 - `middleArea`, `seedingStep` (seeding phase)
 - **`combatPrompt`** — combat is fully open information. When a combat suspends
-  between rounds (#165), *every* viewer sees the full prompt (cell, round,
-  committed unit-id lists, and which player must decide). This is deliberately
+  mid-round for the defender's matchup decision (#166), *every* viewer sees the
+  full prompt (cell, round, committed unit-id lists, revealed rolls, and which
+  player must decide). This is deliberately
   unlike `pickPrompt`/`viewPrompt`. Rationale: the units in the prompt are
   already on the public grid, so nothing new leaks — and both sides watching a
   fight need to see it pause. See #165, and #166–#168 for the decisions that

--- a/engine/src/__tests__/contest-surfacing.test.ts
+++ b/engine/src/__tests__/contest-surfacing.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { produce } from "immer";
 import { applyAction } from "../apply-action";
+import { getValidActions } from "../valid-actions";
 import { deriveCombatOutcome } from "../apply-main";
 import { decideKillVsInjure, computeContestPower } from "../unit-helpers";
 import { rebuildListeners } from "../listeners/rebuild";
@@ -10,6 +11,7 @@ import type {
   CombatSide,
   ContestSide,
   GameEvent,
+  MainAction,
   MainGameState,
   ModifierEntry,
 } from "../types";
@@ -192,7 +194,7 @@ describe("combat_pair_resolved", () => {
     expect(pair.defender.baseStrength + defSum + pair.defender.roll).toBe(pair.defender.power);
   });
 
-  it("emits per pair across a 2v2 — pairing pulls highest-power vs highest-power", () => {
+  it("emits per pair across a 2v2 — greedy default pairs highest-power vs highest-power", () => {
     const a1 = makeUnit({ ownerId: ACTIVE, strength: 10 });
     const a2 = makeUnit({ ownerId: ACTIVE, strength: 3 });
     const d1 = makeUnit({ ownerId: OTHER, strength: 8 });
@@ -202,13 +204,18 @@ describe("combat_pair_resolved", () => {
       d.grid[0][0].units.push(a1, a2, d1, d2);
     });
 
-    const { events } = applyAction(state, {
+    // A 2v2 suspends for the defender's matchup decision (#166). The greedy
+    // default that getValidActions offers pairs highest-vs-highest — the pairing
+    // this per-pair emission check pins.
+    const { state: suspended } = applyAction(state, {
       type: "attack",
       playerId: ACTIVE,
       unitIds: [a1.id, a2.id],
       row: 0,
       col: 0,
     });
+    const ns = suspended as MainGameState;
+    const { events } = applyAction(ns, getValidActions(ns, OTHER)[0] as MainAction);
 
     const pairs = findAllPairs(events);
     expect(pairs.length).toBeGreaterThanOrEqual(2);

--- a/engine/src/__tests__/controller.test.ts
+++ b/engine/src/__tests__/controller.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import { produce } from "immer";
+import { applyAction } from "../apply-action";
 import { BotAdapter } from "../bot-adapter";
 import { GameController } from "../controller";
 import type {
@@ -11,7 +13,15 @@ import type {
   Session,
   VisibleState,
 } from "../types";
-import { DEFAULT_CONFIG, SEED, TWO_PLAYERS } from "./helpers";
+import {
+  createTestGame,
+  DEFAULT_CONFIG,
+  makeLocation,
+  makeUnit,
+  resetIds,
+  SEED,
+  TWO_PLAYERS,
+} from "./helpers";
 
 const MAIN_SETUP_INPUT: SetupInput = {
   mode: "main",
@@ -106,6 +116,82 @@ describe("GameController", () => {
       });
 
       await expect(controller.playTurn()).rejects.toThrow("invalid action");
+    });
+  });
+
+  describe("suspended combat routing", () => {
+    // Build a 2v2 combat suspended for the defender's matchup decision.
+    function buildSuspendedCombat(): MainGameState {
+      resetIds();
+      const strongAtk = makeUnit({ ownerId: "p2", strength: 100 });
+      const weakAtk = makeUnit({ ownerId: "p2", strength: 1 });
+      const strongDef = makeUnit({ ownerId: "p1", strength: 100 });
+      const weakDef = makeUnit({ ownerId: "p1", strength: 1 });
+      const base = produce(createTestGame(), (d) => {
+        d.grid[0][0].location = makeLocation({ ownerId: "p2" });
+        d.grid[0][0].units.push(strongAtk, weakAtk, strongDef, weakDef);
+      });
+      const { state } = applyAction(base, {
+        type: "attack",
+        playerId: "p2",
+        row: 0,
+        col: 0,
+        unitIds: [strongAtk.id, weakAtk.id],
+      });
+      const suspended = state as MainGameState;
+      // Precondition: p2 (active attacker) is suspended; p1 (defender) decides.
+      expect(suspended.combatPrompt?.playerId).toBe("p1");
+      expect(suspended.turn.activePlayerId).toBe("p2");
+      return suspended;
+    }
+
+    // Regression for the #179 finding: `playTurn` drove the loop off the active
+    // (attacker) player, whose valid-action list is empty while suspended, so a
+    // legitimate defender submission was rejected as "invalid action" and the
+    // interactive loop crashed. `playTurn` must route the turn to the decider.
+    it("routes a suspended combat's turn to the non-active defender", async () => {
+      const suspended = buildSuspendedCombat();
+
+      const events: GameEvent[] = [];
+      const deciderAdapter: PlayerAdapter = {
+        // Submit the greedy default (getValidActions offers it first).
+        async chooseAction(_vis: VisibleState, valid: Action[]) {
+          expect(valid.length).toBeGreaterThan(0);
+          return valid[0];
+        },
+      };
+      const attackerAdapter: PlayerAdapter = {
+        async chooseAction() {
+          throw new Error("attacker adapter must not be asked while combat is suspended");
+        },
+      };
+
+      const session: Session = {
+        version: "0.1.0",
+        config: DEFAULT_CONFIG,
+        players: TWO_PLAYERS,
+        seed: SEED,
+        actions: [],
+        snapshot: suspended,
+      };
+      const controller = GameController.fromSession(
+        session,
+        MAIN_SETUP_INPUT,
+        new Map<string, PlayerAdapter>([
+          ["p1", deciderAdapter],
+          ["p2", attackerAdapter],
+        ]),
+        (evs) => events.push(...evs),
+      );
+
+      let guard = 0;
+      while ((controller.getState() as MainGameState).combatPrompt) {
+        if (guard++ > 10) throw new Error("combat failed to terminate");
+        await controller.playTurn();
+      }
+
+      expect((controller.getState() as MainGameState).combatPrompt).toBeUndefined();
+      expect(events.filter((e) => e.type === "combat_resolved")).toHaveLength(1);
     });
   });
 

--- a/engine/src/__tests__/main-actions.test.ts
+++ b/engine/src/__tests__/main-actions.test.ts
@@ -1087,6 +1087,27 @@ describe("defender-assigned matchups (#166)", () => {
     }
   });
 
+  it("emits plain combat sides on resume (no revoked draft proxies leak into events)", () => {
+    // The stashed rolls live on `draft.combatPrompt`; before snapshotting them
+    // out of the draft, `toCombatSide` copied `modifiers` by reference, so the
+    // emitted event held a draft proxy that was revoked once produce() finished
+    // — any later reader (the event log) then threw "proxy revoked".
+    const s = suspendingCombat();
+    const suspended = attackAndSuspend(s);
+    const { events } = applyAction(
+      suspended,
+      getValidActions(suspended, OTHER)[0] as MainAction,
+    );
+    const pair = events.find((e) => e.type === "combat_pair_resolved");
+    expect(pair).toBeDefined();
+    if (pair?.type !== "combat_pair_resolved") return;
+    // Traversing the side (as JSON serialization / the event log does) must not
+    // throw on a revoked proxy.
+    expect(() => JSON.stringify(pair.attacker)).not.toThrow();
+    expect(() => JSON.stringify(pair.defender)).not.toThrow();
+    expect(Array.isArray(pair.attacker.modifiers)).toBe(true);
+  });
+
   it("resolves to the correct winner after the defender assigns matchups", () => {
     // Two str-100 attackers vs two str-1 defenders: min=2 so it suspends, and
     // any greedy pairing (101+ vs 7-max) means the attacker always wins — a

--- a/engine/src/__tests__/main-actions.test.ts
+++ b/engine/src/__tests__/main-actions.test.ts
@@ -3,7 +3,7 @@ import { produce } from "immer";
 import { applyAction } from "../apply-action";
 import { rebuildListeners } from "../listeners/rebuild";
 import { getModifiedStat } from "../listeners/query";
-import type { GameEvent, MainGameState, UnitCard } from "../types";
+import type { GameEvent, MainAction, MainGameState, UnitCard } from "../types";
 import { getValidActions } from "../valid-actions";
 import {
   createTestGame,
@@ -774,145 +774,256 @@ describe("attack", () => {
 });
 
 // ---------------------------------------------------------------------------
-// mid-combat suspension (#165)
+// defender-assigned matchups (#166)
 // ---------------------------------------------------------------------------
 //
-// A 1-vs-3 stack fights one pair per round (min(1,3) = 1), so a lone strong
-// attacker (str 100) deterministically kills one str-1 defender per round —
-// three rounds, with both sides still having uninjured combatants after rounds
-// 0 and 1. That gives a real between-rounds boundary for the suspension hook to
-// pause at. The `combat_suspend_between_rounds` config is the #165 test seam:
-// `combatDecisionPending` returns true, standing in for the real pause
-// conditions that arrive with #166–#168.
-describe("mid-combat suspension (#165)", () => {
+// Per rules step 4 the defender pairs units "after seeing all rolls", so combat
+// suspends *within* a round — after the roll, before resolution — whenever the
+// defender has a real pairing choice (min(sides) >= 2). A 2-vs-2 with widely
+// separated strengths is the canonical case: As (str 100) always outpowers
+// Aw (str 1) and Ds always outpowers Dw regardless of the d6, so the roll-sorted
+// participant order is deterministic — [As, Aw] vs [Ds, Dw] — and the greedy
+// default pairs As↔Ds / Aw↔Dw. The defender may instead cross them (As↔Dw,
+// Aw↔Ds), which the engine must honor.
+describe("defender-assigned matchups (#166)", () => {
   function suspendingCombat(): {
     state: MainGameState;
-    attackerId: string;
-    defenderIds: string[];
+    strongAtk: string;
+    weakAtk: string;
+    strongDef: string;
+    weakDef: string;
   } {
-    const attacker = makeUnit({ ownerId: ACTIVE, strength: 100 });
-    const d1 = makeUnit({ ownerId: OTHER, strength: 1 });
-    const d2 = makeUnit({ ownerId: OTHER, strength: 1 });
-    const d3 = makeUnit({ ownerId: OTHER, strength: 1 });
+    const strongAtk = makeUnit({ ownerId: ACTIVE, strength: 100 });
+    const weakAtk = makeUnit({ ownerId: ACTIVE, strength: 1 });
+    const strongDef = makeUnit({ ownerId: OTHER, strength: 100 });
+    const weakDef = makeUnit({ ownerId: OTHER, strength: 1 });
     const state = gameWith((d) => {
-      d.config["combat_suspend_between_rounds"] = 1;
       d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
-      d.grid[0][0].units.push(attacker, d1, d2, d3);
+      d.grid[0][0].units.push(strongAtk, weakAtk, strongDef, weakDef);
     });
-    return { state, attackerId: attacker.id, defenderIds: [d1.id, d2.id, d3.id] };
+    return {
+      state,
+      strongAtk: strongAtk.id,
+      weakAtk: weakAtk.id,
+      strongDef: strongDef.id,
+      weakDef: weakDef.id,
+    };
   }
 
   const attackAction = { type: "attack" as const, playerId: ACTIVE, row: 0, col: 0 };
 
-  it("suspends between rounds without resolving combat", () => {
-    const { state, attackerId } = suspendingCombat();
-
-    const { state: next, events } = applyAction(state, {
+  /** Attack with both attackers and return the suspended state. */
+  function attackAndSuspend(s: ReturnType<typeof suspendingCombat>): MainGameState {
+    const { state } = applyAction(s.state, {
       ...attackAction,
-      unitIds: [attackerId],
+      unitIds: [s.strongAtk, s.weakAtk],
+    });
+    return state as MainGameState;
+  }
+
+  /** The defender-side ids each attacker was actually paired against, from the
+   *  first (round-0) pair-resolved events. */
+  function round0Pairing(events: GameEvent[]): Record<string, string> {
+    const map: Record<string, string> = {};
+    for (const e of events) {
+      if (e.type === "combat_pair_resolved" && !(e.attacker.unitId in map)) {
+        map[e.attacker.unitId] = e.defender.unitId;
+      }
+    }
+    return map;
+  }
+
+  it("suspends at round 0 for the defender's matchup decision, before resolving", () => {
+    const s = suspendingCombat();
+    const { state: next, events } = applyAction(s.state, {
+      ...attackAction,
+      unitIds: [s.strongAtk, s.weakAtk],
     });
     const ns = next as MainGameState;
 
-    // Combat began and paused: started but not resolved.
+    // Combat began and paused. Unlike #165's between-rounds suspend, NOTHING is
+    // resolved before the pause — the roll is revealed, resolution waits.
     expect(events.map((e) => e.type)).toContain("combat_started");
     expect(events.some((e) => e.type === "combat_resolved")).toBe(false);
-    // Exactly one pair (the opening round) resolved before the pause.
-    expect(events.filter((e) => e.type === "combat_pair_resolved")).toHaveLength(1);
+    expect(events.some((e) => e.type === "combat_pair_resolved")).toBe(false);
 
-    // The prompt carries the resumable state, awaiting round 1.
+    // The prompt hands the decision to the defender (the non-active player) and
+    // carries the round's revealed rolls for both participating sides.
     expect(ns.combatPrompt).toBeDefined();
-    expect(ns.combatPrompt?.round).toBe(1);
-    expect(ns.combatPrompt?.playerId).toBe(ACTIVE);
+    expect(ns.combatPrompt?.round).toBe(0);
+    expect(ns.combatPrompt?.playerId).toBe(OTHER);
     expect(ns.combatPrompt?.attackerId).toBe(ACTIVE);
     expect(ns.combatPrompt?.defenderId).toBe(OTHER);
-    expect(ns.combatPrompt?.attackerUnitIds).toEqual([attackerId]);
+    expect(ns.combatPrompt?.atkRolls.map((r) => r.unitId)).toEqual([s.strongAtk, s.weakAtk]);
+    expect(ns.combatPrompt?.defRolls.map((r) => r.unitId)).toEqual([s.strongDef, s.weakDef]);
 
     // AP was spent up front on the initiating attack (not on resume).
     expect(ns.turn.actionPointsRemaining).toBe(2);
   });
 
-  it("resumes via resolve_combat_round and eventually completes", () => {
-    const { state, attackerId } = suspendingCombat();
+  it("lets the non-active defender submit the assignment and resolve", () => {
+    const s = suspendingCombat();
+    const suspended = attackAndSuspend(s);
 
-    const first = applyAction(state, { ...attackAction, unitIds: [attackerId] });
-    let cur = first.state as MainGameState;
-    const allEvents: GameEvent[] = [...first.events];
+    // The defender (OTHER) is not the active player, yet may resolve.
+    const decision = getValidActions(suspended, OTHER)[0];
+    expect(decision).toMatchObject({ type: "resolve_combat_round", playerId: OTHER });
 
-    // Drive resolve_combat_round until the fight terminates. Each resume fights
-    // exactly one more round then re-suspends (seam still on) until a side empties.
+    let cur = suspended;
+    const events: GameEvent[] = [];
     let guard = 0;
     while (cur.combatPrompt) {
       if (guard++ > 10) throw new Error("combat failed to terminate");
-      const r = applyAction(cur, { type: "resolve_combat_round", playerId: ACTIVE });
+      const r = applyAction(cur, getValidActions(cur, cur.combatPrompt.playerId)[0] as MainAction);
       cur = r.state as MainGameState;
-      allEvents.push(...r.events);
+      events.push(...r.events);
     }
 
-    // Emitted exactly once, at the true end, with the attacker as winner.
-    const resolved = allEvents.filter((e) => e.type === "combat_resolved");
-    expect(resolved).toHaveLength(1);
-    expect(resolved[0]).toMatchObject({ type: "combat_resolved", winnerId: ACTIVE });
-    // combat_started is emitted only once, never on resume.
-    expect(allEvents.filter((e) => e.type === "combat_started")).toHaveLength(1);
-    // All three defenders killed; the attacker holds the cell.
-    expect(cur.grid[0][0].units.map((u) => u.id)).toEqual([attackerId]);
-    // Resuming spends no AP — it was all spent up front on the initiating attack.
-    expect(cur.turn.actionPointsRemaining).toBe(2);
+    expect(cur.combatPrompt).toBeUndefined();
+    expect(events.filter((e) => e.type === "combat_resolved")).toHaveLength(1);
+    expect(events.filter((e) => e.type === "combat_started")).toHaveLength(0); // started fired pre-suspend
   });
 
-  it("rejects any non-resolver action while combat is suspended", () => {
-    const { state, attackerId } = suspendingCombat();
-    const { state: next } = applyAction(state, { ...attackAction, unitIds: [attackerId] });
+  it("honors a non-greedy assignment that diverges from the greedy default", () => {
+    // Greedy default pairs strong↔strong; the defender instead crosses the
+    // matchups (strong attacker vs weak defender, weak attacker vs strong
+    // defender). The engine must resolve the pairs the defender chose. Both
+    // decisions are applied to the same immutable suspended state, so unit ids
+    // (and rolls) match and the pairings are directly comparable.
+    const s = suspendingCombat();
+    const suspended = attackAndSuspend(s);
 
-    expect(() =>
-      applyAction(next, { type: "pass", playerId: ACTIVE }),
-    ).toThrow("suspended combat must be resolved first");
+    const greedyRun = applyAction(suspended, getValidActions(suspended, OTHER)[0] as MainAction);
+    const greedyPairing = round0Pairing(greedyRun.events);
+
+    const crossedRun = applyAction(suspended, {
+      type: "resolve_combat_round",
+      playerId: OTHER,
+      decision: {
+        kind: "assign_matchups",
+        pairs: [
+          { attackerUnitId: s.strongAtk, defenderUnitId: s.weakDef },
+          { attackerUnitId: s.weakAtk, defenderUnitId: s.strongDef },
+        ],
+      },
+    });
+    const crossedPairing = round0Pairing(crossedRun.events);
+
+    // Greedy paired the strong attacker against the strong defender; the
+    // defender's crossed assignment paired it against the weak defender instead.
+    expect(greedyPairing[s.strongAtk]).toBe(s.strongDef);
+    expect(crossedPairing[s.strongAtk]).toBe(s.weakDef);
+    expect(crossedPairing[s.weakAtk]).toBe(s.strongDef);
+    expect(crossedPairing).not.toEqual(greedyPairing);
   });
 
   it("rejects resolve_combat_round from a non-decider", () => {
-    // Construct a suspended combat whose decider is NOT the active player, so the
-    // active player's submit clears the turn-ownership check and reaches the
-    // handler's own decider guard. (In #165 the decider is always the attacker,
-    // i.e. the active player, so this mismatch is only reachable synthetically —
-    // but #166 hands the decision to the defender, where this guard bites.)
-    const state = gameWith((d) => {
-      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
-      d.combatPrompt = {
-        playerId: OTHER,
-        row: 0,
-        col: 0,
-        attackerId: ACTIVE,
-        defenderId: OTHER,
-        round: 1,
-        attackerUnitIds: [],
-        defenderUnitIds: [],
-      };
-    });
-
+    // The decider is the defender (OTHER); the active attacker (ACTIVE) clears
+    // the turn-ownership gate but is rejected by the handler's decider guard.
+    const suspended = attackAndSuspend(suspendingCombat());
     expect(() =>
-      applyAction(state, { type: "resolve_combat_round", playerId: ACTIVE }),
+      applyAction(suspended, {
+        type: "resolve_combat_round",
+        playerId: ACTIVE,
+        decision: { kind: "assign_matchups", pairs: [] },
+      }),
     ).toThrow("pending combat decision is for");
   });
 
   it("rejects resolve_combat_round when no combat is suspended", () => {
     const state = gameWith(() => {});
     expect(() =>
-      applyAction(state, { type: "resolve_combat_round", playerId: ACTIVE }),
+      applyAction(state, {
+        type: "resolve_combat_round",
+        playerId: ACTIVE,
+        decision: { kind: "assign_matchups", pairs: [] },
+      }),
     ).toThrow("no suspended combat");
   });
 
-  it("offers only resolve_combat_round to the decider while suspended", () => {
-    const { state, attackerId } = suspendingCombat();
-    const { state: next } = applyAction(state, { ...attackAction, unitIds: [attackerId] });
-
-    expect(getValidActions(next as MainGameState, ACTIVE)).toEqual([
-      { type: "resolve_combat_round", playerId: ACTIVE },
-    ]);
+  it("rejects an assignment with the wrong pair count", () => {
+    const s = suspendingCombat();
+    const suspended = attackAndSuspend(s);
+    expect(() =>
+      applyAction(suspended, {
+        type: "resolve_combat_round",
+        playerId: OTHER,
+        decision: {
+          kind: "assign_matchups",
+          pairs: [{ attackerUnitId: s.strongAtk, defenderUnitId: s.strongDef }],
+        },
+      }),
+    ).toThrow("expected 2 matchup(s), got 1");
   });
 
-  it("auto-resolves atomically when the decision seam is off", () => {
-    // Same 1-vs-3 stack, but without the seam: combat must resolve in a single
-    // action with no lingering prompt — the #165 scope guard.
+  it("rejects an assignment naming a non-participant unit", () => {
+    const s = suspendingCombat();
+    const suspended = attackAndSuspend(s);
+    expect(() =>
+      applyAction(suspended, {
+        type: "resolve_combat_round",
+        playerId: OTHER,
+        decision: {
+          kind: "assign_matchups",
+          pairs: [
+            { attackerUnitId: s.strongAtk, defenderUnitId: s.strongDef },
+            { attackerUnitId: "ghost", defenderUnitId: s.weakDef },
+          ],
+        },
+      }),
+    ).toThrow('attacker "ghost" is not a participant');
+  });
+
+  it("rejects an assignment that pairs a unit twice", () => {
+    const s = suspendingCombat();
+    const suspended = attackAndSuspend(s);
+    expect(() =>
+      applyAction(suspended, {
+        type: "resolve_combat_round",
+        playerId: OTHER,
+        decision: {
+          kind: "assign_matchups",
+          pairs: [
+            { attackerUnitId: s.strongAtk, defenderUnitId: s.strongDef },
+            { attackerUnitId: s.weakAtk, defenderUnitId: s.strongDef },
+          ],
+        },
+      }),
+    ).toThrow("is paired more than once");
+  });
+
+  it("rejects any non-resolver action while combat is suspended", () => {
+    const suspended = attackAndSuspend(suspendingCombat());
+    expect(() =>
+      applyAction(suspended, { type: "pass", playerId: ACTIVE }),
+    ).toThrow("suspended combat must be resolved first");
+  });
+
+  it("offers the greedy-default matchup to the decider, nothing to others", () => {
+    const s = suspendingCombat();
+    const suspended = attackAndSuspend(s);
+
+    // The defender is offered exactly the greedy default (strong↔strong).
+    expect(getValidActions(suspended, OTHER)).toEqual([
+      {
+        type: "resolve_combat_round",
+        playerId: OTHER,
+        decision: {
+          kind: "assign_matchups",
+          pairs: [
+            { attackerUnitId: s.strongAtk, defenderUnitId: s.strongDef },
+            { attackerUnitId: s.weakAtk, defenderUnitId: s.weakDef },
+          ],
+        },
+      },
+    ]);
+    // The active attacker gets nothing while it waits on the defender.
+    expect(getValidActions(suspended, ACTIVE)).toEqual([]);
+  });
+
+  it("auto-resolves atomically for a trivial pairing (one side has a single unit)", () => {
+    // 1-vs-3: min(1,3) = 1, so there is only one possible matching — no defender
+    // decision. Combat resolves in a single action with no lingering prompt.
     const attacker = makeUnit({ ownerId: ACTIVE, strength: 100 });
     const defenders = [
       makeUnit({ ownerId: OTHER, strength: 1 }),
@@ -934,104 +1045,6 @@ describe("mid-combat suspension (#165)", () => {
     expect(events.some((e) => e.type === "combat_resolved")).toBe(true);
   });
 
-  it("yields identical rolls, grid and winner whether auto-resolved or suspended", () => {
-    // The scope guard's strongest form: suspend/resume must reproduce the exact
-    // auto-resolve outcome. rng is persisted across the suspend boundary, so the
-    // per-round d6 stream — captured here from `combat_pair_resolved` — must
-    // match between the two paths. A resume that re-drew or dropped an rng value
-    // would desync round ≥1 rolls and fail this test even when the win/loss
-    // outcome happens to be roll-insensitive.
-    function rollSequence(events: GameEvent[]): Array<[number, number]> {
-      return events
-        .filter((e) => e.type === "combat_pair_resolved")
-        .map((e) => [e.attacker.roll, e.defender.roll] as [number, number]);
-    }
-
-    // Build one fight, then derive both paths from it so unit instance ids (and
-    // the seed) are identical and the final grids are directly comparable.
-    const { state: base, attackerId } = suspendingCombat();
-
-    // Auto path (seam off): one atomic action.
-    const autoState = produce(base, (d) => {
-      d.config["combat_suspend_between_rounds"] = 0;
-    });
-    const autoRun = applyAction(autoState, { ...attackAction, unitIds: [attackerId] });
-    const autoFinal = autoRun.state as MainGameState;
-
-    // Suspended path (seam on): drive resolve_combat_round to completion.
-    const first = applyAction(base, { ...attackAction, unitIds: [attackerId] });
-    let cur = first.state as MainGameState;
-    const suspEvents: GameEvent[] = [...first.events];
-    let guard = 0;
-    while (cur.combatPrompt) {
-      if (guard++ > 10) throw new Error("combat failed to terminate");
-      const r = applyAction(cur, { type: "resolve_combat_round", playerId: ACTIVE });
-      cur = r.state as MainGameState;
-      suspEvents.push(...r.events);
-    }
-
-    expect(rollSequence(suspEvents)).toEqual(rollSequence(autoRun.events));
-    expect(cur.grid[0][0].units.map((u) => u.id)).toEqual(
-      autoFinal.grid[0][0].units.map((u) => u.id),
-    );
-    const suspWinner = suspEvents.find((e) => e.type === "combat_resolved");
-    const autoWinner = autoRun.events.find((e) => e.type === "combat_resolved");
-    expect(suspWinner).toEqual(autoWinner);
-  });
-
-  it("keeps an injured survivor out of the resumed round and alive in the cell", () => {
-    // Drop-out survivor semantics across a suspend boundary: an already-injured
-    // unit must not fight the resumed round, yet must remain in the cell.
-    // Constructed synthetically (a real fight can't deterministically injure
-    // without killing under d6 swing) — the decider is the active attacker so
-    // the resolve is accepted.
-    const attacker = makeUnit({ ownerId: ACTIVE, strength: 100 });
-    const dInjured = makeUnit({ ownerId: OTHER, strength: 1, injured: true });
-    const dHealthy = makeUnit({ ownerId: OTHER, strength: 1 });
-    const state = gameWith((d) => {
-      d.config["combat_suspend_between_rounds"] = 1;
-      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
-      d.grid[0][0].units.push(attacker, dInjured, dHealthy);
-      d.combatPrompt = {
-        playerId: ACTIVE,
-        row: 0,
-        col: 0,
-        attackerId: ACTIVE,
-        defenderId: OTHER,
-        round: 1,
-        attackerUnitIds: [attacker.id],
-        defenderUnitIds: [dInjured.id, dHealthy.id],
-      };
-    });
-
-    const { state: next, events } = applyAction(state, {
-      type: "resolve_combat_round",
-      playerId: ACTIVE,
-    });
-    const ns = next as MainGameState;
-
-    // Only the healthy defender was ever paired; the injured one sat out.
-    const pairedDefenders = events
-      .filter((e) => e.type === "combat_pair_resolved")
-      .map((e) => e.defender.unitId);
-    expect(pairedDefenders).toEqual([dHealthy.id]);
-    // The injured survivor is still in the cell; the healthy one was killed.
-    const survivors = ns.grid[0][0].units.map((u) => u.id);
-    expect(survivors).toContain(dInjured.id);
-    expect(survivors).not.toContain(dHealthy.id);
-  });
-
-  it("returns no valid actions to a non-decider while combat is suspended", () => {
-    // Documents the current contract: getValidActions returns [] for any
-    // non-active player, and today the decider is always the active attacker.
-    // #166 (defender-assigned decision) must revisit both this and the
-    // active-player gate in apply-action.ts (see the TODO there).
-    const { state, attackerId } = suspendingCombat();
-    const { state: next } = applyAction(state, { ...attackAction, unitIds: [attackerId] });
-
-    expect(getValidActions(next as MainGameState, OTHER)).toEqual([]);
-  });
-
   it("throws if multiple prompts are set at once (mutual-exclusion invariant)", () => {
     // combatPrompt / pickPrompt / viewPrompt are mutually exclusive; a producer
     // that co-sets two must fail loud at dispatch rather than deadlock.
@@ -1045,6 +1058,8 @@ describe("mid-combat suspension (#165)", () => {
         round: 1,
         attackerUnitIds: [],
         defenderUnitIds: [],
+        atkRolls: [],
+        defRolls: [],
       };
       d.pickPrompt = {
         playerId: ACTIVE,
@@ -1056,7 +1071,11 @@ describe("mid-combat suspension (#165)", () => {
     });
 
     expect(() =>
-      applyAction(state, { type: "resolve_combat_round", playerId: ACTIVE }),
+      applyAction(state, {
+        type: "resolve_combat_round",
+        playerId: ACTIVE,
+        decision: { kind: "assign_matchups", pairs: [] },
+      }),
     ).toThrow("multiple prompts are set");
   });
 });

--- a/engine/src/__tests__/main-actions.test.ts
+++ b/engine/src/__tests__/main-actions.test.ts
@@ -992,6 +992,135 @@ describe("defender-assigned matchups (#166)", () => {
     ).toThrow("is paired more than once");
   });
 
+  it("rejects an assignment naming a non-participant defender", () => {
+    // Mirror of the attacker-side check, but the ghost id is in the defender
+    // slot so the `!defSide` branch throws.
+    const s = suspendingCombat();
+    const suspended = attackAndSuspend(s);
+    expect(() =>
+      applyAction(suspended, {
+        type: "resolve_combat_round",
+        playerId: OTHER,
+        decision: {
+          kind: "assign_matchups",
+          pairs: [
+            { attackerUnitId: s.strongAtk, defenderUnitId: "ghost" },
+            { attackerUnitId: s.weakAtk, defenderUnitId: s.weakDef },
+          ],
+        },
+      }),
+    ).toThrow('defender "ghost" is not a participant');
+  });
+
+  it("rejects an assignment placing a real unit on the wrong side", () => {
+    // `strongDef` is a real unit but a DEFENDER — it is not an attacker
+    // participant, so naming it in the attacker slot is rejected.
+    const s = suspendingCombat();
+    const suspended = attackAndSuspend(s);
+    expect(() =>
+      applyAction(suspended, {
+        type: "resolve_combat_round",
+        playerId: OTHER,
+        decision: {
+          kind: "assign_matchups",
+          pairs: [
+            { attackerUnitId: s.strongDef, defenderUnitId: s.weakDef },
+            { attackerUnitId: s.weakAtk, defenderUnitId: s.strongDef },
+          ],
+        },
+      }),
+    ).toThrow(`attacker "${s.strongDef}" is not a participant`);
+  });
+
+  it("rejects an assignment when a participant left the cell before resume", () => {
+    // Defensive path: the dispatch gate normally freezes the board while a
+    // combat is suspended, but if a stashed participant is gone at resume,
+    // `combatantRollFromSide` refuses to reconstruct its roll.
+    const s = suspendingCombat();
+    const suspended = attackAndSuspend(s);
+    const tampered = produce(suspended, (d) => {
+      const cell = d.grid[0][0];
+      cell.units = cell.units.filter((u) => u.id !== s.strongDef);
+    });
+    expect(() =>
+      applyAction(tampered, {
+        type: "resolve_combat_round",
+        playerId: OTHER,
+        decision: {
+          kind: "assign_matchups",
+          pairs: [
+            { attackerUnitId: s.strongAtk, defenderUnitId: s.strongDef },
+            { attackerUnitId: s.weakAtk, defenderUnitId: s.weakDef },
+          ],
+        },
+      }),
+    ).toThrow(`participant "${s.strongDef}" is no longer at the cell`);
+  });
+
+  it("persists the rng stream across the suspend boundary and reuses the shown rolls", () => {
+    const s = suspendingCombat();
+    const preAttackRng = s.state.rngState;
+    const suspended = attackAndSuspend(s);
+
+    // The dice were rolled before the pause, and that rng advance was persisted
+    // on the suspended state — so the resumed round cannot replay round 0's seed.
+    expect(suspended.rngState).not.toEqual(preAttackRng);
+
+    // Resolving reuses the exact rolls the defender saw (no re-roll): the
+    // round-0 pair events carry the rolls stored on the prompt.
+    const shown = new Map(
+      suspended.combatPrompt!.atkRolls.map((r) => [r.unitId, r.roll]),
+    );
+    const { events } = applyAction(
+      suspended,
+      getValidActions(suspended, OTHER)[0] as MainAction,
+    );
+    const round0 = events
+      .filter((e) => e.type === "combat_pair_resolved")
+      .slice(0, 2);
+    expect(round0).toHaveLength(2);
+    for (const e of round0) {
+      if (e.type !== "combat_pair_resolved") continue;
+      const shownRoll = shown.get(e.attacker.unitId);
+      expect(shownRoll).toBeDefined();
+      expect(e.attacker.roll).toBe(shownRoll as number);
+    }
+  });
+
+  it("resolves to the correct winner after the defender assigns matchups", () => {
+    // Two str-100 attackers vs two str-1 defenders: min=2 so it suspends, and
+    // any greedy pairing (101+ vs 7-max) means the attacker always wins — a
+    // deterministic winner the resume path must report.
+    const atk1 = makeUnit({ ownerId: ACTIVE, strength: 100 });
+    const atk2 = makeUnit({ ownerId: ACTIVE, strength: 100 });
+    const def1 = makeUnit({ ownerId: OTHER, strength: 1 });
+    const def2 = makeUnit({ ownerId: OTHER, strength: 1 });
+    const state = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(atk1, atk2, def1, def2);
+    });
+    const { state: suspended } = applyAction(state, {
+      type: "attack",
+      playerId: ACTIVE,
+      row: 0,
+      col: 0,
+      unitIds: [atk1.id, atk2.id],
+    });
+    const susp = suspended as MainGameState;
+    expect(susp.combatPrompt).toBeDefined();
+
+    const { events } = applyAction(
+      susp,
+      getValidActions(susp, OTHER)[0] as MainAction,
+    );
+    const resolved = events.filter((e) => e.type === "combat_resolved");
+    expect(resolved).toHaveLength(1);
+    const ev = resolved[0];
+    if (ev.type === "combat_resolved") {
+      expect(ev.winnerId).toBe(ACTIVE);
+    }
+  });
+
   it("rejects any non-resolver action while combat is suspended", () => {
     const suspended = attackAndSuspend(suspendingCombat());
     expect(() =>
@@ -999,12 +1128,15 @@ describe("defender-assigned matchups (#166)", () => {
     ).toThrow("suspended combat must be resolved first");
   });
 
-  it("offers the greedy-default matchup to the decider, nothing to others", () => {
+  it("offers every matchup bijection to the decider, greedy default first, nothing to others", () => {
     const s = suspendingCombat();
     const suspended = attackAndSuspend(s);
 
-    // The defender is offered exactly the greedy default (strong↔strong).
-    expect(getValidActions(suspended, OTHER)).toEqual([
+    // 2v2: the defender is offered both bijections so bots/search can explore
+    // non-greedy pairings. The identity permutation (strong↔strong) is first —
+    // the greedy auto-resolve default a bot can submit as-is.
+    const offered = getValidActions(suspended, OTHER);
+    expect(offered).toEqual([
       {
         type: "resolve_combat_round",
         playerId: OTHER,
@@ -1013,6 +1145,17 @@ describe("defender-assigned matchups (#166)", () => {
           pairs: [
             { attackerUnitId: s.strongAtk, defenderUnitId: s.strongDef },
             { attackerUnitId: s.weakAtk, defenderUnitId: s.weakDef },
+          ],
+        },
+      },
+      {
+        type: "resolve_combat_round",
+        playerId: OTHER,
+        decision: {
+          kind: "assign_matchups",
+          pairs: [
+            { attackerUnitId: s.strongAtk, defenderUnitId: s.weakDef },
+            { attackerUnitId: s.weakAtk, defenderUnitId: s.strongDef },
           ],
         },
       },

--- a/engine/src/__tests__/main-actions.test.ts
+++ b/engine/src/__tests__/main-actions.test.ts
@@ -1185,6 +1185,52 @@ describe("defender-assigned matchups (#166)", () => {
     expect(getValidActions(suspended, ACTIVE)).toEqual([]);
   });
 
+  it("enumerates all n! bijections for a 3v3, greedy default first", () => {
+    // Strengths far enough apart that the d6 roll can't reorder the power sort,
+    // so the greedy default (identity permutation) is deterministic.
+    const a100 = makeUnit({ ownerId: ACTIVE, strength: 100 });
+    const a50 = makeUnit({ ownerId: ACTIVE, strength: 50 });
+    const a1 = makeUnit({ ownerId: ACTIVE, strength: 1 });
+    const d100 = makeUnit({ ownerId: OTHER, strength: 100 });
+    const d50 = makeUnit({ ownerId: OTHER, strength: 50 });
+    const d1 = makeUnit({ ownerId: OTHER, strength: 1 });
+    const state = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(a100, a50, a1, d100, d50, d1);
+    });
+    const { state: suspended } = applyAction(state, {
+      type: "attack",
+      playerId: ACTIVE,
+      row: 0,
+      col: 0,
+      unitIds: [a100.id, a50.id, a1.id],
+    });
+    const susp = suspended as MainGameState;
+    expect(susp.combatPrompt).toBeDefined();
+
+    const offered = getValidActions(susp, OTHER);
+    expect(offered).toHaveLength(6); // 3!
+    // Greedy default first: highest-vs-highest by power.
+    expect(offered[0]).toMatchObject({
+      type: "resolve_combat_round",
+      playerId: OTHER,
+      decision: {
+        kind: "assign_matchups",
+        pairs: [
+          { attackerUnitId: a100.id, defenderUnitId: d100.id },
+          { attackerUnitId: a50.id, defenderUnitId: d50.id },
+          { attackerUnitId: a1.id, defenderUnitId: d1.id },
+        ],
+      },
+    });
+    // Every offer is a well-formed 3-pair bijection over the defenders.
+    for (const act of offered) {
+      if (act.type !== "resolve_combat_round") continue;
+      expect(act.decision.pairs).toHaveLength(3);
+      expect(new Set(act.decision.pairs.map((p) => p.defenderUnitId)).size).toBe(3);
+    }
+  });
+
   it("auto-resolves atomically for a trivial pairing (one side has a single unit)", () => {
     // 1-vs-3: min(1,3) = 1, so there is only one possible matching — no defender
     // decision. Combat resolves in a single action with no lingering prompt.

--- a/engine/src/__tests__/visible-state.test.ts
+++ b/engine/src/__tests__/visible-state.test.ts
@@ -241,6 +241,8 @@ describe("getVisibleState", () => {
       round: 1,
       attackerUnitIds: ["u1"],
       defenderUnitIds: ["u2", "u3"],
+      atkRolls: [],
+      defRolls: [],
     };
 
     it("surfaces the full prompt unredacted to every viewer, decider or not", () => {

--- a/engine/src/__tests__/win-condition.test.ts
+++ b/engine/src/__tests__/win-condition.test.ts
@@ -152,6 +152,8 @@ describe("toEndedState", () => {
         round: 1,
         attackerUnitIds: [],
         defenderUnitIds: [],
+        atkRolls: [],
+        defRolls: [],
       };
     });
 

--- a/engine/src/apply-action.ts
+++ b/engine/src/apply-action.ts
@@ -24,14 +24,18 @@ export function applyAction<S extends GameState>(
 ): ApplyResult {
   const activePlayerId = getActivePlayerId(state);
 
-  // TODO(#166): this gate rejects every non-active player, so it will reject a
-  // defender-assigned `resolve_combat_round` (the defender is normally the
-  // non-active player). When #166 hands the combat decision to the defender,
-  // relax this to also admit the pending prompt's decider
-  // (`state.combatPrompt?.playerId === action.playerId`), and mirror the
-  // fall-through in `getValidActions`. Today decider == attacker == active, so
-  // the paths agree and this is inert.
-  if (action.playerId !== activePlayerId) {
+  // A suspended combat hands its decision to the prompt's decider — for #166's
+  // matchup assignment that is the **defender**, normally the *non-active*
+  // player. Admit that decider's `resolve_combat_round` as a special case;
+  // `applyMainAction` then enforces that the action is in fact
+  // `resolve_combat_round` and that the id matches the prompt. `getValidActions`
+  // mirrors this by keying its combat offer off `combatPrompt.playerId`. Every
+  // other action still requires the active player.
+  const combatDecider: string | undefined =
+    state.phase === "main" ? state.combatPrompt?.playerId : undefined;
+  const isCombatDecider =
+    action.type === "resolve_combat_round" && action.playerId === combatDecider;
+  if (action.playerId !== activePlayerId && !isCombatDecider) {
     throw new Error(
       `Action from player "${action.playerId}" rejected: it is player "${activePlayerId}"'s turn`,
     );

--- a/engine/src/apply-action.ts
+++ b/engine/src/apply-action.ts
@@ -26,14 +26,13 @@ export function applyAction<S extends GameState>(
 
   // A suspended combat hands its decision to the prompt's decider — for #166's
   // matchup assignment that is the **defender**, normally the *non-active*
-  // player. Admit that decider's `resolve_combat_round` as a special case;
-  // `applyMainAction` then enforces that the action is in fact
-  // `resolve_combat_round` and that the id matches the prompt. `getValidActions`
-  // mirrors this by keying its combat offer off `combatPrompt.playerId`. Every
-  // other action still requires the active player.
+  // player. This gate here already restricts the decider to `resolve_combat_round`;
+  // `handleResolveCombatRound` then re-checks that the id matches the prompt.
+  // `getValidActions` mirrors this by keying its combat offer off
+  // `combatPrompt.playerId`. Every other action still requires the active player.
   const combatDecider: string | undefined =
     state.phase === "main" ? state.combatPrompt?.playerId : undefined;
-  const isCombatDecider =
+  const isCombatDecider: boolean =
     action.type === "resolve_combat_round" && action.playerId === combatDecider;
   if (action.playerId !== activePlayerId && !isCombatDecider) {
     throw new Error(

--- a/engine/src/apply-action.ts
+++ b/engine/src/apply-action.ts
@@ -7,7 +7,7 @@ import type {
   MainAction,
   SeedingAction,
 } from "./types";
-import { getActivePlayerId } from "./types";
+import { getActivePlayerId, getDeciderId } from "./types";
 
 export type { ApplyResult };
 
@@ -30,8 +30,7 @@ export function applyAction<S extends GameState>(
   // `handleResolveCombatRound` then re-checks that the id matches the prompt.
   // `getValidActions` mirrors this by keying its combat offer off
   // `combatPrompt.playerId`. Every other action still requires the active player.
-  const combatDecider: string | undefined =
-    state.phase === "main" ? state.combatPrompt?.playerId : undefined;
+  const combatDecider: string | undefined = getDeciderId(state);
   const isCombatDecider: boolean =
     action.type === "resolve_combat_round" && action.playerId === combatDecider;
   if (action.playerId !== activePlayerId && !isCombatDecider) {

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -32,6 +32,8 @@ import type {
   ActionDef,
   ActivePassiveEvent,
   ApplyResult,
+  CombatDecision,
+  CombatLoopState,
   CombatPairOutcome,
   CombatPrompt,
   CombatSide,
@@ -699,7 +701,6 @@ function handleAttack(
   runCombat(
     draft,
     {
-      playerId,
       row,
       col,
       attackerId: playerId,
@@ -714,37 +715,32 @@ function handleAttack(
 }
 
 /**
- * Whether combat must suspend before running `round` to await a player
- * decision. This is the #165 suspension hook.
+ * Whether the defender has a meaningful matchup choice this round (#166).
  *
- * Returns `false` for every real game today: no production ruleset sets the
- * seam config, so combat always auto-resolves and no behaviour changes until a
- * real pause condition lands. #166–#168 replace the body with the actual
- * decision logic (defender-assigned matchups, sit-out, retreat). The
- * `combat_suspend_between_rounds` key is a test-only seam — it exercises the
- * suspend/resume machinery end-to-end while the real conditions don't exist yet.
- *
- * `round` is the round the decision would gate (always ≥ 1 — combat never pauses
- * before its opening round; guaranteed by the sole caller, which passes
- * `round + 1`). Unused by the seam, but #166–#168 will branch on it.
- *
- * The seam reads one global config key, so when set it suspends every
- * between-round of every combat — there is no per-combat scoping. That is fine
- * for a test-only seam; #166–#168 replace this body with per-combat decision
- * logic rather than extending the flag.
+ * The `pairs` count is `min(attackers, defenders)` — the greedy sit-out trims
+ * the larger side to that size lowest-power-first, leaving equal-length
+ * participant lists. A bijection over them offers a real choice only when there
+ * are at least two pairs; a single pair (`min <= 1`) has exactly one matching,
+ * so those rounds auto-resolve. Cases where `min == 1` but the larger side must
+ * pick which unit faces the lone opponent are a *sit-out* choice (#167), not a
+ * pairing choice — deferred, so they auto-resolve greedily here too.
  */
-function combatDecisionPending(draft: Draft<MainGameState>, round: number): boolean {
-  void round;
-  return getConfigNumber(draft, "combat_suspend_between_rounds", 0) === 1;
+function matchupDecisionPending(attackers: number, defenders: number): boolean {
+  return Math.min(attackers, defenders) >= 2;
 }
 
 /**
  * Runs combat rounds from `state.round` onward. Shared by both callers: the
  * fresh run from `handleAttack` (round 0) and every `resolve_combat_round`
  * resume of an in-progress fight. Either completes the combat (emitting
- * `combat_resolved`) or, if a decision is pending between rounds, sets
- * `draft.combatPrompt` and returns without emitting `combat_resolved` — leaving
- * the fight suspended for `resolve_combat_round`.
+ * `combat_resolved`) or, if the defender has a matchup choice this round, sets
+ * `draft.combatPrompt` — after rolling but BEFORE resolving (rules step 4: the
+ * defender pairs "after seeing all rolls") — and returns without emitting
+ * `combat_resolved`, leaving the fight suspended for `resolve_combat_round`.
+ *
+ * On resume the caller (`handleResolveCombatRound`) resolves the just-rolled
+ * round from the assignment, then re-enters here at `round + 1` — so this loop
+ * always starts a *fresh* round: it rolls, then either suspends or auto-resolves.
  *
  * Living combatants are re-resolved from the cell by id each round rather than
  * held as references: units get killed/removed mid-combat, and on resume the
@@ -753,7 +749,7 @@ function combatDecisionPending(draft: Draft<MainGameState>, round: number): bool
  */
 function runCombat(
   draft: Draft<MainGameState>,
-  state: CombatPrompt,
+  state: CombatLoopState,
   emit: EmitFn,
   queries: QueryListener[],
 ): void {
@@ -784,6 +780,7 @@ function runCombat(
 
     if (livingAttackers.length === 0 || livingDefenders.length === 0) break;
 
+    // Rules step 3 — Roll: one die per living unit; attack power = strength+roll.
     const atkRolls: CombatantRoll[] = [];
     for (const u of livingAttackers) {
       const [roll, nextRng] = uniformIntDistribution(1, 6, rng);
@@ -798,38 +795,39 @@ function runCombat(
       defRolls.push(buildCombatantRoll(draft, queries, u, "defender", row, col, roll));
     }
 
-    // Sort by power descending, pair highest vs highest
+    // Greedy sit-out: sort by power descending and trim the larger side to the
+    // pair count, so its lowest-power excess sits out. The trimmed lists are
+    // equal length — the participants the defender pairs (or that auto-resolve
+    // greedily, highest vs highest). #167 hands this sit-out choice to the
+    // larger side; until then it stays lowest-power-first.
     atkRolls.sort((a, b) => b.power - a.power);
     defRolls.sort((a, b) => b.power - a.power);
+    const nPairs = Math.min(atkRolls.length, defRolls.length);
+    const atkParticipants = atkRolls.slice(0, nPairs);
+    const defParticipants = defRolls.slice(0, nPairs);
 
-    const pairs = Math.min(atkRolls.length, defRolls.length);
-    for (let i = 0; i < pairs; i++) {
-      const atk = atkRolls[i];
-      const def = defRolls[i];
-      resolveCombatPair(draft, cell, atk, def, row, col, emit);
+    // Rules step 4 — Matchup: when the defender has a real pairing choice,
+    // suspend AFTER the roll and BEFORE resolving, so the assignment is made
+    // "after seeing all rolls". Persist rng (already advanced past this round's
+    // rolls) so the roll stream is unbroken on resume; `combat_resolved` is
+    // deliberately NOT emitted — combat is paused, not over.
+    if (matchupDecisionPending(livingAttackers.length, livingDefenders.length)) {
+      draft.rngState = extractRngState(rng) as number[];
+      const prompt: CombatPrompt = {
+        playerId: defenderId,
+        row, col, attackerId, defenderId, round,
+        attackerUnitIds, defenderUnitIds,
+        atkRolls: atkParticipants.map(toCombatSide),
+        defRolls: defParticipants.map(toCombatSide),
+      };
+      draft.combatPrompt = castDraft(prompt);
+      return;
     }
 
-    // Between-rounds suspension point (#165). Checked AFTER the round resolves
-    // and only when a further round would actually be fought (both sides still
-    // have uninjured combatants AND the round cap is not reached) — so a
-    // finished or capped combat falls through to `combat_resolved` instead of
-    // pausing, and a resumed combat fights its round before it can pause again.
-    // The `round + 1 < maxRounds` guard prevents a phantom final suspend that
-    // would resume into a zero-iteration loop and silently finalize a draw.
-    // `combatDecisionPending` is a cheap config read that is false in every real
-    // game, so the next-round peek below never runs on the default auto-resolve
-    // path.
-    if (round + 1 < maxRounds && combatDecisionPending(draft, round + 1)) {
-      const nextAttackers = livingCombatants(cell, attackerUnitIds, { ignoreInjured: false });
-      const nextDefenders = livingCombatants(cell, defenderUnitIds, { ignoreInjured: false });
-      if (nextAttackers.length > 0 && nextDefenders.length > 0) {
-        // Persist rng so resume continues the same roll stream, then hand
-        // control back. `combat_resolved` is deliberately NOT emitted — combat
-        // is paused, not over.
-        draft.rngState = extractRngState(rng) as number[];
-        draft.combatPrompt = castDraft({ ...state, round: round + 1 });
-        return;
-      }
+    // Rules step 5 — Resolve: auto-resolve the participants greedily (the sort
+    // above already lined them up highest vs highest).
+    for (let i = 0; i < nPairs; i++) {
+      resolveCombatPair(draft, cell, atkParticipants[i], defParticipants[i], row, col, emit);
     }
   }
 
@@ -930,6 +928,30 @@ function toCombatSide(c: CombatantRoll): CombatSide {
     roll: c.roll,
     power: c.power,
     injuredBefore: c.injuredBefore,
+  };
+}
+
+/**
+ * Rebuild the live `CombatantRoll` for a roll stashed on a suspended prompt:
+ * the plain `CombatSide` data plus the unit re-resolved from the cell by id.
+ * The unit is unchanged since suspend — the dispatch gate freezes the board
+ * while a `combatPrompt` is live — so this reconstructs the exact roll the
+ * defender saw, with no re-roll.
+ */
+function combatantRollFromSide(cell: Draft<GridCell>, side: CombatSide): CombatantRoll {
+  const unit = cell.units.find((u) => u.id === side.unitId);
+  if (!unit) {
+    throw new Error(
+      `resolve_combat_round rejected: participant "${side.unitId}" is no longer at the cell`,
+    );
+  }
+  return {
+    unit,
+    baseStrength: side.baseStrength,
+    modifiers: side.modifiers,
+    roll: side.roll,
+    power: side.power,
+    injuredBefore: side.injuredBefore,
   };
 }
 
@@ -1268,9 +1290,66 @@ function handleDismissView(
   draft.viewPrompt = undefined;
 }
 
+/**
+ * Resolve the round's pairs (rules step 5) from the defender's assignment,
+ * validated against the suspended prompt. Rejects unknown/duplicate ids and the
+ * wrong pair count so a malformed submission fails loud rather than silently
+ * mis-pairing. Because the participant lists are equal length and every id must
+ * be a distinct participant, an exact-count assignment is necessarily a full
+ * bijection — no unit is left unpaired or fought twice.
+ */
+function resolveAssignedMatchups(
+  draft: Draft<MainGameState>,
+  cell: Draft<GridCell>,
+  prompt: CombatPrompt,
+  decision: CombatDecision,
+  emit: EmitFn,
+): void {
+  if (decision.kind !== "assign_matchups") {
+    throw new Error(`resolve_combat_round rejected: unsupported decision kind "${decision.kind}"`);
+  }
+
+  const atkById = new Map<string, CombatSide>(prompt.atkRolls.map((s) => [s.unitId, s]));
+  const defById = new Map<string, CombatSide>(prompt.defRolls.map((s) => [s.unitId, s]));
+  const expected = prompt.atkRolls.length; // == defRolls.length (equal participants)
+  if (decision.pairs.length !== expected) {
+    throw new Error(
+      `resolve_combat_round rejected: expected ${expected} matchup(s), got ${decision.pairs.length}`,
+    );
+  }
+
+  const usedAtk = new Set<string>();
+  const usedDef = new Set<string>();
+  for (const { attackerUnitId, defenderUnitId } of decision.pairs) {
+    const atkSide = atkById.get(attackerUnitId);
+    const defSide = defById.get(defenderUnitId);
+    if (!atkSide) {
+      throw new Error(`resolve_combat_round rejected: attacker "${attackerUnitId}" is not a participant`);
+    }
+    if (!defSide) {
+      throw new Error(`resolve_combat_round rejected: defender "${defenderUnitId}" is not a participant`);
+    }
+    if (usedAtk.has(attackerUnitId)) {
+      throw new Error(`resolve_combat_round rejected: attacker "${attackerUnitId}" is paired more than once`);
+    }
+    if (usedDef.has(defenderUnitId)) {
+      throw new Error(`resolve_combat_round rejected: defender "${defenderUnitId}" is paired more than once`);
+    }
+    usedAtk.add(attackerUnitId);
+    usedDef.add(defenderUnitId);
+    resolveCombatPair(
+      draft, cell,
+      combatantRollFromSide(cell, atkSide),
+      combatantRollFromSide(cell, defSide),
+      prompt.row, prompt.col, emit,
+    );
+  }
+}
+
 function handleResolveCombatRound(
   draft: Draft<MainGameState>,
   playerId: string,
+  decision: CombatDecision,
   emit: EmitFn,
   queries: QueryListener[],
 ): void {
@@ -1283,14 +1362,32 @@ function handleResolveCombatRound(
       `resolve_combat_round rejected: pending combat decision is for "${prompt.playerId}", not "${playerId}"`,
     );
   }
-  // #165: the decision is empty — nothing to apply, just resume. #166–#168 will
-  // apply the submitted matchup/sit-out/retreat here before resuming.
-  //
-  // Clear the prompt before resuming: `runCombat` re-sets it if the fight
-  // suspends again on a later round, so clearing first keeps a single source of
-  // truth (an unresolved fight always has exactly one live `combatPrompt`).
+
+  const cell: Draft<GridCell> = draft.grid[prompt.row][prompt.col];
+
+  // Apply the defender's assignment: resolve this round's pairs from the rolls
+  // revealed at suspend (no re-roll, so the outcome matches what the defender
+  // saw), then resume from the next round.
+  resolveAssignedMatchups(draft, cell, prompt, decision, emit);
+
+  // Clear the prompt before resuming: `runCombat` re-sets it if a later round
+  // also needs a decision, so clearing first keeps a single source of truth (an
+  // unresolved fight always has exactly one live `combatPrompt`).
   draft.combatPrompt = undefined;
-  runCombat(draft, prompt, emit, queries);
+  runCombat(
+    draft,
+    {
+      row: prompt.row,
+      col: prompt.col,
+      attackerId: prompt.attackerId,
+      defenderId: prompt.defenderId,
+      round: prompt.round + 1,
+      attackerUnitIds: prompt.attackerUnitIds,
+      defenderUnitIds: prompt.defenderUnitIds,
+    },
+    emit,
+    queries,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -1423,7 +1520,7 @@ export function applyMainAction(
         break;
 
       case "resolve_combat_round":
-        handleResolveCombatRound(draft, action.playerId, emit, queries);
+        handleResolveCombatRound(draft, action.playerId, action.decision, emit, queries);
         break;
 
       default: {

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -1305,13 +1305,16 @@ function resolveAssignedMatchups(
   decision: CombatDecision,
   emit: EmitFn,
 ): void {
+  // Forward-defensive guard for the future `kind`s (#167 sit-out, #168 retreat):
+  // with today's single-variant `CombatDecision`, TS narrows `kind` to the sole
+  // literal so this branch is unreachable — it is intentional, not dead code.
   if (decision.kind !== "assign_matchups") {
     throw new Error(`resolve_combat_round rejected: unsupported decision kind "${decision.kind}"`);
   }
 
   const atkById = new Map<string, CombatSide>(prompt.atkRolls.map((s) => [s.unitId, s]));
   const defById = new Map<string, CombatSide>(prompt.defRolls.map((s) => [s.unitId, s]));
-  const expected = prompt.atkRolls.length; // == defRolls.length (equal participants)
+  const expected: number = prompt.atkRolls.length; // == defRolls.length (equal participants)
   if (decision.pairs.length !== expected) {
     throw new Error(
       `resolve_combat_round rejected: expected ${expected} matchup(s), got ${decision.pairs.length}`,

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -1,5 +1,5 @@
 import type { Draft } from "immer";
-import { castDraft, produce } from "immer";
+import { castDraft, current, produce } from "immer";
 import { fromState, uniformIntDistribution } from "./rng";
 import { parseCost, spendAP, spendGold } from "./cost-helpers";
 import { drawLocationFromProspect, drawMarketCard, drawOneCard } from "./deck-helpers";
@@ -1356,15 +1356,22 @@ function handleResolveCombatRound(
   emit: EmitFn,
   queries: QueryListener[],
 ): void {
-  const prompt = draft.combatPrompt;
-  if (!prompt) {
+  const promptDraft = draft.combatPrompt;
+  if (!promptDraft) {
     throw new Error(`resolve_combat_round rejected: no suspended combat (by player "${playerId}")`);
   }
-  if (prompt.playerId !== playerId) {
+  if (promptDraft.playerId !== playerId) {
     throw new Error(
-      `resolve_combat_round rejected: pending combat decision is for "${prompt.playerId}", not "${playerId}"`,
+      `resolve_combat_round rejected: pending combat decision is for "${promptDraft.playerId}", not "${playerId}"`,
     );
   }
+
+  // Snapshot the stashed rolls out of the draft before they flow into events.
+  // The prompt's `CombatSide` data is copied into emitted `combat_pair_resolved`
+  // events (via `toCombatSide`); a live draft proxy there — e.g. the `modifiers`
+  // array — would be revoked once this `produce()` finalizes, crashing any later
+  // reader such as the event log. `current` yields a plain deep copy.
+  const prompt: CombatPrompt = current(promptDraft);
 
   const cell: Draft<GridCell> = draft.grid[prompt.row][prompt.col];
 

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -1305,11 +1305,13 @@ function resolveAssignedMatchups(
   decision: CombatDecision,
   emit: EmitFn,
 ): void {
-  // Forward-defensive guard for the future `kind`s (#167 sit-out, #168 retreat):
-  // with today's single-variant `CombatDecision`, TS narrows `kind` to the sole
-  // literal so this branch is unreachable — it is intentional, not dead code.
-  if (decision.kind !== "assign_matchups") {
-    throw new Error(`resolve_combat_round rejected: unsupported decision kind "${decision.kind}"`);
+  // Forward-defensive guard for the future `kind`s (#167 sit-out, #168 retreat)
+  // and for a malformed adapter submission: the `decision == null` arm turns a
+  // missing payload into a descriptive rejection rather than a bare TypeError on
+  // `.kind`. With today's single-variant `CombatDecision` the kind check is
+  // otherwise unreachable — intentional, not dead code.
+  if (decision == null || decision.kind !== "assign_matchups") {
+    throw new Error(`resolve_combat_round rejected: unsupported decision kind "${decision?.kind}"`);
   }
 
   const atkById = new Map<string, CombatSide>(prompt.atkRolls.map((s) => [s.unitId, s]));

--- a/engine/src/controller.ts
+++ b/engine/src/controller.ts
@@ -111,14 +111,22 @@ export class GameController {
 
   /** Execute a single turn: get action from adapter, validate, apply. */
   async playTurn(): Promise<GameEvent[]> {
-    const activePlayerId = getActivePlayerId(this.state);
-    const adapter = this.adapters.get(activePlayerId);
+    // While a combat is suspended, the pending decision belongs to the prompt's
+    // decider (the defender — normally NOT the active player), mirroring the
+    // dispatch gate in `apply-action.ts`. Route the turn to that player so we
+    // ask their adapter and validate against their action set; the idle
+    // attacker's valid-action list is empty while suspended, so driving the loop
+    // off the active player would reject the defender's legitimate submission.
+    const decider: string | undefined =
+      this.state.phase === "main" ? this.state.combatPrompt?.playerId : undefined;
+    const actingPlayerId: string = decider ?? getActivePlayerId(this.state);
+    const adapter = this.adapters.get(actingPlayerId);
     if (!adapter) {
-      throw new Error(`No adapter registered for player "${activePlayerId}"`);
+      throw new Error(`No adapter registered for player "${actingPlayerId}"`);
     }
 
-    const visibleState = getVisibleState(this.state, activePlayerId);
-    const validActions = getValidActions(this.state, activePlayerId);
+    const visibleState = getVisibleState(this.state, actingPlayerId);
+    const validActions = getValidActions(this.state, actingPlayerId);
     const action = await adapter.chooseAction(visibleState, validActions);
 
     // Validate the adapter returned a legal action
@@ -127,7 +135,7 @@ export class GameController {
     );
     if (!isValid) {
       throw new Error(
-        `Adapter for player "${activePlayerId}" returned an invalid action: ` +
+        `Adapter for player "${actingPlayerId}" returned an invalid action: ` +
           `${JSON.stringify(action)}`,
       );
     }

--- a/engine/src/controller.ts
+++ b/engine/src/controller.ts
@@ -10,7 +10,7 @@ import type {
   PlayerDescriptor,
   Session,
 } from "./types";
-import { getActivePlayerId } from "./types";
+import { getActivePlayerId, getDeciderId } from "./types";
 import { getValidActions } from "./valid-actions";
 import { getVisibleState } from "./visible-state";
 
@@ -117,8 +117,7 @@ export class GameController {
     // ask their adapter and validate against their action set; the idle
     // attacker's valid-action list is empty while suspended, so driving the loop
     // off the active player would reject the defender's legitimate submission.
-    const decider: string | undefined =
-      this.state.phase === "main" ? this.state.combatPrompt?.playerId : undefined;
+    const decider: string | undefined = getDeciderId(this.state);
     const actingPlayerId: string = decider ?? getActivePlayerId(this.state);
     const adapter = this.adapters.get(actingPlayerId);
     if (!adapter) {

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -445,29 +445,46 @@ export interface ViewPrompt {
  * The duplicated cell coordinates and player ids cannot drift because the
  * dispatch gate (`applyMainAction`) freezes every other mutation while a
  * `combatPrompt` is live — do not reuse this type outside that suspend guard.
- *
- * `playerId` is who must submit `resolve_combat_round`. For #165 (no real
- * decision) that is the attacker (also the active player). #166 will hand the
- * decision to the defender — normally the *non-active* player — which must also
- * relax the active-player gate in `apply-action.ts` (see the TODO there); today
- * that gate would reject a non-active decider. Revealed rolls / matchup payloads
- * are deferred to #166–#168.
  */
-export interface CombatPrompt {
-  /** Player expected to submit `resolve_combat_round`. */
-  playerId: string;
+export interface CombatLoopState {
   row: number;
   col: number;
   /** Attacking player id (the one who issued `attack`). */
   attackerId: string;
   /** Defending player id. */
   defenderId: string;
-  /** Next round index to run on resume (0-based; `combat_round_cap` bounds it). */
+  /** Round index to run (0-based; `combat_round_cap` bounds it). */
   round: number;
   /** Committed attacker unit instance ids (never mutated after suspend). */
   attackerUnitIds: readonly string[];
   /** Committed defender unit instance ids (never mutated after suspend). */
   defenderUnitIds: readonly string[];
+}
+
+/**
+ * A combat suspended mid-round awaiting the defender's matchup assignment
+ * (#166). Per the rules (README.md Combat step 4) the defender pairs units
+ * "after seeing all rolls", so the suspend lands *within* a round — after the
+ * roll, before resolution — carrying that round's revealed rolls inline.
+ *
+ * `playerId` is who must submit `resolve_combat_round`: the **defender**, who is
+ * normally the *non-active* player, so the active-player gate in
+ * `apply-action.ts` admits the prompt's decider as a special case.
+ *
+ * `atkRolls` / `defRolls` are the participating units' revealed rolls for
+ * `round` — the greedily-selected top `min(committed)` per side. Excess units on
+ * the larger side sit out lowest-power-first (the auto-resolve default; #167
+ * hands that sit-out choice to the larger side). Both lists therefore have equal
+ * length, and the defender assigns a bijection between them. Plain `CombatSide`
+ * data (no live unit refs) so it survives the `produce()` suspend boundary.
+ */
+export interface CombatPrompt extends CombatLoopState {
+  /** Player expected to submit `resolve_combat_round` (the defender). */
+  playerId: string;
+  /** Revealed rolls of the participating attacker units for `round`. */
+  atkRolls: CombatSide[];
+  /** Revealed rolls of the participating defender units for `round`. */
+  defRolls: CombatSide[];
 }
 
 export interface MainGameState extends GameStateBase {
@@ -626,17 +643,37 @@ export interface DismissViewAction {
 }
 
 /**
- * Submitted to resume a combat suspended between rounds (pending
- * `combatPrompt`). For #165 the decision is empty — combat merely resumes its
- * auto-resolve loop. The heterogeneous real payloads (matchup assignment #166,
- * sit-out #167, retreat #168) should arrive as a discriminated `decision`
- * sub-union (mirroring `PickPrompt`'s `kind` split) rather than a flat bag of
- * optional fields, so a retreat payload cannot structurally carry matchup data.
- * AP is not spent here (already spent on the initiating `attack`).
+ * One matchup the defender assigns: attacker unit `attackerUnitId` fights
+ * defender unit `defenderUnitId`. Both ids must appear in the pending prompt's
+ * `atkRolls` / `defRolls` (the participating units), each used exactly once.
+ */
+export interface CombatMatchup {
+  attackerUnitId: string;
+  defenderUnitId: string;
+}
+
+/**
+ * The defender's decision when resuming a combat suspended for matchup
+ * assignment (#166). Modeled as a discriminated `kind` sub-union (mirroring
+ * `PickPrompt`'s split) so the sit-out (#167) and retreat (#168) payloads slot
+ * in later without a flat bag of optional fields — a retreat payload cannot then
+ * structurally carry matchup data.
+ */
+export type CombatDecision = {
+  kind: "assign_matchups";
+  /** A bijection over the prompt's participating units; length = min(sides). */
+  pairs: CombatMatchup[];
+};
+
+/**
+ * Submitted to resume a combat suspended for a player decision (pending
+ * `combatPrompt`). Carries the discriminated `decision`. AP is not spent here
+ * (already spent on the initiating `attack`).
  */
 export interface ResolveCombatRoundAction {
   type: "resolve_combat_round";
   playerId: string;
+  decision: CombatDecision;
 }
 
 export type Action = SeedingAction | MainAction;

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -474,11 +474,11 @@ export interface CombatLoopState {
  *
  * `atkRolls` / `defRolls` are the participating units' revealed rolls for
  * `round` — the greedily-selected top `min` of each side's *living* units this
- * round. Excess units on
- * the larger side sit out lowest-power-first (the auto-resolve default; #167
- * hands that sit-out choice to the larger side). Both lists therefore have equal
- * length, and the defender assigns a bijection between them. Plain `CombatSide`
- * data (no live unit refs) so it survives the `produce()` suspend boundary.
+ * round. Excess units on the larger side sit out lowest-power-first (the
+ * auto-resolve default; #167 hands that sit-out choice to the larger side).
+ * Both lists therefore have equal length, and the defender assigns a bijection
+ * between them. Plain `CombatSide` data (no live unit refs) so it survives the
+ * `produce()` suspend boundary.
  */
 export interface CombatPrompt extends CombatLoopState {
   /** Player expected to submit `resolve_combat_round` (the defender). */
@@ -544,6 +544,16 @@ export function getActivePlayerId(state: GameState): string {
     case "ended":
       throw new Error("No active player in ended phase");
   }
+}
+
+/**
+ * The player who must resolve a suspended combat (the defender / matchup
+ * decider), or `undefined` when no combat is suspended. Single-sources the
+ * "decider is `combatPrompt.playerId`" invariant shared by the dispatch gate
+ * (`apply-action.ts`) and the turn loop (`controller.ts`).
+ */
+export function getDeciderId(state: GameState): string | undefined {
+  return state.phase === "main" ? state.combatPrompt?.playerId : undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -434,17 +434,18 @@ export interface ViewPrompt {
 }
 
 /**
- * Set on `GameStateBase.combatPrompt` when a combat suspends between rounds.
- * Stores the resumable loop state inline so `resolve_combat_round` can pick the
- * fight back up: which cell, the two sides' committed unit instance ids, and the
- * next round index. Living combatants are recomputed from the cell each round
- * (units may have been killed/injured), so only the *committed* id lists are
- * stored — not live unit references, which cannot survive the `produce()`
- * boundary between suspend and resume.
+ * Resumable loop state for `runCombat`, shared by both callers: the fresh
+ * round-0 run from `handleAttack` and every `resolve_combat_round` resume of a
+ * suspended fight. Stores the durable handle needed to pick a fight back up:
+ * which cell, the two sides' committed unit instance ids, and the round index to
+ * run. Living combatants are recomputed from the cell each round (units may have
+ * been killed/injured), so only the *committed* id lists are stored — not live
+ * unit references, which cannot survive the `produce()` boundary between suspend
+ * and resume.
  *
- * The duplicated cell coordinates and player ids cannot drift because the
- * dispatch gate (`applyMainAction`) freezes every other mutation while a
- * `combatPrompt` is live — do not reuse this type outside that suspend guard.
+ * `CombatPrompt` extends this with the suspended-decision context (revealed
+ * rolls + decider); `runCombat` itself consumes only the fields here, so the
+ * loop structurally cannot depend on prompt-only data.
  */
 export interface CombatLoopState {
   row: number;
@@ -463,16 +464,17 @@ export interface CombatLoopState {
 
 /**
  * A combat suspended mid-round awaiting the defender's matchup assignment
- * (#166). Per the rules (README.md Combat step 4) the defender pairs units
- * "after seeing all rolls", so the suspend lands *within* a round — after the
- * roll, before resolution — carrying that round's revealed rolls inline.
+ * (#166). Per the rules (README.md Combat step 4 — Matchup) the defender assigns
+ * pairings after the step-3 roll, so the suspend lands *within* a round — after
+ * the roll, before resolution — carrying that round's revealed rolls inline.
  *
  * `playerId` is who must submit `resolve_combat_round`: the **defender**, who is
  * normally the *non-active* player, so the active-player gate in
  * `apply-action.ts` admits the prompt's decider as a special case.
  *
  * `atkRolls` / `defRolls` are the participating units' revealed rolls for
- * `round` — the greedily-selected top `min(committed)` per side. Excess units on
+ * `round` — the greedily-selected top `min` of each side's *living* units this
+ * round. Excess units on
  * the larger side sit out lowest-power-first (the auto-resolve default; #167
  * hands that sit-out choice to the larger side). Both lists therefore have equal
  * length, and the defender assigns a bijection between them. Plain `CombatSide`
@@ -500,16 +502,15 @@ export interface MainGameState extends GameStateBase {
    */
   viewPrompt?: ViewPrompt;
   /**
-   * Set when combat suspends between rounds to await a player decision, cleared
-   * by `resolve_combat_round`. Main-phase only — placed here (not on
+   * Set when combat suspends mid-round for the defender's matchup assignment,
+   * cleared by `resolve_combat_round`. Main-phase only — placed here (not on
    * `GameStateBase`) so a seeding or ended state cannot structurally carry one,
    * mirroring `viewPrompt`. The prompt carries the full resumable loop state
    * inline — the same Option-A pattern `pickPrompt`/`viewPrompt` use.
    *
-   * Dormant in #165: no production combat ever pauses (see
-   * `combatDecisionPending` in `apply-main.ts`). The real pause conditions —
-   * defender-assigned matchups (#166), sit-out (#167), retreat (#168) — arrive
-   * later.
+   * Live as of #166: combat pauses whenever the defender has a real pairing
+   * choice (`matchupDecisionPending` in `apply-main.ts`). Sit-out (#167) and
+   * retreat (#168) will add further pause conditions later.
    */
   combatPrompt?: CombatPrompt;
 }
@@ -948,7 +949,7 @@ export interface VisibleState {
   pickPrompt?: PickPrompt;
   /** Set during main phase when this viewer is the active player on a `peek(opponent + hand)`. */
   viewPrompt?: ViewPrompt;
-  /** Set when combat is suspended between rounds. Public — combat is fully open, so surfaced to every viewer unredacted. */
+  /** Set when combat is suspended mid-round for the defender's matchup decision. Public — combat is fully open, so surfaced to every viewer unredacted. */
   combatPrompt?: CombatPrompt;
   winner?: string;
   scores?: Record<string, number>;

--- a/engine/src/valid-actions.ts
+++ b/engine/src/valid-actions.ts
@@ -151,6 +151,12 @@ export function needsLocationTarget(card: EventCard): boolean {
  * explore non-greedy pairings, not just the default. The lists are stored
  * highest-power-first, so the identity permutation — element `[0]` — is the
  * greedy highest-vs-highest auto-resolve default a bot can submit as-is.
+ *
+ * Count is `n!` where `n = min(sides)` participants (the smaller side). This is
+ * bounded in practice by how many units realistically stack and fight in one
+ * cell — a handful — so it stays small; a pathologically large stack (n ≥ 8)
+ * would make this enumeration expensive. If unit stacks can grow that large,
+ * switch to lazily surfacing only the greedy default here.
  */
 function buildCombatResolutions(
   prompt: CombatPrompt,

--- a/engine/src/valid-actions.ts
+++ b/engine/src/valid-actions.ts
@@ -17,11 +17,13 @@ import { PASSIVE_EVENTS_NEEDING_LOCATION_TARGET, POLICY_ACTIONS } from "./listen
 import { getModifiedCost, getModifiedAPCost } from "./listeners/query";
 import type {
   Action,
+  CombatPrompt,
   EventCard,
   GameState,
   MainAction,
   MainGameState,
   PickPrompt,
+  ResolveCombatRoundAction,
   SeedingAction,
   SeedingGameState,
 } from "./types";
@@ -37,7 +39,12 @@ export function getValidActions(state: GameState, playerId: string): Action[] {
   }
 
   const activePlayerId = getActivePlayerId(state);
-  if (activePlayerId !== playerId) {
+  // A suspended combat offers its resolution to the prompt's decider (the
+  // defender for #166), normally the non-active player — admit them even though
+  // it isn't their turn. Mirrors the dispatch gate in apply-action.ts.
+  const combatDecider: string | undefined =
+    state.phase === "main" ? state.combatPrompt?.playerId : undefined;
+  if (activePlayerId !== playerId && combatDecider !== playerId) {
     return [];
   }
 
@@ -135,12 +142,39 @@ export function needsLocationTarget(card: EventCard): boolean {
   return false;
 }
 
+/**
+ * The greedy-default matchup as a complete, submittable `resolve_combat_round`.
+ * The prompt's `atkRolls` / `defRolls` are stored highest-power-first, so
+ * index-pairing reproduces the auto-resolve default (highest vs highest). The
+ * client's pairing overlay starts from this and lets the defender re-pair; a bot
+ * can submit it as-is.
+ */
+function buildDefaultCombatResolution(
+  prompt: CombatPrompt,
+  playerId: string,
+): ResolveCombatRoundAction {
+  const pairs = prompt.atkRolls.map((atk, i) => ({
+    attackerUnitId: atk.unitId,
+    defenderUnitId: prompt.defRolls[i].unitId,
+  }));
+  return {
+    type: "resolve_combat_round",
+    playerId,
+    decision: { kind: "assign_matchups", pairs },
+  };
+}
+
 function getMainValidActions(
   state: MainGameState,
   playerId: string,
 ): MainAction[] {
-  if (state.combatPrompt && state.combatPrompt.playerId === playerId) {
-    return [{ type: "resolve_combat_round", playerId }];
+  // While a combat is suspended, only its decider may act — and only to resolve
+  // it. Everyone else (including the active attacker waiting on the defender)
+  // gets nothing until the fight resumes.
+  if (state.combatPrompt) {
+    return state.combatPrompt.playerId === playerId
+      ? [buildDefaultCombatResolution(state.combatPrompt, playerId)]
+      : [];
   }
   if (state.pickPrompt && state.pickPrompt.playerId === playerId) {
     return getResolvePickActions(state.pickPrompt, playerId);

--- a/engine/src/valid-actions.ts
+++ b/engine/src/valid-actions.ts
@@ -143,25 +143,32 @@ export function needsLocationTarget(card: EventCard): boolean {
 }
 
 /**
- * The greedy-default matchup as a complete, submittable `resolve_combat_round`.
- * The prompt's `atkRolls` / `defRolls` are stored highest-power-first, so
- * index-pairing reproduces the auto-resolve default (highest vs highest). The
- * client's pairing overlay starts from this and lets the defender re-pair; a bot
- * can submit it as-is.
+ * Every matchup the defender may assign, as complete `resolve_combat_round`
+ * actions — one per bijection between the equal-length participant lists.
+ * Enumerated by permuting the defenders against the fixed attacker order
+ * (mirrors `scholar_reorder`'s full-permutation enumeration), so consumers that
+ * treat `getValidActions` as the exhaustive action space (bots, search) can
+ * explore non-greedy pairings, not just the default. The lists are stored
+ * highest-power-first, so the identity permutation — element `[0]` — is the
+ * greedy highest-vs-highest auto-resolve default a bot can submit as-is.
  */
-function buildDefaultCombatResolution(
+function buildCombatResolutions(
   prompt: CombatPrompt,
   playerId: string,
-): ResolveCombatRoundAction {
-  const pairs = prompt.atkRolls.map((atk, i) => ({
-    attackerUnitId: atk.unitId,
-    defenderUnitId: prompt.defRolls[i].unitId,
-  }));
-  return {
+): ResolveCombatRoundAction[] {
+  const attackerIds: readonly string[] = prompt.atkRolls.map((s) => s.unitId);
+  const defenderIds: readonly string[] = prompt.defRolls.map((s) => s.unitId);
+  return permutationsOf(defenderIds).map((perm) => ({
     type: "resolve_combat_round",
     playerId,
-    decision: { kind: "assign_matchups", pairs },
-  };
+    decision: {
+      kind: "assign_matchups",
+      pairs: attackerIds.map((attackerUnitId, i) => ({
+        attackerUnitId,
+        defenderUnitId: perm[i],
+      })),
+    },
+  }));
 }
 
 function getMainValidActions(
@@ -173,7 +180,7 @@ function getMainValidActions(
   // gets nothing until the fight resumes.
   if (state.combatPrompt) {
     return state.combatPrompt.playerId === playerId
-      ? [buildDefaultCombatResolution(state.combatPrompt, playerId)]
+      ? buildCombatResolutions(state.combatPrompt, playerId)
       : [];
   }
   if (state.pickPrompt && state.pickPrompt.playerId === playerId) {

--- a/rules/README.md
+++ b/rules/README.md
@@ -237,24 +237,26 @@ be present.
   resolves combat against each opponent in turn (attacker chooses
   order). Surviving attacker units carry over between resolutions.
 
-[design: The multi-unit *tactical* layer above — the defender assigning
-matchups and the larger side choosing which units sit out (the Matchup
-step), and per-round retreat (the Next round or end step) — is the
-intended design but is **not yet implemented** (see #164). The engine
-currently auto-resolves combat atomically: the attacker commits units,
-both sides are paired greedily highest-power vs highest-power, excess
-units on the larger side sit out lowest-power-first, and all rounds run
-without pausing for player decisions. The injure/kill consequences, the
-tie-to-defender rule, and the drop-out survivor semantics (injured units
-leave the fighting pool between rounds, per the Next round or end step)
-*are* implemented and match this text. As a safety limit, combat
-resolution is capped at [var:combat_round_cap:10] rounds — drop-out
-guarantees termination regardless (each round removes every matchup's
-loser), and normal combats finish in far fewer rounds; the cap only
-bounds combats with unusually large unit stacks (worst case scales with
-the larger committed side's size). Until #164 lands, do not build card
-designs on the tactical layer (defender-assigned matchups, sit-out,
-per-round retreat) — validate such designs against engine behavior.]
+[design: The multi-unit *tactical* layer above is landing incrementally
+with #164. **Defender-assigned matchups (the Matchup step) are now
+implemented** (#166): after a round's rolls are revealed, if the defender
+has a real pairing choice, combat pauses and the defender assigns which
+attacker faces which defender before the pairs resolve. Two pieces of the
+Matchup / Next round steps remain **not yet implemented**: the larger side
+choosing which excess units **sit out** (#167), and per-round **retreat**
+(#168). Until those land, excess units on the larger side sit out greedily
+lowest-power-first (rather than by the controller's choice), and no side
+can retreat. The injure/kill consequences, the tie-to-defender rule, and
+the drop-out survivor semantics (injured units leave the fighting pool
+between rounds, per the Next round or end step) *are* implemented and match
+this text. As a safety limit, combat resolution is capped at
+[var:combat_round_cap:10] rounds — drop-out guarantees termination
+regardless (each round removes every matchup's loser), and normal combats
+finish in far fewer rounds; the cap only bounds combats with unusually
+large unit stacks (worst case scales with the larger committed side's
+size). Until #164 fully lands, do not build card designs on the
+still-unimplemented pieces (sit-out, per-round retreat) — validate such
+designs against engine behavior.]
 
 > See [Market and Economy Rules](market.md) for details on the Buy action.
 


### PR DESCRIPTION
## Summary

Replace greedy auto-pairing in combat with a **defender-assigned matchup** decision, made after rolls are revealed (rules Option A). Builds on the #165 mid-combat suspension hook.

- **Engine:** new `assign_matchups` action in the `MainAction` union (`engine/src/types.ts`), consuming the mid-combat suspension point (#165's `combatPrompt` / resolve-round mechanism). Replaces the greedy highest-power-vs-highest-power pairing (`engine/src/apply-main.ts` combat loop). Gate + handler follow the existing `resolve_pick`/`dismiss_view` resolver pattern.
- **Client:** pairing UI for the defender to assign attacker units to defender units after rolls are shown, near the #146 contest-result dialog.

## Depends on
- #165 — mid-combat suspension (MERGED). Part of the #164 multi-unit combat tree.

Closes #166