### PR TITLE
#167 — Engine + client: sit-out selection for excess units

### DIFF
--- a/clients/web/src/components/CombatPromptOverlay.svelte
+++ b/clients/web/src/components/CombatPromptOverlay.svelte
@@ -11,34 +11,64 @@
 
   const vs = $derived(getVisibleState());
   const prompt = $derived(vs?.combatPrompt);
+  const isSitOut = $derived(prompt?.kind === "sit_out");
 
   function signed(delta: number): string {
     return delta >= 0 ? `+${delta}` : `${delta}`;
   }
 
+  // ---- assign_matchups state -------------------------------------------------
   // assignment[attackerUnitId] = defenderUnitId. Seeded to the greedy default
   // (participants are stored highest-power-first, so index-pairing matches
   // highest-vs-highest — the engine's auto-resolve fallback). The defender may
   // re-pair before confirming.
   let assignment = $state<Record<string, string>>({});
+
+  // ---- sit_out state ---------------------------------------------------------
+  // The excess units the larger side removes this round. Seeded to the greedy
+  // lowest-power default (mirroring the engine's `getValidActions[0]`), which the
+  // decider may change before confirming.
+  let sitOut = $state<string[]>([]);
+
   let submitted = $state(false);
   // The error banner present at submit time, so the recovery effect below can
   // tell a NEW mid-submit error (which should re-enable Confirm) from a stale,
   // unrelated banner (which must not).
   let errorAtSubmit = $state<string | null>(null);
 
+  // For a sit-out prompt the larger side is the longer roll list; that side's
+  // owner (prompt.playerId) picks exactly `excess` units to remove.
+  const attackerLarger = $derived(
+    !!prompt && prompt.atkRolls.length > prompt.defRolls.length,
+  );
+  const largerRolls = $derived<CombatSide[]>(
+    !prompt ? [] : attackerLarger ? prompt.atkRolls : prompt.defRolls,
+  );
+  const excess = $derived(
+    !prompt ? 0 : Math.abs(prompt.atkRolls.length - prompt.defRolls.length),
+  );
+
   // Reseed when the prompt content changes. Today the outer `{#if vs?.combatPrompt}`
   // unmounts and remounts on every prompt transition, so this is defensive.
   $effect(() => {
     if (!prompt) return;
     void prompt.atkRolls.map((r) => r.unitId).join(",");
-    // The engine guarantees equal-length participant lists (the greedy sit-out
-    // trims both sides to `min`). If they ever desync, surface it rather than
-    // silently seeding `""` — an unseeded attacker would leave `isBijection`
-    // false forever with no explanation.
+    submitted = false;
+
+    if (prompt.kind === "sit_out") {
+      // Greedy default: the lowest-power `excess` units on the larger side.
+      const weakestFirst = [...largerRolls].sort((a, b) => a.power - b.power);
+      sitOut = weakestFirst.slice(0, excess).map((r) => r.unitId);
+      return;
+    }
+
+    // assign_matchups: the engine guarantees equal-length participant lists (the
+    // sit-out step already trimmed both sides to `min`). If they ever desync,
+    // surface it rather than silently seeding `""` — an unseeded attacker would
+    // leave `isBijection` false forever with no explanation.
     if (prompt.atkRolls.length !== prompt.defRolls.length) {
       console.warn(
-        "CombatPromptOverlay: atkRolls/defRolls length mismatch — participant lists should be equal",
+        "CombatPromptOverlay: atkRolls/defRolls length mismatch — matchup participant lists should be equal",
         { atk: prompt.atkRolls.length, def: prompt.defRolls.length },
       );
     }
@@ -47,13 +77,12 @@
       seed[atk.unitId] = prompt.defRolls[i]?.unitId ?? "";
     });
     assignment = seed;
-    submitted = false;
   });
 
   // Unlock the confirm button if the engine surfaces a NEW error mid-submit, so
-  // the defender can retry. Gating on a fresh error (not merely any error
-  // present) avoids a stale banner re-enabling Confirm and inviting a second,
-  // dropped click. Mirrors PickPromptOverlay's recovery pattern.
+  // the decider can retry. Gating on a fresh error (not merely any error present)
+  // avoids a stale banner re-enabling Confirm and inviting a second, dropped
+  // click. Mirrors PickPromptOverlay's recovery pattern.
   const error = $derived(getError());
   $effect(() => {
     if (submitted && error && error !== errorAtSubmit) submitted = false;
@@ -70,10 +99,31 @@
     );
   });
 
