### PR TITLE
168: Engine + client: per-round combat retreat

### DIFF
--- a/clients/web/src/components/CombatPromptOverlay.svelte
+++ b/clients/web/src/components/CombatPromptOverlay.svelte
@@ -12,6 +12,18 @@
   const vs = $derived(getVisibleState());
   const prompt = $derived(vs?.combatPrompt);
   const isSitOut = $derived(prompt?.kind === "sit_out");
+  const isRetreat = $derived(prompt?.kind === "retreat");
+
+  // The units the deciding side would pull back on a retreat (#168). A retreat
+  // prompt is blind (raised before the round rolls), so its sides carry identity
+  // and strength but no dice — shown without a roll line.
+  const retreatingSide = $derived<CombatSide[]>(
+    !prompt
+      ? []
+      : prompt.playerId === prompt.attackerId
+        ? prompt.atkRolls
+        : prompt.defRolls,
+  );
 
   function signed(delta: number): string {
     return delta >= 0 ? `+${delta}` : `${delta}`;
@@ -56,6 +68,10 @@
     if (!prompt) return;
     void prompt.atkRolls.map((r) => r.unitId).join(",");
     submitted = false;
+
+    // Retreat is a blind all-or-nothing choice — no seeding, and its side lists
+    // can differ in length (both sides' survivors), so skip the matchup checks.
+    if (prompt.kind === "retreat") return;
 
     if (prompt.kind === "sit_out") {
       // Greedy default: the lowest-power `excess` units on the larger side.
@@ -124,6 +140,19 @@
     }
   }
 