+  // A valid sit-out picks exactly `excess` distinct units off the larger side.
+  const isValidSitOut = $derived(sitOut.length === excess);
+
+  const canConfirm = $derived(isSitOut ? isValidSitOut : isBijection);
+
+  function toggleSitOut(unitId: string): void {
+    if (sitOut.includes(unitId)) {
+      sitOut = sitOut.filter((id) => id !== unitId);
+    } else {
+      sitOut = [...sitOut, unitId];
+    }
+  }
+
   function confirm(): void {
-    if (!prompt || submitted || !isBijection) return;
+    if (!prompt || submitted || !canConfirm) return;
     errorAtSubmit = error;
     submitted = true;
+    if (prompt.kind === "sit_out") {
+      selectAction({
+        type: "resolve_combat_round",
+        playerId: prompt.playerId,
+        decision: { kind: "sit_out", sitOutUnitIds: sitOut },
+      });
+      return;
+    }
     selectAction({
       type: "resolve_combat_round",
       playerId: prompt.playerId,
@@ -113,49 +163,90 @@
   {@const defenderName = resolvePlayerName(prompt.defenderId)}
   {@const attackerName = resolvePlayerName(prompt.attackerId)}
   <Modal width="w-auto max-w-2xl">
-    <h3 class="mb-1 text-center text-lg font-bold text-text-primary">
-      Assign combat matchups — round {prompt.round + 1}
-    </h3>
-    <p class="mb-4 text-center text-sm text-text-muted">
-      {defenderName} is defending against {attackerName}. Pair each attacker
-      against one of your units — you choose after seeing every roll.
-    </p>
-
-    <div class="mb-4 space-y-2">
-      {#each prompt.atkRolls as atk (atk.unitId)}
-        <div class="rounded border border-border bg-surface p-2">
-          <div class="mb-2 rounded bg-surface-raised p-2">
-            {@render rollLine(atk)}
-          </div>
-          <div class="flex items-center gap-2">
-            <span class="text-xs text-text-faint">faces</span>
-            <select
-              bind:value={assignment[atk.unitId]}
-              class="flex-1 rounded border border-border bg-surface-raised px-2 py-1 text-sm text-text-primary"
-            >
-              {#each prompt.defRolls as def (def.unitId)}
-                <option value={def.unitId}>
-                  {resolveCardName(def.unitId)} (power {def.power}{def.injuredBefore ? ", injured" : ""})
-                </option>
-              {/each}
-            </select>
-          </div>
-        </div>
-      {/each}
-    </div>
-
-    {#if !isBijection}
-      <p class="mb-3 text-center text-xs text-error">
-        Each of your units must face exactly one attacker.
+    {#if isSitOut}
+      {@const deciderName = resolvePlayerName(prompt.playerId)}
+      {@const smallerRolls = attackerLarger ? prompt.defRolls : prompt.atkRolls}
+      <h3 class="mb-1 text-center text-lg font-bold text-text-primary">
+        Choose units to sit out — round {prompt.round + 1}
+      </h3>
+      <p class="mb-4 text-center text-sm text-text-muted">
+        {deciderName} committed {largerRolls.length} units against {smallerRolls.length}.
+        Pick exactly {excess} to sit out this round — the rest fight.
       </p>
+
+      <div class="mb-4 space-y-2">
+        {#each largerRolls as side (side.unitId)}
+          {@const chosen = sitOut.includes(side.unitId)}
+          <button
+            type="button"
+            onclick={() => toggleSitOut(side.unitId)}
+            class="w-full rounded border p-2 text-left transition-colors {chosen
+              ? 'border-amber-500 bg-amber-500/10'
+              : 'border-border bg-surface hover:border-border-strong'}"
+          >
+            <div class="mb-1 flex items-center justify-between">
+              <span class="text-xs font-semibold {chosen ? 'text-amber-500' : 'text-text-faint'}">
+                {chosen ? "Sitting out" : "Fighting"}
+              </span>
+            </div>
+            <div class="rounded bg-surface-raised p-2">
+              {@render rollLine(side)}
+            </div>
+          </button>
+        {/each}
+      </div>
+
+      {#if !isValidSitOut}
+        <p class="mb-3 text-center text-xs text-error">
+          Select exactly {excess} unit{excess === 1 ? "" : "s"} to sit out
+          (currently {sitOut.length}).
+        </p>
+      {/if}
+    {:else}
+      <h3 class="mb-1 text-center text-lg font-bold text-text-primary">
+        Assign combat matchups — round {prompt.round + 1}
+      </h3>
+      <p class="mb-4 text-center text-sm text-text-muted">
+        {defenderName} is defending against {attackerName}. Pair each attacker
+        against one of your units — you choose after seeing every roll.
+      </p>
+
+      <div class="mb-4 space-y-2">
+        {#each prompt.atkRolls as atk (atk.unitId)}
+          <div class="rounded border border-border bg-surface p-2">
+            <div class="mb-2 rounded bg-surface-raised p-2">
+              {@render rollLine(atk)}
+            </div>
+            <div class="flex items-center gap-2">
+              <span class="text-xs text-text-faint">faces</span>
+              <select
+                bind:value={assignment[atk.unitId]}
+                class="flex-1 rounded border border-border bg-surface-raised px-2 py-1 text-sm text-text-primary"
+              >
+                {#each prompt.defRolls as def (def.unitId)}
+                  <option value={def.unitId}>
+                    {resolveCardName(def.unitId)} (power {def.power}{def.injuredBefore ? ", injured" : ""})
+                  </option>
+                {/each}
+              </select>
+            </div>
+          </div>
+        {/each}
+      </div>
+
+      {#if !isBijection}
+        <p class="mb-3 text-center text-xs text-error">
+          Each of your units must face exactly one attacker.
+        </p>
+      {/if}
     {/if}
 
     <button
       onclick={confirm}
-      disabled={submitted || !isBijection}
+      disabled={submitted || !canConfirm}
       class="w-full rounded bg-amber-600 py-2 font-semibold text-white hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-50"
     >
-      {submitted ? "Resolving…" : "Confirm matchups"}
+      {submitted ? "Resolving…" : isSitOut ? "Confirm sit-out" : "Confirm matchups"}
     </button>
   </Modal>
 {/if}

--- a/clients/web/src/components/CombatPromptOverlay.svelte
+++ b/clients/web/src/components/CombatPromptOverlay.svelte
@@ -48,8 +48,10 @@
     !prompt ? 0 : Math.abs(prompt.atkRolls.length - prompt.defRolls.length),
   );
 
-  // Reseed when the prompt content changes. Today the outer `{#if vs?.combatPrompt}`
-  // unmounts and remounts on every prompt transition, so this is defensive.
+  // Reseed when the prompt content changes. A sit_out → assign_matchups transition
+  // keeps the outer `{#if vs?.combatPrompt}` truthy (no remount), so this effect —
+  // re-running on the changed `atkRolls` — is what reseeds the new decision and
+  // clears `submitted`; it also covers the defensive remount case.
   $effect(() => {
     if (!prompt) return;
     void prompt.atkRolls.map((r) => r.unitId).join(",");
@@ -100,7 +102,17 @@
   });
 
   // A valid sit-out picks exactly `excess` distinct units off the larger side.
-  const isValidSitOut = $derived(sitOut.length === excess);
+  // `toggleSitOut` already guarantees this, but validate structurally (matching
+  // `isBijection`'s rigor) so a future seeding change can't slip an out-of-set or
+  // duplicate id past the confirm gate.
+  const isValidSitOut = $derived.by(() => {
+    const largerIds = new Set(largerRolls.map((r) => r.unitId));
+    return (
+      sitOut.length === excess &&
+      new Set(sitOut).size === excess &&
+      sitOut.every((id) => largerIds.has(id))
+    );
+  });
 
   const canConfirm = $derived(isSitOut ? isValidSitOut : isBijection);
 

--- a/engine/src/__tests__/contest-surfacing.test.ts
+++ b/engine/src/__tests__/contest-surfacing.test.ts
@@ -58,6 +58,29 @@ function findAllPairs(events: readonly GameEvent[]): Extract<GameEvent, { type: 
   return events.filter((e): e is Extract<GameEvent, { type: "combat_pair_resolved" }> => e.type === "combat_pair_resolved");
 }
 
+/**
+ * Attack, then drive any combat suspensions (#167 sit-out, #166 matchup) to
+ * completion via the greedy default (`getValidActions[0]`), accumulating every
+ * event. Lets tests that only care about the drop-out / round-cap end state stay
+ * agnostic to how many interactive decisions the fight now interleaves.
+ */
+function attackToEnd(
+  state: MainGameState,
+  attack: MainAction,
+): { state: MainGameState; events: GameEvent[] } {
+  const first = applyAction(state, attack);
+  let cur = first.state as MainGameState;
+  const events: GameEvent[] = [...first.events];
+  let guard = 0;
+  while (cur.combatPrompt) {
+    if (guard++ > 40) throw new Error("combat failed to terminate");
+    const r = applyAction(cur, getValidActions(cur, cur.combatPrompt.playerId)[0] as MainAction);
+    cur = r.state as MainGameState;
+    events.push(...r.events);
+  }
+  return { state: cur, events };
+}
+
 function findContest(events: readonly GameEvent[]): Extract<GameEvent, { type: "contest_resolved" }> {
   const ev = events.find((e) => e.type === "contest_resolved");
   if (!ev || ev.type !== "contest_resolved") {
@@ -325,14 +348,16 @@ describe("combat drop-out survivor semantics", () => {
       d.grid[0][0].units.push(attacker, ...defenders);
     });
 
-    const { state: next, events } = applyAction(state, {
+    // 1-vs-2: the defender (larger side) picks which unit sits out (#167); the
+    // greedy default drops one, leaving the 1-vs-1 this test pins.
+    const { state: next, events } = attackToEnd(state, {
       type: "attack",
       playerId: ACTIVE,
       unitIds: [attacker.id],
       row: 0,
       col: 0,
     });
-    const ns = next as MainGameState;
+    const ns = next;
 
     // Round 0 ran (pre-injured attacker participated, killing one defender);
     // round 1 did not (attacker excluded, no attackers left to roll).
@@ -373,14 +398,14 @@ describe("combat drop-out survivor semantics", () => {
       },
     );
 
-    const { state: next, events } = applyAction(state, {
+    const { state: next, events } = attackToEnd(state, {
       type: "attack",
       playerId: ACTIVE,
       unitIds: [attacker.id],
       row: 0,
       col: 0,
     });
-    const ns = next as MainGameState;
+    const ns = next;
 
     // Only one round ran → exactly one matchup resolved.
     expect(findAllPairs(events)).toHaveLength(1);
@@ -409,14 +434,14 @@ describe("combat drop-out survivor semantics", () => {
       d.grid[0][0].units.push(attacker, ...defenders);
     });
 
-    const { state: next, events } = applyAction(state, {
+    const { state: next, events } = attackToEnd(state, {
       type: "attack",
       playerId: ACTIVE,
       unitIds: [attacker.id],
       row: 0,
       col: 0,
     });
-    const ns = next as MainGameState;
+    const ns = next;
 
     // Three rounds, three kills — all defenders cleared, attacker takes the cell.
     expect(findAllPairs(events)).toHaveLength(3);

--- a/engine/src/__tests__/main-actions.test.ts
+++ b/engine/src/__tests__/main-actions.test.ts
@@ -1410,6 +1410,60 @@ describe("sit-out selection (#167)", () => {
     ).toThrow("not an excess unit");
   });
 
+  it("rejects a sit-out that names the same unit twice", () => {
+    // 3-vs-1 (excess 2): a duplicate id has the right *count*, so it slips past
+    // the count guard and must be caught by the distinctness check — otherwise it
+    // would sit out one unit and leave the round a unit short.
+    const atk1 = makeUnit({ ownerId: ACTIVE, strength: 30 });
+    const atk2 = makeUnit({ ownerId: ACTIVE, strength: 20 });
+    const atk3 = makeUnit({ ownerId: ACTIVE, strength: 10 });
+    const defender = makeUnit({ ownerId: OTHER, strength: 1 });
+    const state = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(atk1, atk2, atk3, defender);
+    });
+    const { state: next } = applyAction(state, {
+      ...attackAction,
+      unitIds: [atk1.id, atk2.id, atk3.id],
+    });
+    const suspended = next as MainGameState;
+
+    expect(() =>
+      applyAction(suspended, {
+        type: "resolve_combat_round",
+        playerId: ACTIVE,
+        decision: { kind: "sit_out", sitOutUnitIds: [atk1.id, atk1.id] },
+      }),
+    ).toThrow("sits out more than once");
+  });
+
+  it("rejects a decision whose kind does not match the pending prompt", () => {
+    // A sit_out prompt must not accept an assign_matchups payload (or vice versa):
+    // the kind guard fails loud rather than routing the wrong payload into the
+    // wrong resolver.
+    const atk1 = makeUnit({ ownerId: ACTIVE, strength: 10 });
+    const atk2 = makeUnit({ ownerId: ACTIVE, strength: 10 });
+    const defender = makeUnit({ ownerId: OTHER, strength: 10 });
+    const state = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(atk1, atk2, defender);
+    });
+    const { state: next } = applyAction(state, {
+      ...attackAction,
+      unitIds: [atk1.id, atk2.id],
+    });
+    const suspended = next as MainGameState;
+    expect(suspended.combatPrompt?.kind).toBe("sit_out");
+
+    expect(() =>
+      applyAction(suspended, {
+        type: "resolve_combat_round",
+        playerId: ACTIVE,
+        decision: { kind: "assign_matchups", pairs: [] },
+      }),
+    ).toThrow('expected a "sit_out" decision');
+  });
+
   it("suspends twice in one round: sit-out first, then the matchup decision (3v2)", () => {
     // 3 attackers vs 2 defenders. The attacker drops 1 excess (sit-out), leaving
     // 2v2 — which then needs the defender's matchup pairing. Both decisions fire
@@ -1453,6 +1507,86 @@ describe("sit-out selection (#167)", () => {
     expect(done.combatPrompt).toBeUndefined();
     expect(e3.some((e) => e.type === "combat_pair_resolved")).toBe(true);
     expect(e3.filter((e) => e.type === "combat_resolved")).toHaveLength(1);
+  });
+
+  it("enumerates every sit-out combination, greedy-weakest first, decider-only", () => {
+    // 3-vs-1 (excess 2): the larger (attacking) side may drop any 2 of 3, so
+    // `getValidActions` offers C(3,2) = 3 sit-outs. Strength gaps > 6 make power
+    // order track strength order regardless of the d6, so `[0]` (weakest-first)
+    // sits out the two weakest, keeping the strongest to fight.
+    const atkStrong = makeUnit({ ownerId: ACTIVE, strength: 100 });
+    const atkMid = makeUnit({ ownerId: ACTIVE, strength: 50 });
+    const atkWeak = makeUnit({ ownerId: ACTIVE, strength: 10 });
+    const defender = makeUnit({ ownerId: OTHER, strength: 1 });
+    const state = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(atkStrong, atkMid, atkWeak, defender);
+    });
+    const { state: next } = applyAction(state, {
+      ...attackAction,
+      unitIds: [atkStrong.id, atkMid.id, atkWeak.id],
+    });
+    const susp = next as MainGameState;
+
+    const offered = getValidActions(susp, ACTIVE);
+    expect(offered).toHaveLength(3); // C(3, 2)
+    for (const act of offered) {
+      if (act.type !== "resolve_combat_round") continue;
+      if (act.decision.kind !== "sit_out") throw new Error("expected sit_out decisions");
+      expect(act.decision.sitOutUnitIds).toHaveLength(2);
+      expect(new Set(act.decision.sitOutUnitIds).size).toBe(2); // distinct
+    }
+    // Greedy default `[0]`: the two weakest sit out (mid + weak), strongest fights.
+    const greedy = offered[0];
+    if (greedy.type !== "resolve_combat_round" || greedy.decision.kind !== "sit_out") {
+      throw new Error("expected a sit_out action at [0]");
+    }
+    expect(new Set(greedy.decision.sitOutUnitIds)).toEqual(new Set([atkMid.id, atkWeak.id]));
+
+    // Only the decider (the larger side) is offered anything.
+    expect(getValidActions(susp, OTHER)).toHaveLength(0);
+  });
+
+  it("carries the shown rolls unchanged across both suspends and does not re-roll", () => {
+    // The rolls revealed at the sit_out suspend must be the exact rolls used at
+    // the later matchup suspend and at resolution — no re-roll, no rng advance
+    // across the sit-out step (sit-out consumes no randomness).
+    const atkA = makeUnit({ ownerId: ACTIVE, strength: 100 });
+    const atkB = makeUnit({ ownerId: ACTIVE, strength: 50 });
+    const atkC = makeUnit({ ownerId: ACTIVE, strength: 10 });
+    const defA = makeUnit({ ownerId: OTHER, strength: 100 });
+    const defB = makeUnit({ ownerId: OTHER, strength: 50 });
+    const state = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(atkA, atkB, atkC, defA, defB);
+    });
+
+    const { state: s1 } = applyAction(state, {
+      ...attackAction,
+      unitIds: [atkA.id, atkB.id, atkC.id],
+    });
+    const susp1 = s1 as MainGameState;
+    const rollAtSuspend1 = new Map<string, number>();
+    for (const side of [...susp1.combatPrompt!.atkRolls, ...susp1.combatPrompt!.defRolls]) {
+      rollAtSuspend1.set(side.unitId, side.roll);
+    }
+
+    const { state: s2 } = applyAction(susp1, {
+      type: "resolve_combat_round",
+      playerId: ACTIVE,
+      decision: { kind: "sit_out", sitOutUnitIds: [atkC.id] },
+    });
+    const susp2 = s2 as MainGameState;
+
+    // rng must not advance across the sit-out resolution — resolution and sit-out
+    // consume no randomness, so the stream resumes unbroken.
+    expect(susp2.rngState).toEqual(susp1.rngState);
+
+    // Every surviving participant keeps the roll it was shown at the first suspend.
+    for (const side of [...susp2.combatPrompt!.atkRolls, ...susp2.combatPrompt!.defRolls]) {
+      expect(rollAtSuspend1.has(side.unitId)).toBe(true);
+      expect(side.roll).toBe(rollAtSuspend1.get(side.unitId)!);
+    }
   });
 });
 

--- a/engine/src/__tests__/main-actions.test.ts
+++ b/engine/src/__tests__/main-actions.test.ts
@@ -1226,14 +1226,16 @@ describe("defender-assigned matchups (#166)", () => {
     // Every offer is a well-formed 3-pair bijection over the defenders.
     for (const act of offered) {
       if (act.type !== "resolve_combat_round") continue;
+      if (act.decision.kind !== "assign_matchups") continue;
       expect(act.decision.pairs).toHaveLength(3);
       expect(new Set(act.decision.pairs.map((p) => p.defenderUnitId)).size).toBe(3);
     }
   });
 
-  it("auto-resolves atomically for a trivial pairing (one side has a single unit)", () => {
-    // 1-vs-3: min(1,3) = 1, so there is only one possible matching — no defender
-    // decision. Combat resolves in a single action with no lingering prompt.
+  it("suspends for a sit-out choice when one side has excess (1 attacker vs 3 defenders)", () => {
+    // 1-vs-3: min(1,3) = 1, so there is no *pairing* choice — but the defender
+    // (the larger side) must pick which 2 of its 3 units sit out (#167). Combat
+    // suspends for that sit-out decision, then the lone 1-vs-1 resolves.
     const attacker = makeUnit({ ownerId: ACTIVE, strength: 100 });
     const defenders = [
       makeUnit({ ownerId: OTHER, strength: 1 }),
@@ -1245,14 +1247,29 @@ describe("defender-assigned matchups (#166)", () => {
       d.grid[0][0].units.push(attacker, ...defenders);
     });
 
-    const { state: next, events } = applyAction(state, {
+    const { state: suspended } = applyAction(state, {
       ...attackAction,
       unitIds: [attacker.id],
     });
-    const ns = next as MainGameState;
+    let cur = suspended as MainGameState;
 
-    expect(ns.combatPrompt).toBeUndefined();
-    expect(events.some((e) => e.type === "combat_resolved")).toBe(true);
+    // Suspended for the defender's sit-out choice, not resolved.
+    expect(cur.combatPrompt?.kind).toBe("sit_out");
+    expect(cur.combatPrompt?.playerId).toBe(OTHER); // the larger (defending) side decides
+    expect(cur.combatPrompt?.defRolls).toHaveLength(3);
+    expect(cur.combatPrompt?.atkRolls).toHaveLength(1);
+
+    const events: GameEvent[] = [];
+    let guard = 0;
+    while (cur.combatPrompt) {
+      if (guard++ > 10) throw new Error("combat failed to terminate");
+      const r = applyAction(cur, getValidActions(cur, cur.combatPrompt.playerId)[0] as MainAction);
+      cur = r.state as MainGameState;
+      events.push(...r.events);
+    }
+
+    expect(cur.combatPrompt).toBeUndefined();
+    expect(events.filter((e) => e.type === "combat_resolved")).toHaveLength(1);
   });
 
   it("throws if multiple prompts are set at once (mutual-exclusion invariant)", () => {
@@ -1260,6 +1277,7 @@ describe("defender-assigned matchups (#166)", () => {
     // that co-sets two must fail loud at dispatch rather than deadlock.
     const state = gameWith((d) => {
       d.combatPrompt = {
+        kind: "assign_matchups",
         playerId: ACTIVE,
         row: 0,
         col: 0,
@@ -1287,6 +1305,154 @@ describe("defender-assigned matchups (#166)", () => {
         decision: { kind: "assign_matchups", pairs: [] },
       }),
     ).toThrow("multiple prompts are set");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sit-out selection (#167)
+// ---------------------------------------------------------------------------
+
+describe("sit-out selection (#167)", () => {
+  const attackAction = { type: "attack" as const, playerId: ACTIVE, row: 0, col: 0 };
+
+  /** Drive the fight to completion via the greedy default (`[0]`) at each
+   *  suspend, collecting every event. Returns the terminal state + events. */
+  function runToEnd(suspended: MainGameState): { state: MainGameState; events: GameEvent[] } {
+    let cur = suspended;
+    const events: GameEvent[] = [];
+    let guard = 0;
+    while (cur.combatPrompt) {
+      if (guard++ > 10) throw new Error("combat failed to terminate");
+      const r = applyAction(cur, getValidActions(cur, cur.combatPrompt.playerId)[0] as MainAction);
+      cur = r.state as MainGameState;
+      events.push(...r.events);
+    }
+    return { state: cur, events };
+  }
+
+  it("hands the sit-out choice to the larger (attacking) side and resolves the remainder", () => {
+    // 3 attackers vs 1 defender: the attacker is the larger side and must drop 2
+    // excess units. A non-greedy choice (sit out the two strongest) proves the
+    // engine honors the submitted ids rather than trimming lowest-power itself.
+    const atkStrong = makeUnit({ ownerId: ACTIVE, strength: 100 });
+    const atkMid = makeUnit({ ownerId: ACTIVE, strength: 50 });
+    const atkWeak = makeUnit({ ownerId: ACTIVE, strength: 20 });
+    const defender = makeUnit({ ownerId: OTHER, strength: 1 });
+    const state = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(atkStrong, atkMid, atkWeak, defender);
+    });
+
+    const { state: next } = applyAction(state, {
+      ...attackAction,
+      unitIds: [atkStrong.id, atkMid.id, atkWeak.id],
+    });
+    const suspended = next as MainGameState;
+
+    // Suspended for the attacker's sit-out choice, before any resolution.
+    expect(suspended.combatPrompt?.kind).toBe("sit_out");
+    expect(suspended.combatPrompt?.playerId).toBe(ACTIVE);
+    expect(suspended.combatPrompt?.atkRolls).toHaveLength(3);
+    expect(suspended.combatPrompt?.defRolls).toHaveLength(1);
+
+    // Sit out the two strongest, keeping the weak attacker to fight.
+    const { state: resolved, events } = applyAction(suspended, {
+      type: "resolve_combat_round",
+      playerId: ACTIVE,
+      decision: { kind: "sit_out", sitOutUnitIds: [atkStrong.id, atkMid.id] },
+    });
+    const ns = resolved as MainGameState;
+
+    // One clean resolution, no lingering prompt.
+    expect(ns.combatPrompt).toBeUndefined();
+    expect(events.filter((e) => e.type === "combat_resolved")).toHaveLength(1);
+
+    // The kept (weak) attacker is the one that fought the defender.
+    const pair = events.find((e) => e.type === "combat_pair_resolved");
+    expect(pair && pair.type === "combat_pair_resolved" && pair.attacker.unitId).toBe(atkWeak.id);
+
+    // Both sat-out attackers are untouched and still present.
+    expect(ns.grid[0][0].units.some((u) => u.id === atkStrong.id)).toBe(true);
+    expect(ns.grid[0][0].units.some((u) => u.id === atkMid.id)).toBe(true);
+  });
+
+  it("rejects a sit-out that drops the wrong count or a non-excess unit", () => {
+    const atk1 = makeUnit({ ownerId: ACTIVE, strength: 10 });
+    const atk2 = makeUnit({ ownerId: ACTIVE, strength: 10 });
+    const defender = makeUnit({ ownerId: OTHER, strength: 10 });
+    const state = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(atk1, atk2, defender);
+    });
+    const { state: next } = applyAction(state, {
+      ...attackAction,
+      unitIds: [atk1.id, atk2.id],
+    });
+    const suspended = next as MainGameState;
+    expect(suspended.combatPrompt?.kind).toBe("sit_out");
+
+    // Wrong count: excess is 1, not 2.
+    expect(() =>
+      applyAction(suspended, {
+        type: "resolve_combat_round",
+        playerId: ACTIVE,
+        decision: { kind: "sit_out", sitOutUnitIds: [atk1.id, atk2.id] },
+      }),
+    ).toThrow("expected 1 sit-out");
+
+    // A unit not on the larger side cannot be told to sit out.
+    expect(() =>
+      applyAction(suspended, {
+        type: "resolve_combat_round",
+        playerId: ACTIVE,
+        decision: { kind: "sit_out", sitOutUnitIds: [defender.id] },
+      }),
+    ).toThrow("not an excess unit");
+  });
+
+  it("suspends twice in one round: sit-out first, then the matchup decision (3v2)", () => {
+    // 3 attackers vs 2 defenders. The attacker drops 1 excess (sit-out), leaving
+    // 2v2 — which then needs the defender's matchup pairing. Both decisions fire
+    // within the SAME round before any pair resolves.
+    const atkA = makeUnit({ ownerId: ACTIVE, strength: 100 });
+    const atkB = makeUnit({ ownerId: ACTIVE, strength: 50 });
+    const atkC = makeUnit({ ownerId: ACTIVE, strength: 10 });
+    const defA = makeUnit({ ownerId: OTHER, strength: 100 });
+    const defB = makeUnit({ ownerId: OTHER, strength: 50 });
+    const state = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(atkA, atkB, atkC, defA, defB);
+    });
+
+    // First suspend: sit-out, decided by the larger (attacking) side.
+    const { state: s1, events: e1 } = applyAction(state, {
+      ...attackAction,
+      unitIds: [atkA.id, atkB.id, atkC.id],
+    });
+    const susp1 = s1 as MainGameState;
+    expect(susp1.combatPrompt?.kind).toBe("sit_out");
+    expect(susp1.combatPrompt?.playerId).toBe(ACTIVE);
+    expect(e1.some((e) => e.type === "combat_pair_resolved")).toBe(false); // nothing resolved yet
+
+    // Drop one attacker → 2v2, which must re-suspend for the matchup decision.
+    const { state: s2, events: e2 } = applyAction(susp1, {
+      type: "resolve_combat_round",
+      playerId: ACTIVE,
+      decision: { kind: "sit_out", sitOutUnitIds: [atkC.id] },
+    });
+    const susp2 = s2 as MainGameState;
+    expect(susp2.combatPrompt?.kind).toBe("assign_matchups");
+    expect(susp2.combatPrompt?.playerId).toBe(OTHER); // the defender pairs
+    expect(susp2.combatPrompt?.round).toBe(0); // still the same round
+    expect(susp2.combatPrompt?.atkRolls).toHaveLength(2);
+    expect(susp2.combatPrompt?.defRolls).toHaveLength(2);
+    expect(e2.some((e) => e.type === "combat_pair_resolved")).toBe(false); // still nothing resolved
+
+    // Submit the matchup and let the fight finish.
+    const { state: done, events: e3 } = runToEnd(susp2);
+    expect(done.combatPrompt).toBeUndefined();
+    expect(e3.some((e) => e.type === "combat_pair_resolved")).toBe(true);
+    expect(e3.filter((e) => e.type === "combat_resolved")).toHaveLength(1);
   });
 });
 
@@ -1694,19 +1860,34 @@ describe("combat details", () => {
       d.grid[0][0].units.push(atk1, atk2, defender);
     });
 
-    const { state: next, events } = applyAction(state, {
+    // 2-vs-1: the attacker is the larger side, so combat suspends for a sit-out
+    // choice (#167) before resolving. Drive the greedy default (`[0]`) to sit one
+    // attacker out, leaving a 1-vs-1 that resolves.
+    const { state: suspended, events: startEvents } = applyAction(state, {
       type: "attack",
       playerId: ACTIVE,
       unitIds: [atk1.id, atk2.id],
       row: 0,
       col: 0,
     });
-    const ns = next as MainGameState;
+    let cur = suspended as MainGameState;
+    expect(cur.combatPrompt?.kind).toBe("sit_out");
+    expect(cur.combatPrompt?.playerId).toBe(ACTIVE); // the larger (attacking) side decides
+
+    const events: GameEvent[] = [...startEvents];
+    let guard = 0;
+    while (cur.combatPrompt) {
+      if (guard++ > 10) throw new Error("combat failed to terminate");
+      const r = applyAction(cur, getValidActions(cur, cur.combatPrompt.playerId)[0] as MainAction);
+      cur = r.state as MainGameState;
+      events.push(...r.events);
+    }
+    const ns = cur;
 
     expect(events.some((e) => e.type === "combat_resolved")).toBe(true);
-    // Defender should be dead (2 strong attackers vs 1 weak defender)
+    // Defender should be dead (a strong attacker vs 1 weak defender)
     expect(ns.grid[0][0].units.every((u) => u.id !== defender.id)).toBe(true);
-    // Attackers should survive
+    // Both attackers should survive — the one that fought and the one that sat out
     expect(ns.grid[0][0].units.some((u) => u.id === atk1.id)).toBe(true);
     expect(ns.grid[0][0].units.some((u) => u.id === atk2.id)).toBe(true);
   });

--- a/engine/src/__tests__/visible-state.test.ts
+++ b/engine/src/__tests__/visible-state.test.ts
@@ -233,6 +233,7 @@ describe("getVisibleState", () => {
 
   describe("combatPrompt (public info)", () => {
     const prompt = {
+      kind: "assign_matchups" as const,
       playerId: "p1",
       row: 0,
       col: 0,

--- a/engine/src/__tests__/win-condition.test.ts
+++ b/engine/src/__tests__/win-condition.test.ts
@@ -144,6 +144,7 @@ describe("toEndedState", () => {
     )!.id;
     const withPrompt = produce(base, (d) => {
       d.combatPrompt = {
+        kind: "assign_matchups",
         playerId: d.turn.activePlayerId,
         row: 0,
         col: 0,

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -715,18 +715,107 @@ function handleAttack(
 }
 
 /**
- * Whether the defender has a meaningful matchup choice this round (#166).
- *
- * The `pairs` count is `min(attackers, defenders)` — the greedy sit-out trims
- * the larger side to that size lowest-power-first, leaving equal-length
- * participant lists. A bijection over them offers a real choice only when there
- * are at least two pairs; a single pair (`min <= 1`) has exactly one matching,
- * so those rounds auto-resolve. Cases where `min == 1` but the larger side must
- * pick which unit faces the lone opponent are a *sit-out* choice (#167), not a
- * pairing choice — deferred, so they auto-resolve greedily here too.
+ * Whether the defender has a meaningful matchup choice among `n` equal-length
+ * participants (#166). A bijection over them offers a real choice only when
+ * there are at least two pairs; a single pair has exactly one matching, so those
+ * rounds auto-resolve.
  */
-function matchupDecisionPending(attackers: number, defenders: number): boolean {
-  return Math.min(attackers, defenders) >= 2;
+function matchupDecisionPending(n: number): boolean {
+  return n >= 2;
+}
+
+/**
+ * Rules steps 4–5 for one already-rolled round: decide whether the round needs a
+ * player decision (suspend) or can auto-resolve, and act on it. Shared by the
+ * fresh-round path in `runCombat` and — for the post-sit-out continuation — the
+ * `resolve_combat_round` handler, so a round that suspends for sit-out still
+ * re-evaluates for a matchup decision on resume (the 3v2 double-suspend).
+ *
+ * When the sides are unequal (excess exists — and since `runCombat` already
+ * `break`s on an empty side, `min >= 1` always holds here) the larger side must
+ * choose which excess units sit out (#167): suspend with a `sit_out` prompt
+ * carrying the *full* living rolls, decided by the larger side's owner.
+ * Otherwise the sides are already equal participants — hand off to
+ * `resolveOrSuspendMatchup`.
+ *
+ * Returns `"suspended"` if it set `draft.combatPrompt` (caller must stop), or
+ * `"resolved"` if it resolved the round's pairs in place (caller continues).
+ */
+function processRolledRound(
+  draft: Draft<MainGameState>,
+  cell: Draft<GridCell>,
+  base: CombatLoopState,
+  atkRolls: CombatantRoll[],
+  defRolls: CombatantRoll[],
+  emit: EmitFn,
+): "suspended" | "resolved" {
+  if (atkRolls.length !== defRolls.length) {
+    const attackerLarger: boolean = atkRolls.length > defRolls.length;
+    const prompt: CombatPrompt = {
+      kind: "sit_out",
+      playerId: attackerLarger ? base.attackerId : base.defenderId,
+      row: base.row,
+      col: base.col,
+      attackerId: base.attackerId,
+      defenderId: base.defenderId,
+      round: base.round,
+      attackerUnitIds: base.attackerUnitIds,
+      defenderUnitIds: base.defenderUnitIds,
+      atkRolls: atkRolls.map(toCombatSide),
+      defRolls: defRolls.map(toCombatSide),
+    };
+    draft.combatPrompt = castDraft(prompt);
+    return "suspended";
+  }
+  return resolveOrSuspendMatchup(draft, cell, base, atkRolls, defRolls, emit);
+}
+
+/**
+ * Rules steps 4–5 for equal-length participant lists: either suspend for the
+ * defender's matchup assignment (when `>= 2` pairs offer a real choice) or
+ * auto-resolve greedily. Sorts both sides power-descending first, so the stored
+ * participant order is highest-first — the greedy identity pairing is the
+ * auto-resolve default (and element `[0]` of the enumerated matchup actions).
+ *
+ * `atkParticipants.length === defParticipants.length` is a precondition.
+ * Returns `"suspended"` (prompt set) or `"resolved"` (pairs resolved).
+ */
+function resolveOrSuspendMatchup(
+  draft: Draft<MainGameState>,
+  cell: Draft<GridCell>,
+  base: CombatLoopState,
+  atkParticipants: CombatantRoll[],
+  defParticipants: CombatantRoll[],
+  emit: EmitFn,
+): "suspended" | "resolved" {
+  atkParticipants.sort((a, b) => b.power - a.power);
+  defParticipants.sort((a, b) => b.power - a.power);
+  const n: number = atkParticipants.length;
+
+  if (matchupDecisionPending(n)) {
+    const prompt: CombatPrompt = {
+      kind: "assign_matchups",
+      playerId: base.defenderId,
+      row: base.row,
+      col: base.col,
+      attackerId: base.attackerId,
+      defenderId: base.defenderId,
+      round: base.round,
+      attackerUnitIds: base.attackerUnitIds,
+      defenderUnitIds: base.defenderUnitIds,
+      atkRolls: atkParticipants.map(toCombatSide),
+      defRolls: defParticipants.map(toCombatSide),
+    };
+    draft.combatPrompt = castDraft(prompt);
+    return "suspended";
+  }
+
+  // Rules step 5 — Resolve: auto-resolve the participants greedily (the sort
+  // above already lined them up highest vs highest).
+  for (let i = 0; i < n; i++) {
+    resolveCombatPair(draft, cell, atkParticipants[i], defParticipants[i], base.row, base.col, emit);
+  }
+  return "resolved";
 }
 
 /**
@@ -795,39 +884,19 @@ function runCombat(
       defRolls.push(buildCombatantRoll(draft, queries, u, "defender", row, col, roll));
     }
 
-    // Greedy sit-out: sort by power descending and trim the larger side to the
-    // pair count, so its lowest-power excess sits out. The trimmed lists are
-    // equal length — the participants the defender pairs (or that auto-resolve
-    // greedily, highest vs highest). #167 hands this sit-out choice to the
-    // larger side; until then it stays lowest-power-first.
-    atkRolls.sort((a, b) => b.power - a.power);
-    defRolls.sort((a, b) => b.power - a.power);
-    const nPairs = Math.min(atkRolls.length, defRolls.length);
-    const atkParticipants = atkRolls.slice(0, nPairs);
-    const defParticipants = defRolls.slice(0, nPairs);
+    // Persist rng now: it has advanced past this round's rolls and combat
+    // resolution consumes no further randomness, so this covers both the
+    // suspend-and-return paths below and normal loop continuation. Keeps the
+    // roll stream unbroken across a `produce()` suspend boundary.
+    draft.rngState = extractRngState(rng) as number[];
 
-    // Rules step 4 — Matchup: when the defender has a real pairing choice,
-    // suspend AFTER the roll and BEFORE resolving, so the assignment is made
-    // "after seeing all rolls". Persist rng (already advanced past this round's
-    // rolls) so the roll stream is unbroken on resume; `combat_resolved` is
-    // deliberately NOT emitted — combat is paused, not over.
-    if (matchupDecisionPending(livingAttackers.length, livingDefenders.length)) {
-      draft.rngState = extractRngState(rng) as number[];
-      const prompt: CombatPrompt = {
-        playerId: defenderId,
-        row, col, attackerId, defenderId, round,
-        attackerUnitIds, defenderUnitIds,
-        atkRolls: atkParticipants.map(toCombatSide),
-        defRolls: defParticipants.map(toCombatSide),
-      };
-      draft.combatPrompt = castDraft(prompt);
+    // Rules steps 4–5 — Matchup + Resolve. `processRolledRound` either suspends
+    // for a player decision (sit-out and/or matchup, setting `draft.combatPrompt`
+    // and NOT emitting `combat_resolved` — combat is paused, not over) or
+    // auto-resolves the round's pairs in place.
+    const base: CombatLoopState = { ...state, round };
+    if (processRolledRound(draft, cell, base, atkRolls, defRolls, emit) === "suspended") {
       return;
-    }
-
-    // Rules step 5 — Resolve: auto-resolve the participants greedily (the sort
-    // above already lined them up highest vs highest).
-    for (let i = 0; i < nPairs; i++) {
-      resolveCombatPair(draft, cell, atkParticipants[i], defParticipants[i], row, col, emit);
     }
   }
 
@@ -1305,11 +1374,11 @@ function resolveAssignedMatchups(
   decision: CombatDecision,
   emit: EmitFn,
 ): void {
-  // Forward-defensive guard for the future `kind`s (#167 sit-out, #168 retreat)
-  // and for a malformed adapter submission: the `decision == null` arm turns a
-  // missing payload into a descriptive rejection rather than a bare TypeError on
-  // `.kind`. With today's single-variant `CombatDecision` the kind check is
-  // otherwise unreachable — intentional, not dead code.
+  // Defensive guard: `handleResolveCombatRound` already dispatches on `kind` and
+  // only routes an `assign_matchups` decision here, so this is unreachable in
+  // practice — kept so a future caller (or a malformed adapter submission) fails
+  // loud rather than mis-pairing. The `decision == null` arm turns a missing
+  // payload into a descriptive rejection rather than a bare TypeError on `.kind`.
   if (decision == null || decision.kind !== "assign_matchups") {
     throw new Error(`resolve_combat_round rejected: unsupported decision kind "${decision?.kind}"`);
   }
@@ -1351,6 +1420,55 @@ function resolveAssignedMatchups(
   }
 }
 
+/**
+ * Validate a sit-out decision (#167) against the pending prompt and return the
+ * resulting equal-length participants: the larger side with its chosen excess
+ * removed, paired against the (unchanged) smaller side. Rejects a wrong count or
+ * ids that are not on the larger side, so a malformed submission fails loud
+ * rather than silently dropping the wrong units.
+ */
+function resolveSitOut(
+  cell: Draft<GridCell>,
+  prompt: CombatPrompt,
+  decision: Extract<CombatDecision, { kind: "sit_out" }>,
+): { atkParticipants: CombatantRoll[]; defParticipants: CombatantRoll[] } {
+  const atkLen: number = prompt.atkRolls.length;
+  const defLen: number = prompt.defRolls.length;
+  // A sit-out prompt is only raised for unequal sides — guard defensively.
+  if (atkLen === defLen) {
+    throw new Error(`resolve_combat_round rejected: sit_out on balanced sides (${atkLen} vs ${defLen})`);
+  }
+  const attackerLarger: boolean = atkLen > defLen;
+  const largerSides: CombatSide[] = attackerLarger ? prompt.atkRolls : prompt.defRolls;
+  const excess: number = Math.abs(atkLen - defLen);
+
+  if (decision.sitOutUnitIds.length !== excess) {
+    throw new Error(
+      `resolve_combat_round rejected: expected ${excess} sit-out(s), got ${decision.sitOutUnitIds.length}`,
+    );
+  }
+
+  const largerIds = new Set<string>(largerSides.map((s) => s.unitId));
+  const sittingOut = new Set<string>();
+  for (const id of decision.sitOutUnitIds) {
+    if (!largerIds.has(id)) {
+      throw new Error(`resolve_combat_round rejected: "${id}" is not an excess unit on the larger side`);
+    }
+    if (sittingOut.has(id)) {
+      throw new Error(`resolve_combat_round rejected: "${id}" sits out more than once`);
+    }
+    sittingOut.add(id);
+  }
+
+  const remainingLarger: CombatSide[] = largerSides.filter((s) => !sittingOut.has(s.unitId));
+  const atkSides: CombatSide[] = attackerLarger ? remainingLarger : prompt.atkRolls;
+  const defSides: CombatSide[] = attackerLarger ? prompt.defRolls : remainingLarger;
+  return {
+    atkParticipants: atkSides.map((s) => combatantRollFromSide(cell, s)),
+    defParticipants: defSides.map((s) => combatantRollFromSide(cell, s)),
+  };
+}
+
 function handleResolveCombatRound(
   draft: Draft<MainGameState>,
   playerId: string,
@@ -1375,31 +1493,46 @@ function handleResolveCombatRound(
   // reader such as the event log. `current` yields a plain deep copy.
   const prompt: CombatPrompt = current(promptDraft);
 
+  if (decision == null || decision.kind !== prompt.kind) {
+    throw new Error(
+      `resolve_combat_round rejected: expected a "${prompt.kind}" decision, got "${decision?.kind}"`,
+    );
+  }
+
   const cell: Draft<GridCell> = draft.grid[prompt.row][prompt.col];
+  const base: CombatLoopState = {
+    row: prompt.row,
+    col: prompt.col,
+    attackerId: prompt.attackerId,
+    defenderId: prompt.defenderId,
+    round: prompt.round,
+    attackerUnitIds: prompt.attackerUnitIds,
+    defenderUnitIds: prompt.defenderUnitIds,
+  };
 
-  // Apply the defender's assignment: resolve this round's pairs from the rolls
-  // revealed at suspend (no re-roll, so the outcome matches what the defender
-  // saw), then resume from the next round.
+  if (decision.kind === "sit_out") {
+    // Remove the larger side's chosen excess, then continue the SAME round: the
+    // remaining participants either auto-resolve or raise a matchup decision (the
+    // 3v2 double-suspend). Clear the sit-out prompt first — `resolveOrSuspendMatchup`
+    // may set a fresh matchup prompt in its place, and a fight must never carry
+    // two live prompts.
+    const { atkParticipants, defParticipants } = resolveSitOut(cell, prompt, decision);
+    draft.combatPrompt = undefined;
+    if (resolveOrSuspendMatchup(draft, cell, base, atkParticipants, defParticipants, emit) === "suspended") {
+      return;
+    }
+    // Round fully resolved — resume from the next round.
+    runCombat(draft, { ...base, round: prompt.round + 1 }, emit, queries);
+    return;
+  }
+
+  // assign_matchups: resolve this round's pairs from the rolls revealed at
+  // suspend (no re-roll, so the outcome matches what the defender saw), then
+  // resume from the next round. Clear the prompt before resuming so `runCombat`
+  // is the single writer of any later prompt (one live `combatPrompt` per fight).
   resolveAssignedMatchups(draft, cell, prompt, decision, emit);
-
-  // Clear the prompt before resuming: `runCombat` re-sets it if a later round
-  // also needs a decision, so clearing first keeps a single source of truth (an
-  // unresolved fight always has exactly one live `combatPrompt`).
   draft.combatPrompt = undefined;
-  runCombat(
-    draft,
-    {
-      row: prompt.row,
-      col: prompt.col,
-      attackerId: prompt.attackerId,
-      defenderId: prompt.defenderId,
-      round: prompt.round + 1,
-      attackerUnitIds: prompt.attackerUnitIds,
-      defenderUnitIds: prompt.defenderUnitIds,
-    },
-    emit,
-    queries,
-  );
+  runCombat(draft, { ...base, round: prompt.round + 1 }, emit, queries);
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -725,11 +725,47 @@ function matchupDecisionPending(n: number): boolean {
 }
 
 /**
+ * Single source of truth for a suspended-combat prompt: derives BOTH the `kind`
+ * discriminator and the decider from the two roll lists, so the invariants
+ * "unequal ⟺ sit_out, decided by the larger side" and "equal ⟺ assign_matchups,
+ * decided by the defender" hold *by construction* rather than being re-asserted
+ * at each call site (which could drift). Callers pass the already-selected rolls;
+ * this only assembles the record.
+ */
+function makeCombatPrompt(
+  base: CombatLoopState,
+  atkRolls: CombatantRoll[],
+  defRolls: CombatantRoll[],
+): CombatPrompt {
+  const kind: CombatDecision["kind"] =
+    atkRolls.length === defRolls.length ? "assign_matchups" : "sit_out";
+  // sit_out is decided by the larger side's owner; assign_matchups by the
+  // defender (both derivable from the same length comparison).
+  const playerId: string =
+    kind === "sit_out" && atkRolls.length > defRolls.length ? base.attackerId : base.defenderId;
+  return {
+    kind,
+    playerId,
+    row: base.row,
+    col: base.col,
+    attackerId: base.attackerId,
+    defenderId: base.defenderId,
+    round: base.round,
+    attackerUnitIds: base.attackerUnitIds,
+    defenderUnitIds: base.defenderUnitIds,
+    atkRolls: atkRolls.map(toCombatSide),
+    defRolls: defRolls.map(toCombatSide),
+  };
+}
+
+/**
  * Rules steps 4–5 for one already-rolled round: decide whether the round needs a
- * player decision (suspend) or can auto-resolve, and act on it. Shared by the
- * fresh-round path in `runCombat` and — for the post-sit-out continuation — the
- * `resolve_combat_round` handler, so a round that suspends for sit-out still
- * re-evaluates for a matchup decision on resume (the 3v2 double-suspend).
+ * player decision (suspend) or can auto-resolve, and act on it. Called only from
+ * `runCombat`'s fresh-round path. The equal-length step-4–5 logic it delegates to
+ * (`resolveOrSuspendMatchup`) is what the `resolve_combat_round` handler re-enters
+ * after a sit-out — so a sit-out round still re-evaluates for a matchup decision
+ * on resume (the 3v2 double-suspend) without re-running this function's sit-out
+ * check (by then the sides are already equal).
  *
  * When the sides are unequal (excess exists — and since `runCombat` already
  * `break`s on an empty side, `min >= 1` always holds here) the larger side must
@@ -750,21 +786,7 @@ function processRolledRound(
   emit: EmitFn,
 ): "suspended" | "resolved" {
   if (atkRolls.length !== defRolls.length) {
-    const attackerLarger: boolean = atkRolls.length > defRolls.length;
-    const prompt: CombatPrompt = {
-      kind: "sit_out",
-      playerId: attackerLarger ? base.attackerId : base.defenderId,
-      row: base.row,
-      col: base.col,
-      attackerId: base.attackerId,
-      defenderId: base.defenderId,
-      round: base.round,
-      attackerUnitIds: base.attackerUnitIds,
-      defenderUnitIds: base.defenderUnitIds,
-      atkRolls: atkRolls.map(toCombatSide),
-      defRolls: defRolls.map(toCombatSide),
-    };
-    draft.combatPrompt = castDraft(prompt);
+    draft.combatPrompt = castDraft(makeCombatPrompt(base, atkRolls, defRolls));
     return "suspended";
   }
   return resolveOrSuspendMatchup(draft, cell, base, atkRolls, defRolls, emit);
@@ -777,7 +799,8 @@ function processRolledRound(
  * participant order is highest-first — the greedy identity pairing is the
  * auto-resolve default (and element `[0]` of the enumerated matchup actions).
  *
- * `atkParticipants.length === defParticipants.length` is a precondition.
+ * `atkParticipants.length === defParticipants.length` is a precondition (equal
+ * lengths make `makeCombatPrompt` derive `kind: "assign_matchups"`).
  * Returns `"suspended"` (prompt set) or `"resolved"` (pairs resolved).
  */
 function resolveOrSuspendMatchup(
@@ -793,20 +816,7 @@ function resolveOrSuspendMatchup(
   const n: number = atkParticipants.length;
 
   if (matchupDecisionPending(n)) {
-    const prompt: CombatPrompt = {
-      kind: "assign_matchups",
-      playerId: base.defenderId,
-      row: base.row,
-      col: base.col,
-      attackerId: base.attackerId,
-      defenderId: base.defenderId,
-      round: base.round,
-      attackerUnitIds: base.attackerUnitIds,
-      defenderUnitIds: base.defenderUnitIds,
-      atkRolls: atkParticipants.map(toCombatSide),
-      defRolls: defParticipants.map(toCombatSide),
-    };
-    draft.combatPrompt = castDraft(prompt);
+    draft.combatPrompt = castDraft(makeCombatPrompt(base, atkParticipants, defParticipants));
     return "suspended";
   }
 

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -463,29 +463,38 @@ export interface CombatLoopState {
 }
 
 /**
- * A combat suspended mid-round awaiting the defender's matchup assignment
- * (#166). Per the rules (README.md Combat step 4 — Matchup) the defender assigns
- * pairings after the step-3 roll, so the suspend lands *within* a round — after
- * the roll, before resolution — carrying that round's revealed rolls inline.
+ * A combat suspended mid-round awaiting a player decision. Per the rules
+ * (README.md Combat step 4 — Matchup) decisions land *within* a round — after
+ * the step-3 roll, before resolution — carrying that round's revealed rolls
+ * inline. A single round can suspend twice (`kind` transitions): a `sit_out`
+ * prompt first (larger side drops its excess), then, if `min >= 2` participants
+ * remain, an `assign_matchups` prompt.
  *
- * `playerId` is who must submit `resolve_combat_round`: the **defender**, who is
- * normally the *non-active* player, so the active-player gate in
+ * `kind` discriminates the two decisions:
+ * - `"sit_out"` (#167): the larger side removes `max - min` excess units.
+ *   `playerId` is the **larger side's** owner (attacker or defender), and
+ *   `atkRolls` / `defRolls` are the *full* living rolls — so the lists have
+ *   **unequal** length (that is what makes the choice exist).
+ * - `"assign_matchups"` (#166): the defender pairs the participants. `playerId`
+ *   is the **defender**, and `atkRolls` / `defRolls` are the equal-length
+ *   participant lists (post sit-out), a bijection to assign between them.
+ *
+ * `playerId` is who must submit `resolve_combat_round`. It may be the *non-active*
+ * player (always so for `assign_matchups`), so the active-player gate in
  * `apply-action.ts` admits the prompt's decider as a special case.
  *
- * `atkRolls` / `defRolls` are the participating units' revealed rolls for
- * `round` — the greedily-selected top `min` of each side's *living* units this
- * round. Excess units on the larger side sit out lowest-power-first (the
- * auto-resolve default; #167 hands that sit-out choice to the larger side).
- * Both lists therefore have equal length, and the defender assigns a bijection
- * between them. Plain `CombatSide` data (no live unit refs) so it survives the
- * `produce()` suspend boundary.
+ * Plain `CombatSide` data (no live unit refs) so it survives the `produce()`
+ * suspend boundary.
  */
 export interface CombatPrompt extends CombatLoopState {
-  /** Player expected to submit `resolve_combat_round` (the defender). */
+  /** Which decision this suspend is awaiting (see type doc). */
+  kind: CombatDecision["kind"];
+  /** Player expected to submit `resolve_combat_round`. */
   playerId: string;
-  /** Revealed rolls of the participating attacker units for `round`. */
+  /** Revealed rolls of the attacker units for `round` (full living set for
+   *  `sit_out`; equal-length participants for `assign_matchups`). */
   atkRolls: CombatSide[];
-  /** Revealed rolls of the participating defender units for `round`. */
+  /** Revealed rolls of the defender units for `round` (see `atkRolls`). */
   defRolls: CombatSide[];
 }
 
@@ -670,11 +679,23 @@ export interface CombatMatchup {
  * in later without a flat bag of optional fields — a retreat payload cannot then
  * structurally carry matchup data.
  */
-export type CombatDecision = {
-  kind: "assign_matchups";
-  /** A bijection over the prompt's participating units; length = min(sides). */
-  pairs: CombatMatchup[];
-};
+export type CombatDecision =
+  | {
+      kind: "assign_matchups";
+      /** A bijection over the prompt's participating units; length = min(sides). */
+      pairs: CombatMatchup[];
+    }
+  | {
+      kind: "sit_out";
+      /**
+       * The excess units the larger side removes this round (#167). Length must
+       * equal `max(sides) - min(sides)`, and every id must be on the larger side
+       * (the prompt's longer roll list). Removing them leaves equal-length
+       * participants, which then either auto-resolve or trigger a matchup
+       * decision (the 3v2 double-suspend case).
+       */
+      sitOutUnitIds: string[];
+    };
 
 /**
  * Submitted to resume a combat suspended for a player decision (pending

--- a/engine/src/valid-actions.ts
+++ b/engine/src/valid-actions.ts
@@ -143,25 +143,46 @@ export function needsLocationTarget(card: EventCard): boolean {
 }
 
 /**
- * Every matchup the defender may assign, as complete `resolve_combat_round`
- * actions — one per bijection between the equal-length participant lists.
- * Enumerated by permuting the defenders against the fixed attacker order
- * (mirrors `scholar_reorder`'s full-permutation enumeration), so consumers that
- * treat `getValidActions` as the exhaustive action space (bots, search) can
- * explore non-greedy pairings, not just the default. The lists are stored
- * highest-power-first, so the identity permutation — element `[0]` — is the
- * greedy highest-vs-highest auto-resolve default a bot can submit as-is.
+ * Every legal `resolve_combat_round` action for the pending prompt, branching on
+ * its `kind`. Consumers that treat `getValidActions` as the exhaustive action
+ * space (bots, search) get all choices; element `[0]` is always the greedy
+ * auto-resolve default a bot can submit as-is.
  *
- * Count is `n!` where `n = min(sides)` participants (the smaller side). This is
- * bounded in practice by how many units realistically stack and fight in one
- * cell — a handful — so it stays small; a pathologically large stack (n ≥ 8)
- * would make this enumeration expensive. If unit stacks can grow that large,
+ * - `sit_out` (#167): every way the larger side can drop its `max - min` excess
+ *   units, as `C(max, max-min)` combinations. Ordered so `[0]` is the greedy
+ *   lowest-power default (the larger side's rolls are enumerated power-ascending,
+ *   so the first combination is the weakest `excess` units).
+ * - `assign_matchups` (#166): every bijection between the equal-length
+ *   participant lists — `n!` permutations of the defenders against the fixed
+ *   attacker order (mirrors `scholar_reorder`). The lists are stored
+ *   highest-power-first, so the identity permutation `[0]` is the greedy
+ *   highest-vs-highest default.
+ *
+ * Both counts are bounded in practice by how many units realistically stack and
+ * fight in one cell — a handful — so they stay small; a pathologically large
+ * stack would make either enumeration expensive. If stacks can grow that large,
  * switch to lazily surfacing only the greedy default here.
  */
 function buildCombatResolutions(
   prompt: CombatPrompt,
   playerId: string,
 ): ResolveCombatRoundAction[] {
+  if (prompt.kind === "sit_out") {
+    const attackerLarger: boolean = prompt.atkRolls.length > prompt.defRolls.length;
+    const largerRolls = attackerLarger ? prompt.atkRolls : prompt.defRolls;
+    const excess: number = Math.abs(prompt.atkRolls.length - prompt.defRolls.length);
+    // Ascending power → the first size-`excess` subset is the weakest units,
+    // making element `[0]` the greedy lowest-power sit-out default.
+    const idsByPowerAsc: string[] = [...largerRolls]
+      .sort((a, b) => a.power - b.power)
+      .map((s) => s.unitId);
+    return subsetsOfSize(idsByPowerAsc, excess).map((sitOutUnitIds) => ({
+      type: "resolve_combat_round",
+      playerId,
+      decision: { kind: "sit_out", sitOutUnitIds },
+    }));
+  }
+
   const attackerIds: readonly string[] = prompt.atkRolls.map((s) => s.unitId);
   const defenderIds: readonly string[] = prompt.defRolls.map((s) => s.unitId);
   return permutationsOf(defenderIds).map((perm) => ({


### PR DESCRIPTION
## Summary

Let the side with **more committed units choose which excess units sit out**, after rolls are revealed — replacing the implicit `min(count)` truncation that silently dropped the lowest-power excess. Extends the #165 suspension hook and #166's `resolve_combat_round` decision machinery.

## Implementation

**Engine**
- `types.ts` — added `kind:"sit_out"` to the `CombatDecision` union, and a `kind` discriminator to `CombatPrompt`. A `sit_out` prompt carries the **full, unequal** roll lists (that's what makes the choice exist); an `assign_matchups` prompt carries the equal-length participants as before.
- `apply-main.ts` — factored the post-roll round into `processRolledRound` + `resolveOrSuspendMatchup`, shared by the fresh-round path and the sit-out resume. A single round can now suspend **twice** (sit-out → matchup) before resolving, resuming within the same round until pairs resolve, then advancing to `round+1`. `handleResolveCombatRound` dispatches on decision kind; `resolveSitOut` validates the chosen units are on the larger side, distinct, and exactly `max-min`. rng is persisted once after rolling (resolution consumes no randomness), keeping the roll stream unbroken across both suspends.
- `valid-actions.ts` — `buildCombatResolutions` enumerates sit-out combinations (`C(max, max-min)`, greedy lowest-power default at `[0]`) alongside the existing matchup permutations.

**Client**
- `CombatPromptOverlay.svelte` switches on `prompt.kind`: a sit-out prompt renders a picker over the larger side's units (toggle exactly `max-min`, seeded to the greedy lowest-power default) dispatching a `sit_out` decision; the matchup UI is unchanged. `App.svelte` wiring is untouched.

## Decision ordering (the subtlety)

A side can have both excess *and* a downstream matchup choice — e.g. **3 attackers vs 2 defenders**: sit-out drops 1 attacker → 2v2 → then a matchup decision. Sit-out resolves first, then the round re-evaluates for a matchup, so the suspension point fires twice in one round (sit-out → resolve → matchup → resolve → pairs). Covered by a dedicated double-suspend test.

## Tests
- New `#167` engine suite: larger (attacking) side picks sit-outs and the remainder resolves; validation rejects wrong count / non-excess units; the 3v2 double-suspend fires both decisions in one round.
- Converted the two unequal-side auto-resolve cases (1v3, 2v1) to drive the sit-out prompt; drop-out / round-cap tests now drive the prompt via a helper (pinned semantics unchanged).
- `bun test` engine suite green (596); engine `tsc` and client `svelte-check` clean.

## Depends on
- #165 (mid-combat suspension) and #166 (defender-assigned matchups) — both MERGED. Part of the #164 combat tree.

Closes #167