+  // Retreat (#168): all-or-nothing, so submit directly from the chosen button
+  // rather than via the shared confirm gate.
+  function submitRetreat(retreat: boolean): void {
+    if (!prompt || submitted) return;
+    errorAtSubmit = error;
+    submitted = true;
+    selectAction({
+      type: "resolve_combat_round",
+      playerId: prompt.playerId,
+      decision: { kind: "retreat", retreat },
+    });
+  }
+
   function confirm(): void {
     if (!prompt || submitted || !canConfirm) return;
     errorAtSubmit = error;
@@ -175,9 +204,55 @@
   {@const defenderName = resolvePlayerName(prompt.defenderId)}
   {@const attackerName = resolvePlayerName(prompt.attackerId)}
   <Modal width="w-auto max-w-2xl">
-    {#if isSitOut}
+    {#if isRetreat}
       {@const deciderName = resolvePlayerName(prompt.playerId)}
-      {@const smallerRolls = attackerLarger ? prompt.defRolls : prompt.atkRolls}
+      <h3 class="mb-1 text-center text-lg font-bold text-text-primary">
+        Retreat to HQ — before round {prompt.round + 1}
+      </h3>
+      <p class="mb-4 text-center text-sm text-text-muted">
+        {deciderName} may pull all {retreatingSide.length} remaining unit{retreatingSide.length ===
+        1
+          ? ""
+          : "s"} back to HQ. Retreating units leave this combat and heal at HQ; the
+        opponent holds the location.
+      </p>
+
+      <div class="mb-4 space-y-2">
+        {#each retreatingSide as side (side.unitId)}
+          <div class="rounded border border-border bg-surface p-2">
+            <div class="flex flex-wrap items-center gap-1 text-xs text-text-secondary">
+              <span class="font-semibold text-text-primary">{resolveCardName(side.unitId)}</span>
+              <span class="font-mono">strength {side.baseStrength}</span>
+              {#if side.injuredBefore}
+                <span class="rounded bg-surface px-1.5 py-0.5 font-mono text-error">injured</span>
+              {/if}
+            </div>
+          </div>
+        {/each}
+      </div>
+
+      <div class="flex gap-2">
+        <button
+          type="button"
+          onclick={() => submitRetreat(false)}
+          disabled={submitted}
+          class="flex-1 rounded border border-border bg-surface-raised py-2 font-semibold text-text-primary hover:bg-surface disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {submitted ? "…" : "Stay and fight"}
+        </button>
+        <button
+          type="button"
+          onclick={() => submitRetreat(true)}
+          disabled={submitted}
+          class="flex-1 rounded bg-amber-600 py-2 font-semibold text-white hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {submitted ? "Retreating…" : "Retreat all to HQ"}
+        </button>
+      </div>
+    {:else}
+      {#if isSitOut}
+        {@const deciderName = resolvePlayerName(prompt.playerId)}
+        {@const smallerRolls = attackerLarger ? prompt.defRolls : prompt.atkRolls}
       <h3 class="mb-1 text-center text-lg font-bold text-text-primary">
         Choose units to sit out — round {prompt.round + 1}
       </h3>
@@ -260,5 +335,6 @@
     >
       {submitted ? "Resolving…" : isSitOut ? "Confirm sit-out" : "Confirm matchups"}
     </button>
+    {/if}
   </Modal>
 {/if}

--- a/clients/web/src/components/CombatPromptOverlay.svelte
+++ b/clients/web/src/components/CombatPromptOverlay.svelte
@@ -201,14 +201,12 @@
     {#if isRetreat}
       {@const deciderName = resolvePlayerName(prompt.playerId)}
       <h3 class="mb-1 text-center text-lg font-bold text-text-primary">
-        Retreat to HQ — before round {prompt.round + 1}
+        Retreat to HQ, or fight on?
       </h3>
       <p class="mb-4 text-center text-sm text-text-muted">
-        {deciderName} may pull all {retreatingSide.length} remaining unit{retreatingSide.length ===
-        1
-          ? ""
-          : "s"} back to HQ. Retreating units leave this combat and heal at HQ; the
-        opponent wins this combat.
+        Before round {prompt.round + 1} rolls, {deciderName} may pull all {retreatingSide.length}
+        remaining unit{retreatingSide.length === 1 ? "" : "s"} back to HQ, or stay and fight the
+        round. Retreating units leave this combat and heal at HQ; the opponent wins this combat.
       </p>
 
       <div class="mb-4 space-y-2">

--- a/clients/web/src/components/CombatPromptOverlay.svelte
+++ b/clients/web/src/components/CombatPromptOverlay.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { CombatSide } from "cards-engine";
+  import type { CombatSide, RetreatUnitDisplay } from "cards-engine";
   import {
     getError,
     getVisibleState,
@@ -15,15 +15,9 @@
   const isRetreat = $derived(prompt?.kind === "retreat");
 
   // The units the deciding side would pull back on a retreat (#168). A retreat
-  // prompt is blind (raised before the round rolls), so its sides carry identity
-  // and strength but no dice — shown without a roll line.
-  const retreatingSide = $derived<CombatSide[]>(
-    !prompt
-      ? []
-      : prompt.playerId === prompt.attackerId
-        ? prompt.atkRolls
-        : prompt.defRolls,
-  );
+  // prompt is blind (raised before the round rolls), so it carries identity,
+  // strength, and injured status but no dice — shown without a roll line.
+  const retreatingSide = $derived<readonly RetreatUnitDisplay[]>(prompt?.retreatUnits ?? []);
 
   function signed(delta: number): string {
     return delta >= 0 ? `+${delta}` : `${delta}`;
@@ -53,7 +47,7 @@
   const attackerLarger = $derived(
     !!prompt && prompt.atkRolls.length > prompt.defRolls.length,
   );
-  const largerRolls = $derived<CombatSide[]>(
+  const largerRolls = $derived<readonly CombatSide[]>(
     !prompt ? [] : attackerLarger ? prompt.atkRolls : prompt.defRolls,
   );
   const excess = $derived(
@@ -214,7 +208,7 @@
         1
           ? ""
           : "s"} back to HQ. Retreating units leave this combat and heal at HQ; the
-        opponent holds the location.
+        opponent wins this combat.
       </p>
 
       <div class="mb-4 space-y-2">
@@ -222,8 +216,8 @@
           <div class="rounded border border-border bg-surface p-2">
             <div class="flex flex-wrap items-center gap-1 text-xs text-text-secondary">
               <span class="font-semibold text-text-primary">{resolveCardName(side.unitId)}</span>
-              <span class="font-mono">strength {side.baseStrength}</span>
-              {#if side.injuredBefore}
+              <span class="font-mono">strength {side.strength}</span>
+              {#if side.injured}
                 <span class="rounded bg-surface px-1.5 py-0.5 font-mono text-error">injured</span>
               {/if}
             </div>

--- a/clients/web/src/components/ContestResultPopup.svelte
+++ b/clients/web/src/components/ContestResultPopup.svelte
@@ -5,26 +5,13 @@
     type ContestResult,
     type PairSideView,
   } from "../lib/gameStore.svelte";
-  import { buildDialogView, type ContestOutcome, type DialogView } from "../lib/contestResult";
+  import { buildDialogView, outcomeSide, type DialogView } from "../lib/contestResult";
   import Modal from "./Modal.svelte";
 
   const result: ContestResult | null = $derived(getContestResult());
 
   function signed(delta: number): string {
     return delta >= 0 ? `+${delta}` : `${delta}`;
-  }
-
-  // Which player owns the unit in an outcome, so the row can align to that side
-  // (attacker/Player 1 → left, defender/Player 2 → right). Compares player ids
-  // (not display names, which can collide). Only combat results carry the side
-  // ids and the multi-pair layout this mirrors.
-  function outcomeSide(outcome: ContestOutcome): "attacker" | "defender" | null {
-    if (!result || result.source !== "combat") return null;
-    if (outcome.type === "injured" || outcome.type === "killed") {
-      if (outcome.ownerId === result.attackerId) return "attacker";
-      if (outcome.ownerId === result.defenderId) return "defender";
-    }
-    return null;
   }
 
   const view: DialogView | null = $derived(result ? buildDialogView(result) : null);
@@ -96,7 +83,7 @@
     {#if result.outcomes.length > 0}
       <div class="mb-4 space-y-1">
         {#each result.outcomes as outcome}
-          {@const side = outcomeSide(outcome)}
+          {@const side = outcomeSide(result, outcome)}
           <div
             class="flex w-fit max-w-[90%] items-center gap-2 rounded bg-surface-raised px-3 py-1.5 text-sm {side ===
             'defender'

--- a/clients/web/src/components/ContestResultPopup.svelte
+++ b/clients/web/src/components/ContestResultPopup.svelte
@@ -132,6 +132,12 @@
       <p class="mb-4 text-center text-sm text-text-muted">{view.emptyOutcomesMsg}</p>
     {/if}
 
+    {#if result.source === "combat" && result.retreatedName}
+      <p class="mb-4 text-center text-sm font-semibold text-text-secondary">
+        🏳️ {result.retreatedName} retreated to HQ
+      </p>
+    {/if}
+
     {#if result.winnerName}
       <div class="mb-4 text-center text-sm font-semibold">
         <span class="text-highlight">

--- a/clients/web/src/lib/__tests__/contestResult.test.ts
+++ b/clients/web/src/lib/__tests__/contestResult.test.ts
@@ -4,8 +4,10 @@ import {
   buildDialogView,
   buildPairDetail,
   buildPairDetailFromContest,
+  outcomeSide,
   stepCombatBuffer,
   type CombatPairResolved,
+  type ContestOutcome,
   type ContestResolved,
   type ContestResult,
 } from "../contestResult";
@@ -212,6 +214,8 @@ describe("buildDialogView", () => {
       locationName: "Palace",
       attackerName: "Cleopatra-owner",
       defenderName: "Tank-owner",
+      attackerId: "p1",
+      defenderId: "p2",
       pairs: [],
       outcomes: [],
       winnerName: "Cleopatra-owner",
@@ -246,5 +250,45 @@ describe("buildDialogView", () => {
   it("dsl cunning contest capitalizes stat in title", () => {
     const view = buildDialogView(dslResult({ stat: "cunning" }));
     expect(view.title).toBe("Cunning contest at Palace");
+  });
+});
+
+describe("outcomeSide", () => {
+  const base = {
+    stat: "strength" as const,
+    row: 0, col: 0,
+    locationName: "X",
+    attackerName: "A", defenderName: "B",
+    attackerId: "p1", defenderId: "p2",
+    pairs: [],
+    outcomes: [],
+  };
+  const combat: ContestResult = { source: "combat", ...base, winnerName: null, retreatedName: null };
+  const dsl: ContestResult = { source: "dsl", ...base, winnerName: "A" };
+  const injured = (ownerId: string): ContestOutcome => ({ type: "injured", unitName: "u", ownerName: "o", ownerId });
+
+  it("combat: aligns injured/killed to the owning side, null for an outsider", () => {
+    expect(outcomeSide(combat, injured("p1"))).toBe("attacker");
+    expect(outcomeSide(combat, injured("p2"))).toBe("defender");
+    expect(outcomeSide(combat, { type: "killed", unitName: "u", ownerName: "o", ownerId: "p1" })).toBe("attacker");
+    expect(outcomeSide(combat, injured("p3"))).toBeNull();
+  });
+
+  it("dsl: aligns injured/killed to the owning side too (regression — was always left)", () => {
+    // A DSL contest's defender-owned injury must align right, not fall through to
+    // the left default (the bug: outcomeSide used to bail for source !== 'combat').
+    expect(outcomeSide(dsl, injured("p2"))).toBe("defender");
+    expect(outcomeSide(dsl, injured("p1"))).toBe("attacker");
+  });
+
+  it("controlled outcomes belong to no side", () => {
+    const controlled: ContestOutcome = {
+      type: "controlled",
+      unitName: "u",
+      previousControllerName: "a",
+      newControllerName: "b",
+      durationTurns: 1,
+    };
+    expect(outcomeSide(dsl, controlled)).toBeNull();
   });
 });

--- a/clients/web/src/lib/__tests__/contestResult.test.ts
+++ b/clients/web/src/lib/__tests__/contestResult.test.ts
@@ -73,7 +73,7 @@ describe("buildPairDetail", () => {
 
 describe("stepCombatBuffer", () => {
   const started: GameEvent = { type: "combat_started", row: 0, col: 0, attackerId: "p1", defenderId: "p2" };
-  const resolved: GameEvent = { type: "combat_resolved", row: 0, col: 0, winnerId: "p1" };
+  const resolved: GameEvent = { type: "combat_resolved", row: 0, col: 0, winnerId: "p1", attackerId: "p1", defenderId: "p2" };
   const pair: GameEvent = makeEvent("kill_defender");
   const injured: GameEvent = { type: "unit_injured", unitId: "def", controllerId: "p2" };
   const unrelated: GameEvent = { type: "turn_started", playerId: "p1", round: 1 };
@@ -135,7 +135,7 @@ describe("stepCombatBuffer", () => {
   it("a fresh combat_started discards a stale non-empty buffer (no cross-fight leak)", () => {
     const started2: GameEvent = { type: "combat_started", row: 1, col: 1, attackerId: "p2", defenderId: "p1" };
     const pair2: GameEvent = makeEvent("kill_attacker");
-    const resolved2: GameEvent = { type: "combat_resolved", row: 1, col: 1, winnerId: "p2" };
+    const resolved2: GameEvent = { type: "combat_resolved", row: 1, col: 1, winnerId: "p2", attackerId: "p2", defenderId: "p1" };
     // Previous fight left [started, pair] buffered; a new atomic fight arrives.
     const step = stepCombatBuffer([started, pair], [started2, pair2, resolved2]);
     expect(step.outcome.kind).toBe("complete");

--- a/clients/web/src/lib/__tests__/contestResult.test.ts
+++ b/clients/web/src/lib/__tests__/contestResult.test.ts
@@ -115,6 +115,16 @@ describe("stepCombatBuffer", () => {
     expect(step.outcome.kind).toBe("orphan");
   });
 
+  it("a resume that ends via retreat carries the combat_retreated event into the dialog", () => {
+    const retreated: GameEvent = { type: "combat_retreated", row: 0, col: 0, playerId: "p1" };
+    // Round 0 rolled and suspended; the retreat batch resolves the fight.
+    const step = stepCombatBuffer([started, pair], [retreated, resolved]);
+    expect(step.outcome.kind).toBe("complete");
+    if (step.outcome.kind !== "complete") return;
+    expect(step.outcome.dialogEvents).toEqual([started, pair, retreated, resolved]);
+    expect(step.buffer).toEqual([]);
+  });
+
   it("a batch with no combat activity is 'none' and leaves the buffer untouched", () => {
     expect(stepCombatBuffer([], [unrelated]).outcome.kind).toBe("none");
     expect(stepCombatBuffer([started], [unrelated]).buffer).toEqual([started]);
@@ -190,6 +200,7 @@ describe("buildDialogView", () => {
       pairs: [],
       outcomes: [],
       winnerName: null,
+      retreatedName: null,
       ...overrides,
     };
   }
@@ -213,6 +224,11 @@ describe("buildDialogView", () => {
     expect(view.title).toBe("Combat at Marketplace");
     expect(view.showPairCaption).toBe(true);
     expect(view.emptyOutcomesMsg).toBe("No casualties — draw!");
+  });
+
+  it("combat with a retreat suppresses the no-casualties draw copy", () => {
+    const view = buildDialogView(combatResult({ retreatedName: "Alice", winnerName: "Bob" }));
+    expect(view.emptyOutcomesMsg).toBe(null);
   });
 
   it("dsl with winner → '{Stat} contest at {loc}' title, no caption, null empty-msg (footer carries it)", () => {

--- a/clients/web/src/lib/__tests__/eventDescriptions.test.ts
+++ b/clients/web/src/lib/__tests__/eventDescriptions.test.ts
@@ -229,6 +229,17 @@ describe("describeEvent", () => {
       expect(categorizeEvent(event, "p1")).toBe("player");
       expect(categorizeEvent(event, "p2")).toBe("opponent");
     });
+
+    it("routes combat_resolved by attackerId — keeps the winner line out of the hidden System bucket", () => {
+      const event: GameEvent = {
+        type: "combat_resolved",
+        row: 0, col: 0,
+        winnerId: "p2",
+        attackerId: "p1", defenderId: "p2",
+      };
+      expect(categorizeEvent(event, "p1")).toBe("player");
+      expect(categorizeEvent(event, "p2")).toBe("opponent");
+    });
   });
 
   describe("card_drawn", () => {

--- a/clients/web/src/lib/contestResult.ts
+++ b/clients/web/src/lib/contestResult.ts
@@ -93,6 +93,10 @@ export type ContestResult =
       locationName: string;
       attackerName: string;
       defenderName: string;
+      /** Player ids for the two sides (caster / target's controller), so outcome
+       *  rows align to the owning side — same contract as the combat arm. */
+      attackerId: string;
+      defenderId: string;
       pairs: PairDetail[];
       outcomes: ContestOutcome[];
       winnerName: string;
@@ -209,6 +213,23 @@ export function buildDialogView(result: ContestResult): DialogView {
     // win/lose effect land here.
     emptyOutcomesMsg: result.winnerName ? null : "No effect.",
   };
+}
+
+/** Which side an outcome row belongs to, so the popup can align it (attacker →
+ *  left, defender → right). Both result sources carry `attackerId`/`defenderId`
+ *  (combat: the two players; DSL: caster / target's controller), so injured and
+ *  killed rows align by owner for either. `controlled` and any owner that matches
+ *  neither side return `null` (centered/left default). Pure so it's testable
+ *  without the component. */
+export function outcomeSide(
+  result: ContestResult,
+  outcome: ContestOutcome,
+): "attacker" | "defender" | null {
+  if (outcome.type === "injured" || outcome.type === "killed") {
+    if (outcome.ownerId === result.attackerId) return "attacker";
+    if (outcome.ownerId === result.defenderId) return "defender";
+  }
+  return null;
 }
 
 /** Factory result. `result` is non-null on success; `error` is non-null on
@@ -408,14 +429,17 @@ export function buildDslContestResult(
 
   // Guard against same-batch controller swaps changing the defender's owner
   // before our lookup — scan PRECEDING events for a unit_controlled on the
-  // defender; if found, use the previousControllerId from that event.
-  let safeDefenderOwnerName = defenderOwnerName;
+  // defender; if found, use the previousControllerId from that event. Track the
+  // id (not just the name) so the result's `defenderId` aligns outcome rows to
+  // the same owner the name shows.
+  let safeDefenderOwnerId = defenderUnit.controllerId;
   for (let i = 0; i < contestIdx; i++) {
     const e = events[i];
     if (e.type === "unit_controlled" && e.unitId === contestEvent.defenderId) {
-      safeDefenderOwnerName = resolvers.player(e.previousControllerId);
+      safeDefenderOwnerId = e.previousControllerId;
     }
   }
+  const safeDefenderOwnerName = resolvers.player(safeDefenderOwnerId);
   if (safeDefenderOwnerName !== defenderOwnerName) {
     detail.defender.ownerName = safeDefenderOwnerName;
   }
@@ -430,6 +454,8 @@ export function buildDslContestResult(
       locationName: attackerCell?.location?.name ?? `(${attackerLoc.row},${attackerLoc.col})`,
       attackerName: detail.attacker.ownerName,
       defenderName: detail.defender.ownerName,
+      attackerId: contestEvent.casterPlayerId,
+      defenderId: safeDefenderOwnerId,
       pairs: [detail],
       outcomes: contestOutcomes,
       winnerName: detail.winnerSide === "attacker"

--- a/clients/web/src/lib/contestResult.ts
+++ b/clients/web/src/lib/contestResult.ts
@@ -81,6 +81,9 @@ export type ContestResult =
       pairs: PairDetail[];
       outcomes: CombatOutcome[];
       winnerName: string | null;
+      /** Name of the side that retreated its whole force to HQ (#168), or `null`
+       *  if the combat was decided by dice. Drives the retreat line in the dialog. */
+      retreatedName: string | null;
     }
   | {
       source: "dsl";
@@ -191,7 +194,9 @@ export function buildDialogView(result: ContestResult): DialogView {
     return {
       title: `Combat at ${result.locationName}`,
       showPairCaption: true,
-      emptyOutcomesMsg: "No casualties — draw!",
+      // A retreat is not a draw — its own line plus the winner footer describe it,
+      // so suppress the no-casualties message when a side withdrew.
+      emptyOutcomesMsg: result.retreatedName ? null : "No casualties — draw!",
     };
   }
   return {
@@ -220,6 +225,7 @@ const COMBAT_DIALOG_EVENT_TYPES: ReadonlySet<GameEvent["type"]> = new Set([
   "combat_pair_resolved",
   "unit_injured",
   "unit_killed",
+  "combat_retreated",
   "combat_resolved",
 ]);
 
@@ -320,6 +326,7 @@ export function buildCombatContestResult(
     }
   }
 
+  const retreat = events.find((e) => e.type === "combat_retreated");
   const cell = visibleState?.grid[combatStart.row]?.[combatStart.col];
   return {
     result: {
@@ -336,6 +343,9 @@ export function buildCombatContestResult(
       outcomes,
       winnerName: combatEnd?.type === "combat_resolved" && combatEnd.winnerId
         ? resolvers.player(combatEnd.winnerId)
+        : null,
+      retreatedName: retreat?.type === "combat_retreated"
+        ? resolvers.player(retreat.playerId)
         : null,
     },
     error: errors.length > 0 ? errors.join("\n") : null,

--- a/clients/web/src/lib/eventDescriptions.ts
+++ b/clients/web/src/lib/eventDescriptions.ts
@@ -159,6 +159,8 @@ export function describeEvent(event: GameEvent, r?: NameResolvers): string {
       return `Combat at ${cell(event.row, event.col, r)}: ${p(event.attackerId, r)} vs ${p(event.defenderId, r)}`;
     case "combat_resolved":
       return `Combat resolved at ${cell(event.row, event.col, r)}: ${event.winnerId ? `winner ${p(event.winnerId, r)}` : "draw"}`;
+    case "combat_retreated":
+      return `${p(event.playerId, r)} retreated to HQ from ${cell(event.row, event.col, r)}`;
     case "combat_pair_resolved": {
       const left = formatCombatSide(event.attacker, r);
       const right = formatCombatSide(event.defender, r);

--- a/engine/src/__tests__/main-actions.test.ts
+++ b/engine/src/__tests__/main-actions.test.ts
@@ -428,12 +428,17 @@ describe("move", () => {
     expect((next as MainGameState).turn.actionPointsRemaining).toBe(1); // 3 - 2
   });
 
-  it("allows retreat to HQ from perimeter with open boundary edge", () => {
+  it("allows retreat to HQ from perimeter with open boundary edge, carrying equipped items", () => {
     const unit = makeUnit({ ownerId: ACTIVE });
+    // Equipped item exercises the shared `retreatUnitsToHQ` item-move loop on the
+    // Move-action (single-unit) path — the combat retreat covers it separately.
+    const sword = makeItem({ ownerId: ACTIVE, equippedTo: unit.id });
     const state = gameWith((d) => {
       d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
       d.grid[0][0].units.push(unit);
+      d.grid[0][0].items.push(sword);
     });
+    const apBefore = (state as MainGameState).turn.actionPointsRemaining;
 
     const { state: next } = applyAction(state, {
       type: "move",
@@ -445,7 +450,12 @@ describe("move", () => {
     const ns = next as MainGameState;
 
     expect(ns.grid[0][0].units).toHaveLength(0);
+    expect(ns.grid[0][0].items).toHaveLength(0);
     expect(ns.players[ACTIVE_IDX].hq.some((c) => c.id === unit.id)).toBe(true);
+    // The item travels to HQ with its unit.
+    expect(ns.players[ACTIVE_IDX].hq.some((c) => c.id === sword.id)).toBe(true);
+    // Unlike the combat retreat, the Move-action retreat costs 1 AP.
+    expect(ns.turn.actionPointsRemaining).toBe(apBefore - 1);
   });
 });
 
@@ -1609,6 +1619,7 @@ describe("per-round retreat (#168)", () => {
     state: MainGameState;
     events: GameEvent[];
     aWin: string;
+    aLose: string;
     dWin: string;
   } {
     const aWin = makeUnit({ ownerId: ACTIVE, strength: 100 });
@@ -1639,11 +1650,11 @@ describe("per-round retreat (#168)", () => {
         ],
       },
     });
-    return { state: afterRound0 as MainGameState, events, aWin: aWin.id, dWin: dWin.id };
+    return { state: afterRound0 as MainGameState, events, aWin: aWin.id, aLose: aLose.id, dWin: dWin.id };
   }
 
   it("offers retreat to the attacker before round 1 rolls, not at round 0", () => {
-    const { state, events, aWin, dWin } = reachRound1Retreat();
+    const { state, events, aWin } = reachRound1Retreat();
 
     // Round 0 resolved its two pairs; the round-1 fight has NOT been rolled yet.
     expect(events.filter((e) => e.type === "combat_pair_resolved")).toHaveLength(2);
@@ -1654,15 +1665,18 @@ describe("per-round retreat (#168)", () => {
     expect(state.combatPrompt?.playerId).toBe(ACTIVE);
     expect(state.combatPrompt?.round).toBe(1);
 
-    // Each side has exactly its one surviving unit, listed blind (no roll yet).
-    expect(state.combatPrompt?.atkRolls.map((s) => s.unitId)).toEqual([aWin]);
-    expect(state.combatPrompt?.defRolls.map((s) => s.unitId)).toEqual([dWin]);
-    expect(state.combatPrompt?.atkRolls[0].roll).toBe(0);
-    expect(state.combatPrompt?.defRolls[0].roll).toBe(0);
+    // The deciding side (attacker) lists its one surviving unit, blind — the
+    // slim retreat shape carries identity + strength + injured, no dice/power.
+    expect(state.combatPrompt?.retreatUnits?.map((s) => s.unitId)).toEqual([aWin]);
+    expect(state.combatPrompt?.retreatUnits?.[0].strength).toBe(100);
+    expect(state.combatPrompt?.retreatUnits?.[0].injured).toBe(false);
+    // A retreat prompt is pre-roll, so the rolled lists are empty.
+    expect(state.combatPrompt?.atkRolls).toEqual([]);
+    expect(state.combatPrompt?.defRolls).toEqual([]);
   });
 
   it("attacker retreat withdraws the side to HQ and hands the win to the defender", () => {
-    const { state: suspended, aWin, dWin } = reachRound1Retreat();
+    const { state: suspended, aWin, aLose, dWin } = reachRound1Retreat();
 
     const { state: next, events } = applyAction(suspended, {
       type: "resolve_combat_round",
@@ -1678,10 +1692,28 @@ describe("per-round retreat (#168)", () => {
     expect(ns.players[ACTIVE_IDX].hq.some((c) => c.id === aWin)).toBe(true);
     expect(ns.grid[0][0].units.some((u) => u.id === aWin)).toBe(false);
 
+    // aLose was committed but killed in round 0, so it is in `attackerUnitIds`
+    // yet no longer at the cell — `retreatUnitsToHQ` skips such ids rather than
+    // resurrecting them to HQ (it stays in the discard pile from its round-0 kill).
+    expect(ns.players[ACTIVE_IDX].hq.some((c) => c.id === aLose)).toBe(false);
+    expect(ns.players[ACTIVE_IDX].discardPile.some((c) => c.id === aLose)).toBe(true);
+
     // The defender stayed and holds the cell — and wins the combat.
     expect(ns.grid[0][0].units.some((u) => u.id === dWin)).toBe(true);
     const resolved = events.find((e) => e.type === "combat_resolved");
     expect(resolved && resolved.type === "combat_resolved" && resolved.winnerId).toBe(OTHER);
+
+    // The per-round combat retreat is a between-rounds decision, not a Move —
+    // it costs no AP (unlike the 1-AP Move-action retreat).
+    expect(ns.turn.actionPointsRemaining).toBe(suspended.turn.actionPointsRemaining);
+
+    // The withdrawal is surfaced as a to-HQ unit_moved (toRow/toCol === -1) for
+    // the sole surviving attacker (aLose died in round 0).
+    const toHq = events.filter(
+      (e) => e.type === "unit_moved" && e.toRow === -1 && e.toCol === -1,
+    );
+    expect(toHq).toHaveLength(1);
+    expect(toHq[0].type === "unit_moved" && toHq[0].unitId).toBe(aWin);
   });
 
   it("attacker declining hands the same choice to the defender (a second suspend)", () => {
@@ -1741,8 +1773,15 @@ describe("per-round retreat (#168)", () => {
     // The round-1 pair was rolled and resolved (proving no retreat re-offer loop),
     // and combat reached a terminal state.
     expect(events.some((e) => e.type === "combat_pair_resolved")).toBe(true);
-    expect(events.some((e) => e.type === "combat_resolved")).toBe(true);
+    const resolved = events.find((e) => e.type === "combat_resolved");
+    expect(resolved).toBeDefined();
     expect(ns.combatPrompt).toBeUndefined();
+    // The two str-100 units injure exactly one side in round 1 (no 2x kill); the
+    // injured loser stays at the cell (drop-out, not removed), so BOTH sides still
+    // hold a unit there and the combat ends with no winner — deterministic
+    // regardless of which side rolled higher.
+    const winnerId = resolved?.type === "combat_resolved" ? resolved.winnerId : undefined;
+    expect(winnerId).toBeNull();
   });
 
   it("retreats every committed unit still at the cell — injured ones too, with their items", () => {
@@ -1783,6 +1822,13 @@ describe("per-round retreat (#168)", () => {
     // is still at the cell.
     expect(suspended.combatPrompt?.kind).toBe("retreat");
     expect(suspended.grid[0][0].units.some((u) => u.id === aInjured.id && u.injured)).toBe(true);
+
+    // The blind retreat list enumerates BOTH the healthy fighter and the injured
+    // survivor (injured units retreat too), the injured one flagged as such.
+    const listed = suspended.combatPrompt?.retreatUnits ?? [];
+    expect(listed.map((s) => s.unitId).sort()).toEqual([aHealthy.id, aInjured.id].sort());
+    expect(listed.find((s) => s.unitId === aInjured.id)?.injured).toBe(true);
+    expect(listed.find((s) => s.unitId === aHealthy.id)?.injured).toBe(false);
 
     const { state: next } = applyAction(suspended, {
       type: "resolve_combat_round",
@@ -1875,6 +1921,94 @@ describe("per-round retreat (#168)", () => {
 
     expect(ns.combatPrompt).toBeUndefined();
     expect(events.some((e) => e.type === "combat_resolved")).toBe(true);
+  });
+
+  it("re-offers retreat afresh at round 2 once both sides declined at round 1", () => {
+    // Reaching a round-2 retreat offer needs a healthy fighter on BOTH sides at
+    // the top of round 2 — so the settled-round marker must reset per round rather
+    // than suppressing all future offers. A 4v4 of two str-100/str-60 "keepers"
+    // per side plus two str-1 throwaways: round 0 kills every throwaway (keepers
+    // win their pairs and stay healthy), round 1 cross-pairs a str-100 keeper vs
+    // the enemy str-60 keeper (100 beats 60 without the 2x kill margin → injures),
+    // leaving one healthy keeper per side to face off at round 2. All outcomes are
+    // roll-independent (gaps > 6, kill margins strictly < or > 2x).
+    const aHi = makeUnit({ ownerId: ACTIVE, strength: 100 });
+    const aLo = makeUnit({ ownerId: ACTIVE, strength: 60 });
+    const aX1 = makeUnit({ ownerId: ACTIVE, strength: 1 });
+    const aX2 = makeUnit({ ownerId: ACTIVE, strength: 1 });
+    const dHi = makeUnit({ ownerId: OTHER, strength: 100 });
+    const dLo = makeUnit({ ownerId: OTHER, strength: 60 });
+    const dX1 = makeUnit({ ownerId: OTHER, strength: 1 });
+    const dX2 = makeUnit({ ownerId: OTHER, strength: 1 });
+    const start = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(aHi, aLo, aX1, aX2, dHi, dLo, dX1, dX2);
+    });
+
+    // Round 0: 4v4 → defender assigns matchups. Each keeper beats an enemy
+    // throwaway (killed); each throwaway is killed by an enemy keeper.
+    const { state: afterAttack } = applyAction(start, {
+      ...attackAction,
+      unitIds: [aHi.id, aLo.id, aX1.id, aX2.id],
+    });
+    const { state: afterRound0 } = applyAction(afterAttack as MainGameState, {
+      type: "resolve_combat_round",
+      playerId: OTHER,
+      decision: {
+        kind: "assign_matchups",
+        pairs: [
+          { attackerUnitId: aHi.id, defenderUnitId: dX1.id },
+          { attackerUnitId: aLo.id, defenderUnitId: dX2.id },
+          { attackerUnitId: aX1.id, defenderUnitId: dHi.id },
+          { attackerUnitId: aX2.id, defenderUnitId: dLo.id },
+        ],
+      },
+    });
+
+    // Round 1 retreat offer (attacker) — both sides now have two healthy keepers.
+    const round1Atk = afterRound0 as MainGameState;
+    expect(round1Atk.combatPrompt?.kind).toBe("retreat");
+    expect(round1Atk.combatPrompt?.round).toBe(1);
+
+    // Both decline → round 1 rolls → 2v2 → matchup suspend at round 1.
+    const { state: r1AtkDeclined } = applyAction(round1Atk, {
+      type: "resolve_combat_round",
+      playerId: ACTIVE,
+      decision: { kind: "retreat", retreat: false },
+    });
+    const { state: r1BothDeclined } = applyAction(r1AtkDeclined as MainGameState, {
+      type: "resolve_combat_round",
+      playerId: OTHER,
+      decision: { kind: "retreat", retreat: false },
+    });
+    const round1Matchup = r1BothDeclined as MainGameState;
+    expect(round1Matchup.combatPrompt?.kind).toBe("assign_matchups");
+    expect(round1Matchup.combatPrompt?.round).toBe(1);
+
+    // Cross-pair keepers so each side keeps exactly one healthy survivor.
+    const { state: afterRound1 } = applyAction(round1Matchup, {
+      type: "resolve_combat_round",
+      playerId: OTHER,
+      decision: {
+        kind: "assign_matchups",
+        pairs: [
+          { attackerUnitId: aHi.id, defenderUnitId: dLo.id },
+          { attackerUnitId: aLo.id, defenderUnitId: dHi.id },
+        ],
+      },
+    });
+    const round2Atk = afterRound1 as MainGameState;
+
+    // Round 2 raises a FRESH retreat offer (the round-1 settle did not leak).
+    expect(round2Atk.combatPrompt?.kind).toBe("retreat");
+    expect(round2Atk.combatPrompt?.round).toBe(2);
+    expect(round2Atk.combatPrompt?.playerId).toBe(ACTIVE);
+    // The list carries the healthy survivor AND the injured keeper (injured units
+    // retreat too), the injured one flagged.
+    const listed = round2Atk.combatPrompt?.retreatUnits ?? [];
+    expect(listed.map((s) => s.unitId).sort()).toEqual([aHi.id, aLo.id].sort());
+    expect(listed.find((s) => s.unitId === aHi.id)?.injured).toBe(false);
+    expect(listed.find((s) => s.unitId === aLo.id)?.injured).toBe(true);
   });
 });
 

--- a/engine/src/__tests__/main-actions.test.ts
+++ b/engine/src/__tests__/main-actions.test.ts
@@ -1703,6 +1703,10 @@ describe("per-round retreat (#168)", () => {
     const resolved = events.find((e) => e.type === "combat_resolved");
     expect(resolved && resolved.type === "combat_resolved" && resolved.winnerId).toBe(OTHER);
 
+    // The retreat is announced so the result dialog can name who withdrew.
+    const retreated = events.find((e) => e.type === "combat_retreated");
+    expect(retreated && retreated.type === "combat_retreated" && retreated.playerId).toBe(ACTIVE);
+
     // The per-round combat retreat is a between-rounds decision, not a Move —
     // it costs no AP (unlike the 1-AP Move-action retreat).
     expect(ns.turn.actionPointsRemaining).toBe(suspended.turn.actionPointsRemaining);
@@ -1753,6 +1757,10 @@ describe("per-round retreat (#168)", () => {
     expect(ns.grid[0][0].units.some((u) => u.id === aWin)).toBe(true);
     const resolved = events.find((e) => e.type === "combat_resolved");
     expect(resolved && resolved.type === "combat_resolved" && resolved.winnerId).toBe(ACTIVE);
+
+    // The retreating side (defender) is named in a combat_retreated event.
+    const retreated = events.find((e) => e.type === "combat_retreated");
+    expect(retreated && retreated.type === "combat_retreated" && retreated.playerId).toBe(OTHER);
   });
 
   it("both sides declining rolls the round instead of re-offering retreat", () => {

--- a/engine/src/__tests__/main-actions.test.ts
+++ b/engine/src/__tests__/main-actions.test.ts
@@ -1591,6 +1591,294 @@ describe("sit-out selection (#167)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// per-round retreat (#168)
+// ---------------------------------------------------------------------------
+
+describe("per-round retreat (#168)", () => {
+  const attackAction = { type: "attack" as const, playerId: ACTIVE, row: 0, col: 0 };
+
+  /**
+   * Reach the round-1 retreat offer. A 2v2 whose round 0 is cross-paired so each
+   * side's strong unit kills the other side's weak unit (100 vs 1 → always a
+   * kill), leaving one healthy unit per side to face off in round 1 — which is
+   * where the pre-roll retreat offer is raised (attacker first). Strength gaps
+   * make every outcome roll-independent, so the scenario is deterministic without
+   * pinning dice.
+   */
+  function reachRound1Retreat(): {
+    state: MainGameState;
+    events: GameEvent[];
+    aWin: string;
+    dWin: string;
+  } {
+    const aWin = makeUnit({ ownerId: ACTIVE, strength: 100 });
+    const aLose = makeUnit({ ownerId: ACTIVE, strength: 1 });
+    const dWin = makeUnit({ ownerId: OTHER, strength: 100 });
+    const dLose = makeUnit({ ownerId: OTHER, strength: 1 });
+    const start = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(aWin, aLose, dWin, dLose);
+    });
+
+    // Round 0: 2v2 → defender assigns matchups (no retreat is offered at round 0).
+    const { state: afterAttack } = applyAction(start, {
+      ...attackAction,
+      unitIds: [aWin.id, aLose.id],
+    });
+    const matchup = afterAttack as MainGameState;
+    expect(matchup.combatPrompt?.kind).toBe("assign_matchups");
+
+    const { state: afterRound0, events } = applyAction(matchup, {
+      type: "resolve_combat_round",
+      playerId: OTHER,
+      decision: {
+        kind: "assign_matchups",
+        pairs: [
+          { attackerUnitId: aWin.id, defenderUnitId: dLose.id },
+          { attackerUnitId: aLose.id, defenderUnitId: dWin.id },
+        ],
+      },
+    });
+    return { state: afterRound0 as MainGameState, events, aWin: aWin.id, dWin: dWin.id };
+  }
+
+  it("offers retreat to the attacker before round 1 rolls, not at round 0", () => {
+    const { state, events, aWin, dWin } = reachRound1Retreat();
+
+    // Round 0 resolved its two pairs; the round-1 fight has NOT been rolled yet.
+    expect(events.filter((e) => e.type === "combat_pair_resolved")).toHaveLength(2);
+    expect(events.some((e) => e.type === "combat_resolved")).toBe(false);
+
+    // Suspended for the attacker's retreat choice, at round 1, before the roll.
+    expect(state.combatPrompt?.kind).toBe("retreat");
+    expect(state.combatPrompt?.playerId).toBe(ACTIVE);
+    expect(state.combatPrompt?.round).toBe(1);
+
+    // Each side has exactly its one surviving unit, listed blind (no roll yet).
+    expect(state.combatPrompt?.atkRolls.map((s) => s.unitId)).toEqual([aWin]);
+    expect(state.combatPrompt?.defRolls.map((s) => s.unitId)).toEqual([dWin]);
+    expect(state.combatPrompt?.atkRolls[0].roll).toBe(0);
+    expect(state.combatPrompt?.defRolls[0].roll).toBe(0);
+  });
+
+  it("attacker retreat withdraws the side to HQ and hands the win to the defender", () => {
+    const { state: suspended, aWin, dWin } = reachRound1Retreat();
+
+    const { state: next, events } = applyAction(suspended, {
+      type: "resolve_combat_round",
+      playerId: ACTIVE,
+      decision: { kind: "retreat", retreat: true },
+    });
+    const ns = next as MainGameState;
+
+    // Combat over, no lingering prompt.
+    expect(ns.combatPrompt).toBeUndefined();
+
+    // The retreating attacker is back in its HQ, gone from the cell.
+    expect(ns.players[ACTIVE_IDX].hq.some((c) => c.id === aWin)).toBe(true);
+    expect(ns.grid[0][0].units.some((u) => u.id === aWin)).toBe(false);
+
+    // The defender stayed and holds the cell — and wins the combat.
+    expect(ns.grid[0][0].units.some((u) => u.id === dWin)).toBe(true);
+    const resolved = events.find((e) => e.type === "combat_resolved");
+    expect(resolved && resolved.type === "combat_resolved" && resolved.winnerId).toBe(OTHER);
+  });
+
+  it("attacker declining hands the same choice to the defender (a second suspend)", () => {
+    const { state: suspended } = reachRound1Retreat();
+
+    const { state: next } = applyAction(suspended, {
+      type: "resolve_combat_round",
+      playerId: ACTIVE,
+      decision: { kind: "retreat", retreat: false },
+    });
+    const ns = next as MainGameState;
+
+    // Same round, now the defender's retreat decision.
+    expect(ns.combatPrompt?.kind).toBe("retreat");
+    expect(ns.combatPrompt?.playerId).toBe(OTHER);
+    expect(ns.combatPrompt?.round).toBe(1);
+  });
+
+  it("defender retreat (after attacker stays) hands the win to the attacker", () => {
+    const { state: suspended, aWin, dWin } = reachRound1Retreat();
+
+    const { state: afterAtk } = applyAction(suspended, {
+      type: "resolve_combat_round",
+      playerId: ACTIVE,
+      decision: { kind: "retreat", retreat: false },
+    });
+    const { state: next, events } = applyAction(afterAtk as MainGameState, {
+      type: "resolve_combat_round",
+      playerId: OTHER,
+      decision: { kind: "retreat", retreat: true },
+    });
+    const ns = next as MainGameState;
+
+    expect(ns.combatPrompt).toBeUndefined();
+    expect(ns.players[OTHER_IDX].hq.some((c) => c.id === dWin)).toBe(true);
+    expect(ns.grid[0][0].units.some((u) => u.id === dWin)).toBe(false);
+    expect(ns.grid[0][0].units.some((u) => u.id === aWin)).toBe(true);
+    const resolved = events.find((e) => e.type === "combat_resolved");
+    expect(resolved && resolved.type === "combat_resolved" && resolved.winnerId).toBe(ACTIVE);
+  });
+
+  it("both sides declining rolls the round instead of re-offering retreat", () => {
+    const { state: suspended } = reachRound1Retreat();
+
+    const { state: afterAtk } = applyAction(suspended, {
+      type: "resolve_combat_round",
+      playerId: ACTIVE,
+      decision: { kind: "retreat", retreat: false },
+    });
+    const { state: next, events } = applyAction(afterAtk as MainGameState, {
+      type: "resolve_combat_round",
+      playerId: OTHER,
+      decision: { kind: "retreat", retreat: false },
+    });
+    const ns = next as MainGameState;
+
+    // The round-1 pair was rolled and resolved (proving no retreat re-offer loop),
+    // and combat reached a terminal state.
+    expect(events.some((e) => e.type === "combat_pair_resolved")).toBe(true);
+    expect(events.some((e) => e.type === "combat_resolved")).toBe(true);
+    expect(ns.combatPrompt).toBeUndefined();
+  });
+
+  it("retreats every committed unit still at the cell — injured ones too, with their items", () => {
+    // Round 0 cross-pairing: the attacker keeps a healthy unit AND an injured one
+    // (str 11 loses to str 17 but never by the 2x kill margin, so it survives
+    // injured), while the defender keeps a healthy unit. All roll-independent.
+    const aHealthy = makeUnit({ ownerId: ACTIVE, strength: 100 });
+    const aInjured = makeUnit({ ownerId: ACTIVE, strength: 11 });
+    const dDies = makeUnit({ ownerId: OTHER, strength: 1 });
+    const dStrong = makeUnit({ ownerId: OTHER, strength: 17 });
+    // Equipped to the healthy survivor: an injured unit drops its items in combat
+    // (dropEquippedItems), so only a still-equipped unit carries gear on retreat.
+    const sword = makeItem({ ownerId: ACTIVE, equippedTo: aHealthy.id });
+    const start = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(aHealthy, aInjured, dStrong, dDies);
+      d.grid[0][0].items.push(sword);
+    });
+
+    const { state: afterAttack } = applyAction(start, {
+      ...attackAction,
+      unitIds: [aHealthy.id, aInjured.id],
+    });
+    const { state: afterRound0 } = applyAction(afterAttack as MainGameState, {
+      type: "resolve_combat_round",
+      playerId: OTHER,
+      decision: {
+        kind: "assign_matchups",
+        pairs: [
+          { attackerUnitId: aHealthy.id, defenderUnitId: dDies.id },
+          { attackerUnitId: aInjured.id, defenderUnitId: dStrong.id },
+        ],
+      },
+    });
+    const suspended = afterRound0 as MainGameState;
+
+    // Round 1 retreat offer: only the healthy attacker fights, but the injured one
+    // is still at the cell.
+    expect(suspended.combatPrompt?.kind).toBe("retreat");
+    expect(suspended.grid[0][0].units.some((u) => u.id === aInjured.id && u.injured)).toBe(true);
+
+    const { state: next } = applyAction(suspended, {
+      type: "resolve_combat_round",
+      playerId: ACTIVE,
+      decision: { kind: "retreat", retreat: true },
+    });
+    const ns = next as MainGameState;
+    const hq = ns.players[ACTIVE_IDX].hq;
+
+    // Both attacker units — healthy and injured — retreated to HQ, with the item.
+    expect(hq.some((c) => c.id === aHealthy.id)).toBe(true);
+    expect(hq.some((c) => c.id === aInjured.id)).toBe(true);
+    expect(hq.some((c) => c.id === sword.id)).toBe(true);
+    expect(ns.grid[0][0].units.some((u) => u.ownerId === ACTIVE)).toBe(false);
+    expect(ns.grid[0][0].items.some((c) => c.id === sword.id)).toBe(false);
+  });
+
+  it("enumerates exactly stay + retreat for the decider, nothing for the opponent", () => {
+    const { state } = reachRound1Retreat();
+
+    const offered = getValidActions(state, ACTIVE);
+    expect(offered).toHaveLength(2);
+    for (const act of offered) {
+      expect(act.type).toBe("resolve_combat_round");
+      if (act.type !== "resolve_combat_round") continue;
+      expect(act.decision.kind).toBe("retreat");
+    }
+    // Element [0] is the non-disruptive "stay" default a bot submits.
+    const first = offered[0];
+    const second = offered[1];
+    expect(first.type === "resolve_combat_round" && first.decision.kind === "retreat" && first.decision.retreat).toBe(false);
+    expect(second.type === "resolve_combat_round" && second.decision.kind === "retreat" && second.decision.retreat).toBe(true);
+
+    // The non-decider (defender) gets nothing while the attacker decides.
+    expect(getValidActions(state, OTHER)).toHaveLength(0);
+  });
+
+  it("rejects non-resolver actions and a mismatched decision kind", () => {
+    const { state } = reachRound1Retreat();
+
+    // No other action may run while combat is suspended.
+    expect(() => applyAction(state, { type: "pass", playerId: ACTIVE })).toThrow(
+      "suspended combat must be resolved first",
+    );
+
+    // A retreat prompt must not accept a different decision kind.
+    expect(() =>
+      applyAction(state, {
+        type: "resolve_combat_round",
+        playerId: ACTIVE,
+        decision: { kind: "sit_out", sitOutUnitIds: [] },
+      }),
+    ).toThrow('expected a "retreat" decision');
+  });
+
+  it("rejects a resolve from someone other than the prompt's decider", () => {
+    // Advance to the DEFENDER's retreat prompt (decider = the non-active p1). The
+    // active player p2 is admitted past the turn gate but is not the decider, so
+    // the retreat handler's decider check rejects it.
+    const { state: suspended } = reachRound1Retreat();
+    const { state: afterAtk } = applyAction(suspended, {
+      type: "resolve_combat_round",
+      playerId: ACTIVE,
+      decision: { kind: "retreat", retreat: false },
+    });
+    const defenderPrompt = afterAtk as MainGameState;
+    expect(defenderPrompt.combatPrompt?.playerId).toBe(OTHER);
+
+    expect(() =>
+      applyAction(defenderPrompt, {
+        type: "resolve_combat_round",
+        playerId: ACTIVE,
+        decision: { kind: "retreat", retreat: true },
+      }),
+    ).toThrow('pending combat decision is for "p1", not "p2"');
+  });
+
+  it("never offers retreat in a single-round combat that ends at round 0", () => {
+    // A 1-vs-1 wipeout resolves entirely within round 0 — no next round begins, so
+    // no retreat is ever offered.
+    const attacker = makeUnit({ ownerId: ACTIVE, strength: 100 });
+    const defender = makeUnit({ ownerId: OTHER, strength: 1 });
+    const state = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(attacker, defender);
+    });
+
+    const { state: next, events } = applyAction(state, { ...attackAction, unitIds: [attacker.id] });
+    const ns = next as MainGameState;
+
+    expect(ns.combatPrompt).toBeUndefined();
+    expect(events.some((e) => e.type === "combat_resolved")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // turn lifecycle
 // ---------------------------------------------------------------------------
 

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -384,31 +384,7 @@ function handleMove(
     );
     spendAP(draft, apCost);
 
-    const cell = draft.grid[fromRow][fromCol];
-    const idx = cell.units.findIndex((u) => u.id === unitId);
-    if (idx === -1) {
-      throw new Error(`Unit "${unitId}" not found at (${fromRow},${fromCol}) during retreat`);
-    }
-    const removed = cell.units.splice(idx, 1)[0];
-    const player = getPlayerById(draft, playerId);
-    player.hq.push(removed);
-
-    // Move equipped items from grid cell to HQ with the unit
-    for (let i = cell.items.length - 1; i >= 0; i--) {
-      if (cell.items[i].equippedTo === unitId) {
-        player.hq.push(cell.items.splice(i, 1)[0]);
-      }
-    }
-
-    emit({
-      type: "unit_moved",
-      playerId,
-      unitId,
-      fromRow,
-      fromCol,
-      toRow: -1,
-      toCol: -1,
-    });
+    retreatUnitsToHQ(draft, draft.grid[fromRow][fromCol], playerId, [unitId], fromRow, fromCol, emit);
 
     return;
   }
@@ -759,6 +735,83 @@ function makeCombatPrompt(
 }
 
 /**
+ * A retreat prompt (#168), raised at a round boundary *before* the roll. Unlike
+ * `makeCombatPrompt`, `kind`/`playerId` are not derived from roll lengths — the
+ * caller names the deciding side explicitly (attacker first, then defender). The
+ * two side lists are for display only: they enumerate each side's remaining
+ * committed units, but the round is unrolled, so `roll`/`power` are placeholders
+ * (see `buildRetreatSides`).
+ */
+function makeRetreatPrompt(
+  base: CombatLoopState,
+  deciderId: string,
+  cell: Draft<GridCell>,
+): CombatPrompt {
+  return {
+    kind: "retreat",
+    playerId: deciderId,
+    row: base.row,
+    col: base.col,
+    attackerId: base.attackerId,
+    defenderId: base.defenderId,
+    round: base.round,
+    attackerUnitIds: base.attackerUnitIds,
+    defenderUnitIds: base.defenderUnitIds,
+    atkRolls: buildRetreatSides(cell, base.attackerUnitIds),
+    defRolls: buildRetreatSides(cell, base.defenderUnitIds),
+  };
+}
+
+/**
+ * The `CombatSide` list for a retreat prompt: every committed unit of a side
+ * still present in the cell (injured included — they retreat and heal at HQ
+ * too). The round is unrolled, so `roll` is `0` and `power` is base strength;
+ * these carry unit identity/strength for the client, not a rolled outcome.
+ */
+function buildRetreatSides(cell: Draft<GridCell>, unitIds: readonly string[]): CombatSide[] {
+  return livingCombatants(cell, unitIds, { ignoreInjured: true }).map((unit) => ({
+    unitId: unit.id,
+    baseStrength: unit.strength,
+    modifiers: [],
+    roll: 0,
+    power: unit.strength,
+    injuredBefore: unit.injured,
+  }));
+}
+
+/**
+ * Move a set of committed units (by id) from a combat cell to their owner's HQ,
+ * carrying each unit's equipped items. Shared by the Move-action retreat
+ * (`handleMove`, single unit) and the per-round combat retreat (#168, a whole
+ * side). Ids no longer at the cell (already killed this combat) are skipped.
+ */
+function retreatUnitsToHQ(
+  draft: Draft<MainGameState>,
+  cell: Draft<GridCell>,
+  playerId: string,
+  unitIds: readonly string[],
+  row: number,
+  col: number,
+  emit: EmitFn,
+): void {
+  const player = getPlayerById(draft, playerId);
+  for (const unitId of unitIds) {
+    const idx = cell.units.findIndex((u) => u.id === unitId);
+    if (idx === -1) continue;
+    player.hq.push(cell.units.splice(idx, 1)[0]);
+
+    // Move equipped items from the cell to HQ with the unit.
+    for (let i = cell.items.length - 1; i >= 0; i--) {
+      if (cell.items[i].equippedTo === unitId) {
+        player.hq.push(cell.items.splice(i, 1)[0]);
+      }
+    }
+
+    emit({ type: "unit_moved", playerId, unitId, fromRow: row, fromCol: col, toRow: -1, toCol: -1 });
+  }
+}
+
+/**
  * Rules steps 4–5 for one already-rolled round: decide whether the round needs a
  * player decision (suspend) or can auto-resolve, and act on it. Called only from
  * `runCombat`'s fresh-round path. The equal-length step-4–5 logic it delegates to
@@ -878,6 +931,17 @@ function runCombat(
     const livingDefenders = livingCombatants(cell, defenderUnitIds, { ignoreInjured: round === 0 });
 
     if (livingAttackers.length === 0 || livingDefenders.length === 0) break;
+
+    // Rules step 6 — retreat (#168): "Either side may retreat before the next
+    // round begins." Before rolling any round after the first, offer a whole-side
+    // withdrawal — attacker first. `handleResolveCombatRound` chains the
+    // defender's offer and, once both decline, re-enters here with
+    // `retreatSettledRound === round` so we fall through to the roll below. Round
+    // 0 is the initial commit (no prior round to retreat between) and is exempt.
+    if (round >= 1 && state.retreatSettledRound !== round) {
+      draft.combatPrompt = castDraft(makeRetreatPrompt({ ...state, round }, attackerId, cell));
+      return;
+    }
 
     // Rules step 3 — Roll: one die per living unit; attack power = strength+roll.
     const atkRolls: CombatantRoll[] = [];
@@ -1519,6 +1583,39 @@ function handleResolveCombatRound(
     attackerUnitIds: prompt.attackerUnitIds,
     defenderUnitIds: prompt.defenderUnitIds,
   };
+
+  if (decision.kind === "retreat") {
+    // Clear the prompt first: whatever comes next (combat ends, the defender's
+    // offer, or the roll) becomes the sole writer of any successor prompt.
+    draft.combatPrompt = undefined;
+    const deciderIsAttacker: boolean = playerId === prompt.attackerId;
+
+    if (decision.retreat) {
+      // Whole side withdraws: move every committed unit still at the cell to HQ,
+      // then resume the SAME round. The deciding side is now empty there, so
+      // runCombat breaks immediately and emits combat_resolved with the other
+      // side as winner — identical to a dice wipeout, so on-combat-win effects
+      // fire just the same.
+      const retreatingIds: readonly string[] = deciderIsAttacker
+        ? prompt.attackerUnitIds
+        : prompt.defenderUnitIds;
+      retreatUnitsToHQ(draft, cell, playerId, retreatingIds, prompt.row, prompt.col, emit);
+      runCombat(draft, base, emit, queries);
+      return;
+    }
+
+    // Declined. The attacker is offered first, so its decline hands the same
+    // pre-roll choice to the defender (a second suspend in the same round).
+    if (deciderIsAttacker) {
+      draft.combatPrompt = castDraft(makeRetreatPrompt(base, prompt.defenderId, cell));
+      return;
+    }
+
+    // Both sides have now declined — roll this round. `retreatSettledRound` stops
+    // runCombat from re-offering the retreat it just resolved.
+    runCombat(draft, { ...base, retreatSettledRound: prompt.round }, emit, queries);
+    return;
+  }
 
   if (decision.kind === "sit_out") {
     // Remove the larger side's chosen excess, then continue the SAME round: the

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -44,6 +44,7 @@ import type {
   ModifierEntry,
   ModifierSource,
   MainGameState,
+  RetreatUnitDisplay,
   UnitCard,
 } from "./types";
 import { POLICY_ACTIONS } from "./listeners/effects";
@@ -738,15 +739,17 @@ function makeCombatPrompt(
  * A retreat prompt (#168), raised at a round boundary *before* the roll. Unlike
  * `makeCombatPrompt`, `kind`/`playerId` are not derived from roll lengths — the
  * caller names the deciding side explicitly (attacker first, then defender). The
- * two side lists are for display only: they enumerate each side's remaining
- * committed units, but the round is unrolled, so `roll`/`power` are placeholders
- * (see `buildRetreatSides`).
+ * round is unrolled, so `atkRolls`/`defRolls` are empty; the deciding side's
+ * remaining units go in `retreatUnits` for the client to list (see
+ * `buildRetreatUnits`).
  */
 function makeRetreatPrompt(
   base: CombatLoopState,
   deciderId: string,
   cell: Draft<GridCell>,
 ): CombatPrompt {
+  const deciderUnitIds: readonly string[] =
+    deciderId === base.attackerId ? base.attackerUnitIds : base.defenderUnitIds;
   return {
     kind: "retreat",
     playerId: deciderId,
@@ -757,25 +760,23 @@ function makeRetreatPrompt(
     round: base.round,
     attackerUnitIds: base.attackerUnitIds,
     defenderUnitIds: base.defenderUnitIds,
-    atkRolls: buildRetreatSides(cell, base.attackerUnitIds),
-    defRolls: buildRetreatSides(cell, base.defenderUnitIds),
+    atkRolls: [],
+    defRolls: [],
+    retreatUnits: buildRetreatUnits(cell, deciderUnitIds),
   };
 }
 
 /**
- * The `CombatSide` list for a retreat prompt: every committed unit of a side
- * still present in the cell (injured included — they retreat and heal at HQ
- * too). The round is unrolled, so `roll` is `0` and `power` is base strength;
- * these carry unit identity/strength for the client, not a rolled outcome.
+ * The display list for a retreat prompt: every committed unit of the deciding
+ * side still present in the cell (injured included — they retreat and heal at HQ
+ * too). The round is unrolled, so this carries only identity, strength, and
+ * injured status — no roll or power (see `RetreatUnitDisplay`).
  */
-function buildRetreatSides(cell: Draft<GridCell>, unitIds: readonly string[]): CombatSide[] {
+function buildRetreatUnits(cell: Draft<GridCell>, unitIds: readonly string[]): RetreatUnitDisplay[] {
   return livingCombatants(cell, unitIds, { ignoreInjured: true }).map((unit) => ({
     unitId: unit.id,
-    baseStrength: unit.strength,
-    modifiers: [],
-    roll: 0,
-    power: unit.strength,
-    injuredBefore: unit.injured,
+    strength: unit.strength,
+    injured: unit.injured,
   }));
 }
 
@@ -898,15 +899,35 @@ function resolveOrSuspendMatchup(
  * held as references: units get killed/removed mid-combat, and on resume the
  * pre-suspend references are gone (a fresh `produce()` draft). The committed id
  * lists in `state` are the durable handle.
+ *
+ * `settledRound` (#168) is the transient resume marker — NOT part of the durable
+ * `CombatLoopState` — for the "both sides declined the retreat → roll this same
+ * round" path: when it equals the round about to roll, the pre-roll retreat offer
+ * is skipped so the resume proceeds to the dice instead of re-offering. Passed
+ * only on that resume; absent on a fresh combat and after any round advance
+ * (retreat is offered afresh each new round). The loop advances `round` past it,
+ * so it suppresses the re-offer for exactly the round it names.
  */
 function runCombat(
   draft: Draft<MainGameState>,
   state: CombatLoopState,
   emit: EmitFn,
   queries: QueryListener[],
+  settledRound?: number,
 ): void {
   const { row, col, attackerId, defenderId, attackerUnitIds, defenderUnitIds } = state;
   const cell: Draft<GridCell> = draft.grid[row][col];
+
+  // `settledRound`, if given, must be the round we're about to start — it only
+  // ever suppresses the retreat re-offer for the round the caller just resumed.
+  // Enforcing it here turns the "== current round" construction discipline into a
+  // runtime guard, so a future miswired caller fails loud instead of silently
+  // skipping a legitimate retreat offer.
+  if (settledRound !== undefined && settledRound !== state.round) {
+    throw new Error(
+      `runCombat invariant: settledRound=${settledRound} must equal start round ${state.round}`,
+    );
+  }
 
   let rng: RandomGenerator = fromState(draft.rngState);
 
@@ -936,9 +957,9 @@ function runCombat(
     // round begins." Before rolling any round after the first, offer a whole-side
     // withdrawal — attacker first. `handleResolveCombatRound` chains the
     // defender's offer and, once both decline, re-enters here with
-    // `retreatSettledRound === round` so we fall through to the roll below. Round
-    // 0 is the initial commit (no prior round to retreat between) and is exempt.
-    if (round >= 1 && state.retreatSettledRound !== round) {
+    // `settledRound === round` so we fall through to the roll below. Round 0 is
+    // the first fighting round (no prior round to retreat between) and is exempt.
+    if (round >= 1 && settledRound !== round) {
       draft.combatPrompt = castDraft(makeRetreatPrompt({ ...state, round }, attackerId, cell));
       return;
     }
@@ -1513,7 +1534,7 @@ function resolveSitOut(
     throw new Error(`resolve_combat_round rejected: sit_out on balanced sides (${atkLen} vs ${defLen})`);
   }
   const attackerLarger: boolean = atkLen > defLen;
-  const largerSides: CombatSide[] = attackerLarger ? prompt.atkRolls : prompt.defRolls;
+  const largerSides: readonly CombatSide[] = attackerLarger ? prompt.atkRolls : prompt.defRolls;
   const excess: number = Math.abs(atkLen - defLen);
 
   if (decision.sitOutUnitIds.length !== excess) {
@@ -1534,9 +1555,9 @@ function resolveSitOut(
     sittingOut.add(id);
   }
 
-  const remainingLarger: CombatSide[] = largerSides.filter((s) => !sittingOut.has(s.unitId));
-  const atkSides: CombatSide[] = attackerLarger ? remainingLarger : prompt.atkRolls;
-  const defSides: CombatSide[] = attackerLarger ? prompt.defRolls : remainingLarger;
+  const remainingLarger: readonly CombatSide[] = largerSides.filter((s) => !sittingOut.has(s.unitId));
+  const atkSides: readonly CombatSide[] = attackerLarger ? remainingLarger : prompt.atkRolls;
+  const defSides: readonly CombatSide[] = attackerLarger ? prompt.defRolls : remainingLarger;
   return {
     atkParticipants: atkSides.map((s) => combatantRollFromSide(cell, s)),
     defParticipants: defSides.map((s) => combatantRollFromSide(cell, s)),
@@ -1585,6 +1606,19 @@ function handleResolveCombatRound(
   };
 
   if (decision.kind === "retreat") {
+    // Validate the payload's `retreat` flag explicitly — unlike `sit_out` /
+    // `assign_matchups`, which validate their id lists, a plain boolean would
+    // otherwise be silently coerced (an omitted/mistyped field read as a decline,
+    // any truthy non-boolean as a full withdrawal). Fail loud on a malformed
+    // submission so a client bug can't produce a wrong-but-plausible outcome.
+    if (typeof decision.retreat !== "boolean") {
+      throw new Error(
+        `resolve_combat_round rejected: retreat decision requires a boolean "retreat", got ${JSON.stringify(
+          decision.retreat,
+        )}`,
+      );
+    }
+
     // Clear the prompt first: whatever comes next (combat ends, the defender's
     // offer, or the roll) becomes the sole writer of any successor prompt.
     draft.combatPrompt = undefined;
@@ -1595,12 +1629,14 @@ function handleResolveCombatRound(
       // then resume the SAME round. The deciding side is now empty there, so
       // runCombat breaks immediately and emits combat_resolved with the other
       // side as winner — identical to a dice wipeout, so on-combat-win effects
-      // fire just the same.
+      // fire just the same. Pass `prompt.round` as the settled round too: the
+      // emptied side makes runCombat break before the retreat check, so it is
+      // moot today, but it keeps the safety independent of that coincidence.
       const retreatingIds: readonly string[] = deciderIsAttacker
         ? prompt.attackerUnitIds
         : prompt.defenderUnitIds;
       retreatUnitsToHQ(draft, cell, playerId, retreatingIds, prompt.row, prompt.col, emit);
-      runCombat(draft, base, emit, queries);
+      runCombat(draft, base, emit, queries, prompt.round);
       return;
     }
 
@@ -1611,9 +1647,9 @@ function handleResolveCombatRound(
       return;
     }
 
-    // Both sides have now declined — roll this round. `retreatSettledRound` stops
+    // Both sides have now declined — roll this round. `settledRound` stops
     // runCombat from re-offering the retreat it just resolved.
-    runCombat(draft, { ...base, retreatSettledRound: prompt.round }, emit, queries);
+    runCombat(draft, base, emit, queries, prompt.round);
     return;
   }
 

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -1010,7 +1010,7 @@ function runCombat(
     winnerId = defenderId;
   }
 
-  emit({ type: "combat_resolved", row, col, winnerId });
+  emit({ type: "combat_resolved", row, col, winnerId, attackerId, defenderId });
 }
 
 /**

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -1635,6 +1635,10 @@ function handleResolveCombatRound(
       const retreatingIds: readonly string[] = deciderIsAttacker
         ? prompt.attackerUnitIds
         : prompt.defenderUnitIds;
+      // Announce the retreat before the withdrawal + combat_resolved, so the
+      // result dialog can name who pulled out (it is otherwise invisible — a
+      // retreat rolls no dice and produces no combat_pair_resolved).
+      emit({ type: "combat_retreated", row: prompt.row, col: prompt.col, playerId });
       retreatUnitsToHQ(draft, cell, playerId, retreatingIds, prompt.row, prompt.col, emit);
       runCombat(draft, base, emit, queries, prompt.round);
       return;

--- a/engine/src/index.ts
+++ b/engine/src/index.ts
@@ -73,6 +73,7 @@ export type {
   PolicyCard,
   Rarity,
   ResolutionSide,
+  RetreatUnitDisplay,
   Reveals,
   SeedingGameState,
   Session,

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -148,6 +148,21 @@ export interface CombatSide extends ResolutionSide {
   injuredBefore: boolean;
 }
 
+/**
+ * Display-only unit info for a `retreat` prompt (#168). A retreat is offered
+ * *before* the round rolls, so — unlike `CombatSide` — there is no roll or
+ * power: just the identity, strength, and injured status the client needs to
+ * list the units the deciding side would pull back to HQ. Modelling it as its
+ * own type (rather than reusing `CombatSide` with `roll: 0` / `power: base`
+ * placeholders) keeps the prompt from carrying fields that would lie about an
+ * unrolled round.
+ */
+export interface RetreatUnitDisplay {
+  unitId: string;
+  strength: number;
+  injured: boolean;
+}
+
 /** Mirrors `CombatSide` minus combat-specific fields. Contests do not
  *  apply an injury penalty today, so `injuredBefore` is omitted by
  *  design — a future debuff-aware contest can re-derive from the unit. */
@@ -460,34 +475,24 @@ export interface CombatLoopState {
   attackerUnitIds: readonly string[];
   /** Committed defender unit instance ids (never mutated after suspend). */
   defenderUnitIds: readonly string[];
-  /**
-   * Transient resume marker (#168), NOT durable committed state: the round for
-   * which the pre-roll retreat offer has already been made and declined by both
-   * sides. `runCombat` skips re-offering retreat when this equals the round it is
-   * about to roll — so the "both sides declined → roll this same round" resume
-   * path proceeds to the dice instead of looping back into another retreat offer.
-   * Absent on a fresh combat and after any round advance (retreat is offered
-   * afresh each new round).
-   */
-  retreatSettledRound?: number;
 }
 
 /**
- * A combat suspended mid-round awaiting a player decision. Per the rules
- * (README.md Combat step 4 — Matchup) decisions land *within* a round — after
- * the step-3 roll, before resolution — carrying that round's revealed rolls
- * inline. A single round can suspend twice (`kind` transitions): a `sit_out`
- * prompt first (larger side drops its excess), then, if `min >= 2` participants
- * remain, an `assign_matchups` prompt.
+ * A combat suspended awaiting a player decision. The `sit_out` / `assign_matchups`
+ * decisions land *within* a round (README.md Combat step 4 — Matchup) — after the
+ * step-3 roll, before resolution — carrying that round's revealed rolls inline; a
+ * single such round can suspend twice (`kind` transitions): a `sit_out` prompt
+ * first (larger side drops its excess), then, if `min >= 2` participants remain,
+ * an `assign_matchups` prompt. `retreat` is the exception: it is raised at a round
+ * *boundary* **before** the roll, so it carries no rolls (see `retreatUnits`).
  *
  * `kind` discriminates the decisions:
  * - `"retreat"` (#168): raised at a round boundary (round >= 1) **before** the
  *   roll — the attacker decides first, then, if it stays, the defender.
- *   `playerId` is the deciding side's owner. `atkRolls` / `defRolls` list each
- *   side's remaining committed units for display only — **the fight has not been
- *   rolled yet, so their `roll` is `0` and `power` is base strength** (a retreat
- *   is committed blind). All-or-nothing: the decider withdraws its whole side or
- *   stays.
+ *   `playerId` is the deciding side's owner. The round is unrolled, so `atkRolls`
+ *   / `defRolls` are **empty**; the deciding side's remaining committed units are
+ *   carried in `retreatUnits` (identity + strength + injured, no dice). All-or-
+ *   nothing: the decider withdraws its whole side or stays.
  * - `"sit_out"` (#167): the larger side removes `max - min` excess units.
  *   `playerId` is the **larger side's** owner (attacker or defender), and
  *   `atkRolls` / `defRolls` are the *full* living rolls — so the lists have
@@ -509,10 +514,16 @@ export interface CombatPrompt extends CombatLoopState {
   /** Player expected to submit `resolve_combat_round`. */
   playerId: string;
   /** Revealed rolls of the attacker units for `round` (full living set for
-   *  `sit_out`; equal-length participants for `assign_matchups`). */
-  atkRolls: CombatSide[];
+   *  `sit_out`; equal-length participants for `assign_matchups`). **Empty for
+   *  `retreat`** — that decision is pre-roll; see `retreatUnits`. */
+  atkRolls: readonly CombatSide[];
   /** Revealed rolls of the defender units for `round` (see `atkRolls`). */
-  defRolls: CombatSide[];
+  defRolls: readonly CombatSide[];
+  /** For a `retreat` prompt only: the deciding side's remaining committed units
+   *  (injured included), for the client to list. Absent for `sit_out` /
+   *  `assign_matchups`. The round is unrolled at a retreat offer, so these carry
+   *  no roll/power (see `RetreatUnitDisplay`). */
+  retreatUnits?: readonly RetreatUnitDisplay[];
 }
 
 export interface MainGameState extends GameStateBase {
@@ -528,8 +539,8 @@ export interface MainGameState extends GameStateBase {
    */
   viewPrompt?: ViewPrompt;
   /**
-   * Set when combat suspends mid-round for the defender's matchup assignment,
-   * cleared by `resolve_combat_round`. Main-phase only — placed here (not on
+   * Set when combat suspends for a player decision (matchup, sit-out, or
+   * retreat), cleared by `resolve_combat_round`. Main-phase only — placed here (not on
    * `GameStateBase`) so a seeding or ended state cannot structurally carry one,
    * mirroring `viewPrompt`. The prompt carries the full resumable loop state
    * inline — the same Option-A pattern `pickPrompt`/`viewPrompt` use.
@@ -701,7 +712,7 @@ export type CombatDecision =
   | {
       kind: "assign_matchups";
       /** A bijection over the prompt's participating units; length = min(sides). */
-      pairs: CombatMatchup[];
+      pairs: readonly CombatMatchup[];
     }
   | {
       kind: "sit_out";
@@ -712,7 +723,7 @@ export type CombatDecision =
        * participants, which then either auto-resolve or trigger a matchup
        * decision (the 3v2 double-suspend case).
        */
-      sitOutUnitIds: string[];
+      sitOutUnitIds: readonly string[];
     }
   | {
       kind: "retreat";

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -460,6 +460,16 @@ export interface CombatLoopState {
   attackerUnitIds: readonly string[];
   /** Committed defender unit instance ids (never mutated after suspend). */
   defenderUnitIds: readonly string[];
+  /**
+   * Transient resume marker (#168), NOT durable committed state: the round for
+   * which the pre-roll retreat offer has already been made and declined by both
+   * sides. `runCombat` skips re-offering retreat when this equals the round it is
+   * about to roll — so the "both sides declined → roll this same round" resume
+   * path proceeds to the dice instead of looping back into another retreat offer.
+   * Absent on a fresh combat and after any round advance (retreat is offered
+   * afresh each new round).
+   */
+  retreatSettledRound?: number;
 }
 
 /**
@@ -470,7 +480,14 @@ export interface CombatLoopState {
  * prompt first (larger side drops its excess), then, if `min >= 2` participants
  * remain, an `assign_matchups` prompt.
  *
- * `kind` discriminates the two decisions:
+ * `kind` discriminates the decisions:
+ * - `"retreat"` (#168): raised at a round boundary (round >= 1) **before** the
+ *   roll — the attacker decides first, then, if it stays, the defender.
+ *   `playerId` is the deciding side's owner. `atkRolls` / `defRolls` list each
+ *   side's remaining committed units for display only — **the fight has not been
+ *   rolled yet, so their `roll` is `0` and `power` is base strength** (a retreat
+ *   is committed blind). All-or-nothing: the decider withdraws its whole side or
+ *   stays.
  * - `"sit_out"` (#167): the larger side removes `max - min` excess units.
  *   `playerId` is the **larger side's** owner (attacker or defender), and
  *   `atkRolls` / `defRolls` are the *full* living rolls — so the lists have
@@ -518,8 +535,9 @@ export interface MainGameState extends GameStateBase {
    * inline — the same Option-A pattern `pickPrompt`/`viewPrompt` use.
    *
    * Live as of #166: combat pauses whenever the defender has a real pairing
-   * choice (`matchupDecisionPending` in `apply-main.ts`). Sit-out (#167) and
-   * retreat (#168) will add further pause conditions later.
+   * choice (`matchupDecisionPending` in `apply-main.ts`). #167 added the sit-out
+   * pause (larger side drops excess units); #168 added the per-round retreat
+   * pause, raised before each round >= 1 rolls (attacker then defender).
    */
   combatPrompt?: CombatPrompt;
 }
@@ -695,6 +713,18 @@ export type CombatDecision =
        * decision (the 3v2 double-suspend case).
        */
       sitOutUnitIds: string[];
+    }
+  | {
+      kind: "retreat";
+      /**
+       * Per-round retreat (#168), all-or-nothing for the deciding side (the
+       * prompt's `playerId`). `true` withdraws *every* remaining committed unit
+       * of that side to its owner's HQ and ends its part in the combat (the other
+       * side wins if it still holds the cell); `false` stays and fights the round.
+       * Raised at a round boundary *before* the roll — the attacker decides first,
+       * then, if it stays, the defender.
+       */
+      retreat: boolean;
     };
 
 /**

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -904,6 +904,11 @@ export type GameEvent =
       row: number;
       col: number;
       winnerId: string | null;
+      /** The two sides, so the event log can categorize the conclusion with the
+       *  rest of the fight (a bare `winnerId` — null on a draw — otherwise makes
+       *  it uncategorizable and it falls through to a hidden "system" row). */
+      attackerId: string;
+      defenderId: string;
     }
   | {
       /** A side withdrew its whole remaining committed force to HQ before a

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -906,6 +906,16 @@ export type GameEvent =
       winnerId: string | null;
     }
   | {
+      /** A side withdrew its whole remaining committed force to HQ before a
+       *  round rolled (#168). Emitted just before the withdrawal and the
+       *  ensuing `combat_resolved`, so the result dialog can name the retreat. */
+      type: "combat_retreated";
+      row: number;
+      col: number;
+      /** The side (player id) that retreated. */
+      playerId: string;
+    }
+  | {
       type: "combat_pair_resolved";
       row: number;
       col: number;

--- a/engine/src/valid-actions.ts
+++ b/engine/src/valid-actions.ts
@@ -167,6 +167,15 @@ function buildCombatResolutions(
   prompt: CombatPrompt,
   playerId: string,
 ): ResolveCombatRoundAction[] {
+  if (prompt.kind === "retreat") {
+    // Stay vs. withdraw the whole side (#168). `stay` first so element `[0]` is
+    // the non-disruptive default a bot submits to keep the fight progressing.
+    return [
+      { type: "resolve_combat_round", playerId, decision: { kind: "retreat", retreat: false } },
+      { type: "resolve_combat_round", playerId, decision: { kind: "retreat", retreat: true } },
+    ];
+  }
+
   if (prompt.kind === "sit_out") {
     const attackerLarger: boolean = prompt.atkRolls.length > prompt.defRolls.length;
     const largerRolls = attackerLarger ? prompt.atkRolls : prompt.defRolls;

--- a/rules/README.md
+++ b/rules/README.md
@@ -223,9 +223,12 @@ be present.
 6. **Next round or end**: After all pairs resolve, if both sides still
    have surviving (non-injured, non-killed) units at the location,
    combat continues — return to step 3 (re-roll all surviving units).
-   Either side may **retreat** before the next round begins: all
-   retreating units return to their owner's HQ. If one side has no
-   remaining units (or retreats entirely), combat ends.
+   Before that next round's roll, either side may **retreat** — the
+   **attacker decides first**, then (if it stays) the defender. A retreat
+   is all-or-nothing: the deciding side withdraws its **whole** remaining
+   committed force (injured units included) to their owner's HQ, and combat
+   ends with the side still holding the location as the winner. Combat also
+   ends if a side has no remaining units.
 
 **Notes:**
 - The attacker controls commitment size; the defender controls matchup
@@ -237,26 +240,12 @@ be present.
   resolves combat against each opponent in turn (attacker chooses
   order). Surviving attacker units carry over between resolutions.
 
-[design: The multi-unit *tactical* layer above landed incrementally with
-#164 and is now fully implemented. **Defender-assigned matchups** (#166):
-after a round's rolls are revealed, if the defender has a real pairing
-choice, combat pauses and the defender assigns which attacker faces which
-defender before the pairs resolve. **Sit-out selection** (#167): when one
-side commits more units than the other, that side's controller chooses
-which excess units sit out the round (decided after seeing all rolls),
-rather than a greedy lowest-power default. **Per-round retreat** (#168):
-before each round after the first, either side may withdraw its *whole*
-remaining committed force to HQ — the attacker decides first, then, if it
-stays, the defender; a full retreat hands the win to the side that holds
-the location. The injure/kill consequences, the tie-to-defender rule, and
-the drop-out survivor semantics (injured units leave the fighting pool
-between rounds, per the Next round or end step) are implemented and match
-this text. As a safety limit, combat resolution is capped at
-[var:combat_round_cap:10] rounds — drop-out guarantees termination
-regardless (each round removes every matchup's loser), and normal combats
-finish in far fewer rounds; the cap only bounds combats with unusually
-large unit stacks (worst case scales with the larger committed side's
-size).]
+[design: As a safety limit, combat resolution is capped at
+[var:combat_round_cap:10] rounds — the drop-out survivor semantics (each
+round removes every matchup's loser, so the fighting pool strictly shrinks)
+guarantee termination regardless, and normal combats finish in far fewer
+rounds; the cap only bounds combats with unusually large unit stacks (worst
+case scales with the larger committed side's size).]
 
 > See [Market and Economy Rules](market.md) for details on the Buy action.
 

--- a/rules/README.md
+++ b/rules/README.md
@@ -237,26 +237,26 @@ be present.
   resolves combat against each opponent in turn (attacker chooses
   order). Surviving attacker units carry over between resolutions.
 
-[design: The multi-unit *tactical* layer above is landing incrementally
-with #164. **Defender-assigned matchups (the Matchup step) are now
-implemented** (#166): after a round's rolls are revealed, if the defender
-has a real pairing choice, combat pauses and the defender assigns which
-attacker faces which defender before the pairs resolve. Two pieces of the
-Matchup / Next round steps remain **not yet implemented**: the larger side
-choosing which excess units **sit out** (#167), and per-round **retreat**
-(#168). Until those land, excess units on the larger side sit out greedily
-lowest-power-first (rather than by the controller's choice), and no side
-can retreat. The injure/kill consequences, the tie-to-defender rule, and
+[design: The multi-unit *tactical* layer above landed incrementally with
+#164 and is now fully implemented. **Defender-assigned matchups** (#166):
+after a round's rolls are revealed, if the defender has a real pairing
+choice, combat pauses and the defender assigns which attacker faces which
+defender before the pairs resolve. **Sit-out selection** (#167): when one
+side commits more units than the other, that side's controller chooses
+which excess units sit out the round (decided after seeing all rolls),
+rather than a greedy lowest-power default. **Per-round retreat** (#168):
+before each round after the first, either side may withdraw its *whole*
+remaining committed force to HQ — the attacker decides first, then, if it
+stays, the defender; a full retreat hands the win to the side that holds
+the location. The injure/kill consequences, the tie-to-defender rule, and
 the drop-out survivor semantics (injured units leave the fighting pool
-between rounds, per the Next round or end step) *are* implemented and match
+between rounds, per the Next round or end step) are implemented and match
 this text. As a safety limit, combat resolution is capped at
 [var:combat_round_cap:10] rounds — drop-out guarantees termination
 regardless (each round removes every matchup's loser), and normal combats
 finish in far fewer rounds; the cap only bounds combats with unusually
 large unit stacks (worst case scales with the larger committed side's
-size). Until #164 fully lands, do not build card designs on the
-still-unimplemented pieces (sit-out, per-round retreat) — validate such
-designs against engine behavior.]
+size).]
 
 > See [Market and Economy Rules](market.md) for details on the Buy action.
 


### PR DESCRIPTION
## Summary

Adds the rules' **Option A per-round retreat** to combat: before each round after the first, either side may withdraw its **whole** remaining committed force to HQ. This is distinct from the existing Move-action retreat and is modelled *inside* combat as a between-rounds suspension.

Design decisions (confirmed with product):
- **All-or-nothing** — a side retreats all its remaining committed units or none (`{ kind: "retreat"; retreat: boolean }`).
- **Attacker decides first**, then the defender. A full attacker retreat ends combat before the defender is asked.
- **Blind / pre-roll** — the offer is raised at the top of each round ≥ 1 *before* the dice roll, so a retreat is committed without seeing the new rolls.

A full retreat empties that side from the cell, so the side that stays wins via the existing winner logic — identical to a dice wipeout, and it fires the same on-combat-win effects.

## Changes

**Engine**
- `types.ts` — third `CombatDecision` variant `{ kind: "retreat"; retreat: boolean }`; `RetreatUnitDisplay` for the pre-roll prompt (unrolled round → identity + strength + injured, no roll/power); `combat_retreated` event. The retreat-settled marker is a transient `runCombat` parameter, not durable `CombatLoopState`.
- `apply-main.ts` — `makeRetreatPrompt` / `buildRetreatUnits`; a shared `retreatUnitsToHQ` helper (now also used by the Move-action retreat in `handleMove`); the pre-roll offer in `runCombat`; the `retreat` branch in `handleResolveCombatRound` (validate payload → emit `combat_retreated` → withdraw → resolve, attacker-decline → offer defender, both-decline → roll the round).
- `valid-actions.ts` — enumerate `stay` / `retreat` (stay first as the greedy default so bots keep combat progressing).

**Client**
- `CombatPromptOverlay.svelte` — retreat branch listing the deciding side's units from `retreatUnits` (blind, no roll line); title reworded as a question ("Retreat to HQ, or fight on?") with **Retreat all to HQ** / **Stay and fight** buttons.
- `ContestResultPopup.svelte` / `contestResult.ts` — the result dialog surfaces the retreat ("{player} retreated to HQ", winner footer retained; no "draw" copy); `eventDescriptions.ts` gains a `combat_retreated` line.
- `ContestResultPopup.svelte` / `contestResult.ts` — **(bundled, pre-existing)** DSL stat-contest outcome rows now align to the owning side; `outcomeSide` is a shared, tested pure function (was combat-only, so DSL rows always fell left).

**Rules**
- `README.md` — combat-flow step 6 gains the retreat specifics (attacker-decides-first, pre-roll timing, whole-side all-or-nothing, winner handoff); the `[design:]` note trimmed to just the `combat_round_cap` safety limit.

## Test plan

- `bun run test` — engine **611 pass**, web **80 pass**, test **24 pass**, 0 fail.
- `bun run typecheck` (all packages, incl. `svelte-check`) — clean.
- Pre-existing `@library/all.json` client-alias failures are unrelated (present on the base commit).

## Iterations

| # | Change | Validation |
|---|--------|------------|
| 1 | Engine: retreat decision type, pre-roll offer in `runCombat`, resume branch, shared HQ-move helper, valid-actions | full engine suite green |
| 2 | Engine tests: timing, win-on-retreat, decline chain, both-decline, injured+items to HQ, enumeration, guards, no-round-0 | 10/10 pass |
| 3 | Client: retreat control in `CombatPromptOverlay` | `svelte-check` + `tsc` clean |
| 4 | Review — Engine: slim roll-free retreat prompt (`RetreatUnitDisplay`), validate `retreat` payload, settled-round as explicit `runCombat` param + invariant assertion, `readonly` list fields, comment/doc corrections | full engine suite green; `typecheck` clean |
| 5 | Review — Engine tests: round-2 re-offer, 0-AP + `unit_moved` + killed-id-skip asserts, deterministic no-winner both-decline, Move-retreat item carry | 611 pass, 0 fail |
| 6 | Review — Client: consume `retreatUnits`, correct "opponent wins this combat" copy | `svelte-check` + `tsc` clean |
| 7 | Review — Rules: fold retreat specifics into combat step 6; trim `[design:]` note to the round-cap context | — |
| 8 | UX — Engine: `combat_retreated` event (a retreat rolls no dice, so the result dialog was blind to it) + tests | engine green |
| 9 | UX — Client: surface the retreat in the combat result dialog (retreat line, drop draw copy, event-log description) + tests | web 80 pass; `svelte-check` clean |
| 10 | UX — Client: reword retreat prompt title as a question | `svelte-check` clean |

| 11 | Bundled fix — Client: align DSL stat-contest outcome rows to the owning side (was combat-only) + test | web 83 pass; `svelte-check` clean |

| 12 | Event-log fix — Engine: `combat_resolved` now carries `attackerId`/`defenderId` so the winner line categorizes with the fight instead of the hidden "system" bucket + test | web 84 pass; engine green |

Depends on mid-combat suspension (#164 sub-task 1). Closes #168
