### PR TITLE
182: Engine + client: deep-validate adapter actions at the controller boundary and survive engine rejection

### DIFF
--- a/clients/web/src/components/CombatPromptOverlay.svelte
+++ b/clients/web/src/components/CombatPromptOverlay.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
   import type { CombatSide, RetreatUnitDisplay } from "cards-engine";
   import {
-    getError,
+    getRejectionNonce,
     getVisibleState,
     resolveCardName,
     resolvePlayerName,
     selectAction,
   } from "../lib/gameStore.svelte";
+  import { shouldReenableAfterRejection } from "../lib/promptRecovery";
   import Modal from "./Modal.svelte";
 
   const vs = $derived(getVisibleState());
@@ -37,10 +38,11 @@
   let sitOut = $state<string[]>([]);
 
   let submitted = $state(false);
-  // The error banner present at submit time, so the recovery effect below can
-  // tell a NEW mid-submit error (which should re-enable Confirm) from a stale,
-  // unrelated banner (which must not).
-  let errorAtSubmit = $state<string | null>(null);
+  // The rejection-nonce value captured at submit time. The recovery effect below
+  // re-enables Confirm when the nonce advances past this — i.e. the engine
+  // rejected *this* submission — rather than keying off the error-banner string
+  // (which an unrelated banner change could spuriously trip).
+  let nonceAtSubmit = $state(0);
 
   // For a sit-out prompt the larger side is the longer roll list; that side's
   // owner (prompt.playerId) picks exactly `excess` units to remove.
@@ -91,13 +93,15 @@
     assignment = seed;
   });
 
-  // Unlock the confirm button if the engine surfaces a NEW error mid-submit, so
-  // the decider can retry. Gating on a fresh error (not merely any error present)
-  // avoids a stale banner re-enabling Confirm and inviting a second, dropped
-  // click. Mirrors PickPromptOverlay's recovery pattern.
-  const error = $derived(getError());
+  // Unlock the confirm button when the engine rejects THIS submission, so the
+  // decider can retry. Keys off the monotonic rejection nonce advancing past the
+  // value captured at submit — not the error-banner string — so an unrelated
+  // banner change can't spuriously re-enable Confirm. Mirrors PickPromptOverlay.
+  const rejectionNonce = $derived(getRejectionNonce());
   $effect(() => {
-    if (submitted && error && error !== errorAtSubmit) submitted = false;
+    if (shouldReenableAfterRejection(submitted, rejectionNonce, nonceAtSubmit)) {
+      submitted = false;
+    }
   });
 
   // A valid assignment is a bijection: every defender participant used exactly
@@ -138,7 +142,7 @@
   // rather than via the shared confirm gate.
   function submitRetreat(retreat: boolean): void {
     if (!prompt || submitted) return;
-    errorAtSubmit = error;
+    nonceAtSubmit = rejectionNonce;
     submitted = true;
     selectAction({
       type: "resolve_combat_round",
@@ -149,7 +153,7 @@
 
   function confirm(): void {
     if (!prompt || submitted || !canConfirm) return;
-    errorAtSubmit = error;
+    nonceAtSubmit = rejectionNonce;
     submitted = true;
     if (prompt.kind === "sit_out") {
       selectAction({

--- a/clients/web/src/components/PickPromptOverlay.svelte
+++ b/clients/web/src/components/PickPromptOverlay.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import { getError, getVisibleState, selectAction, setError } from "../lib/gameStore.svelte";
+  import { getRejectionNonce, getVisibleState, selectAction, setError } from "../lib/gameStore.svelte";
   import { resolvePickOptions, togglePickSelection } from "../lib/pickPrompt";
+  import { shouldReenableAfterRejection } from "../lib/promptRecovery";
   import CardView from "./CardView.svelte";
   import Modal from "./Modal.svelte";
 
@@ -32,14 +33,19 @@
 
   let selected = $state<ReadonlySet<string>>(new Set<string>());
   let submitted = $state(false);
+  // The rejection-nonce value captured at submit; the effect below unlocks
+  // Confirm when it advances (this submission was rejected).
+  let nonceAtSubmit = $state(0);
 
-  // If the engine surfaces an error while we're mid-submit, unlock the
-  // button so the user can try again (retry may or may not succeed
-  // depending on whether the controller is recoverable, but the button
-  // shouldn't be permanently stuck).
-  const error = $derived(getError());
+  // If the engine rejects THIS submission mid-submit, unlock the button so the
+  // user can try again. Keys off the monotonic rejection nonce (shared with
+  // CombatPromptOverlay) rather than any error being present, so an unrelated
+  // banner can't leave Confirm stuck or unlock it spuriously.
+  const rejectionNonce = $derived(getRejectionNonce());
   $effect(() => {
-    if (error && submitted) submitted = false;
+    if (shouldReenableAfterRejection(submitted, rejectionNonce, nonceAtSubmit)) {
+      submitted = false;
+    }
   });
 
   // Reset local picker state when the prompt changes content. Today the
@@ -59,6 +65,7 @@
 
   function confirm(): void {
     if (!prompt || selected.size !== prompt.count || submitted) return;
+    nonceAtSubmit = rejectionNonce;
     submitted = true;
     selectAction({
       type: "resolve_pick",

--- a/clients/web/src/lib/__tests__/promptRecovery.test.ts
+++ b/clients/web/src/lib/__tests__/promptRecovery.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import {
+  appendBanner,
+  shouldReenableAfterRejection,
+} from "../promptRecovery";
+
+describe("appendBanner", () => {
+  it("returns the message when the banner is empty", () => {
+    expect(appendBanner(null, "oops")).toBe("oops");
+    expect(appendBanner("", "oops")).toBe("oops");
+  });
+
+  it("newline-separates a distinct new message", () => {
+    expect(appendBanner("first", "second")).toBe("first\nsecond");
+  });
+
+  it("dedupes a consecutive identical trailing message", () => {
+    // The rejection re-prompt pushes the same line each time — it must not stack.
+    const msg = "That move wasn't legal — please choose again (Ada).";
+    let banner = appendBanner(null, msg);
+    for (let i = 0; i < 100; i++) banner = appendBanner(banner, msg);
+    expect(banner).toBe(msg); // one line, not 101
+  });
+
+  it("still accumulates a distinct message after a repeated one", () => {
+    const reject = "That move wasn't legal — please choose again (Ada).";
+    let banner = appendBanner(null, reject);
+    banner = appendBanner(banner, reject); // deduped
+    banner = appendBanner(banner, "Auto-save is failing.");
+    expect(banner).toBe(`${reject}\nAuto-save is failing.`);
+  });
+
+  it("only compares the trailing segment, not earlier lines", () => {
+    // A message equal to an EARLIER (non-trailing) line is still appended.
+    const banner = appendBanner("a\nb", "a");
+    expect(banner).toBe("a\nb\na");
+  });
+});
+
+describe("shouldReenableAfterRejection", () => {
+  it("stays locked when not mid-submit", () => {
+    expect(shouldReenableAfterRejection(false, 5, 3)).toBe(false);
+  });
+
+  it("stays locked while the nonce is unchanged since submit", () => {
+    expect(shouldReenableAfterRejection(true, 3, 3)).toBe(false);
+  });
+
+  it("unlocks when the nonce advances past the submit-time value", () => {
+    expect(shouldReenableAfterRejection(true, 4, 3)).toBe(true);
+  });
+
+  it("unlocks on any nonce change (a second rejection re-arms too)", () => {
+    // Two consecutive rejections yield identical banner text (deduped), but the
+    // nonce still advances — so the overlay unlocks each time, which the old
+    // error-string approach could not guarantee.
+    expect(shouldReenableAfterRejection(true, 5, 4)).toBe(true);
+  });
+});

--- a/clients/web/src/lib/gameStore.svelte.ts
+++ b/clients/web/src/lib/gameStore.svelte.ts
@@ -1,28 +1,38 @@
 import {
-  GameController,
-  getVisibleEvent,
-  getVisibleState as engineGetVisibleState,
   type Action,
   type ActionDef,
   type Card,
+  getVisibleState as engineGetVisibleState,
+  GameController,
   type GameEvent,
   type GameState,
+  getVisibleEvent,
   type PlayerDescriptor,
+  setAutoFreeze,
   type VisibleState,
 } from "cards-engine";
-import { setAutoFreeze } from "cards-engine";
-import { HotseatAdapter } from "./HotseatAdapter";
-import { DEFAULT_CONFIG, buildSeedingSetup, buildMainSetup } from "./gameSetup";
-import { autoSave, listSessions, loadSession, saveSession } from "./persistence";
 import {
   buildCombatContestResult,
   buildDslContestResult,
-  stepCombatBuffer,
   type CombatBufferStep,
   type ContestResult,
+  stepCombatBuffer,
 } from "./contestResult";
+import { buildMainSetup, buildSeedingSetup, DEFAULT_CONFIG } from "./gameSetup";
+import { HotseatAdapter } from "./HotseatAdapter";
+import {
+  autoSave,
+  listSessions,
+  loadSession,
+  saveSession,
+} from "./persistence";
 
-export type { ContestOutcome, ContestResult, PairDetail, PairSideView } from "./contestResult";
+export type {
+  ContestOutcome,
+  ContestResult,
+  PairDetail,
+  PairSideView,
+} from "./contestResult";
 
 // Immer auto-freezes produce() output. Svelte 5's $state uses deep proxies.
 // Frozen objects passed into $state (and proxied objects passed back to immer)
@@ -97,7 +107,7 @@ export function dismissContest() {
 // Derived card name lookup — rebuilt when visible state changes.
 // Covers grid, hand, HQ, policies, decks, discard, removed, market,
 // middle area, and opponent public zones.
-let _cardNameMap = $derived.by(() => {
+const _cardNameMap = $derived.by(() => {
   const vs = _visibleState;
   if (!vs) return new Map<string, string>();
   const map = new Map<string, string>();
@@ -109,9 +119,14 @@ let _cardNameMap = $derived.by(() => {
     }
   }
   const selfZones = [
-    vs.self.hand, vs.self.hq, vs.self.activePolicies,
-    vs.self.discardPile, vs.self.removedFromGame,
-    vs.self.seedingDeck, vs.self.prospectDeck, vs.self.policyPool,
+    vs.self.hand,
+    vs.self.hq,
+    vs.self.activePolicies,
+    vs.self.discardPile,
+    vs.self.removedFromGame,
+    vs.self.seedingDeck,
+    vs.self.prospectDeck,
+    vs.self.policyPool,
   ];
   for (const zone of selfZones) {
     for (const c of zone) map.set(c.id, c.name);
@@ -298,7 +313,9 @@ function onEvent(events: GameEvent[], state: GameState): void {
   _combatEvents = combat.buffer;
 
   if (contestEvents.length > 1) {
-    pushError("Multiple contest_resolved events in one batch — only the first is shown.");
+    pushError(
+      "Multiple contest_resolved events in one batch — only the first is shown.",
+    );
   }
 
   switch (combat.outcome.kind) {
@@ -307,11 +324,16 @@ function onEvent(events: GameEvent[], state: GameState): void {
       // dialog from the whole accumulated combat. A co-batched contest loses to
       // the combat popup, so warn only here — where a dialog is actually shown.
       if (contestEvents.length > 0) {
-        pushError("Both combat and a contest resolved in the same batch — only the combat popup is shown.");
+        pushError(
+          "Both combat and a contest resolved in the same batch — only the combat popup is shown.",
+        );
       }
-      const { result: combatResult, error: combatError } = buildCombatContestResult(
-        combat.outcome.dialogEvents, _visibleState, resolvers,
-      );
+      const { result: combatResult, error: combatError } =
+        buildCombatContestResult(
+          combat.outcome.dialogEvents,
+          _visibleState,
+          resolvers,
+        );
       if (combatError) pushError(combatError);
       _contestResult = combatResult;
       break;
@@ -323,7 +345,9 @@ function onEvent(events: GameEvent[], state: GameState): void {
       break;
     case "orphan":
       _contestResult = null;
-      pushError("Combat pair event arrived without combat_started — popup skipped.");
+      pushError(
+        "Combat pair event arrived without combat_started — popup skipped.",
+      );
       break;
     case "none": {
       // No combat dialog to build (no combat events, or a multi-round fight
@@ -331,9 +355,14 @@ function onEvent(events: GameEvent[], state: GameState): void {
       const contestResolved = contestEvents[0];
       if (contestResolved && contestResolved.type === "contest_resolved") {
         const contestIdx = events.indexOf(contestResolved);
-        const { result: contestResult, error: contestError } = buildDslContestResult(
-          contestResolved, contestIdx, events, _visibleState, resolvers,
-        );
+        const { result: contestResult, error: contestError } =
+          buildDslContestResult(
+            contestResolved,
+            contestIdx,
+            events,
+            _visibleState,
+            resolvers,
+          );
         if (contestResult) {
           _contestResult = contestResult;
         } else if (contestError) {
@@ -374,7 +403,8 @@ function onEvent(events: GameEvent[], state: GameState): void {
       console.error("Failed to serialize session for auto-save:", err);
       autoSaveFailCount++;
       if (autoSaveFailCount >= 3) {
-        _error = "Auto-save is failing. Your progress may not be saved. Try saving manually.";
+        _error =
+          "Auto-save is failing. Your progress may not be saved. Try saving manually.";
       }
     }
   }
@@ -385,6 +415,19 @@ function handleGameLoopError(err: unknown): void {
   console.error("Game loop error:", err);
   _error = `The game encountered an error: ${err instanceof Error ? err.message : String(err)}`;
   _screen = "playing";
+}
+
+/**
+ * The engine rejected a submitted action at the pre-apply gate (#182). The loop
+ * has already re-prompted the same decider, so `resolveAction` is freshly armed
+ * — we only need to surface the rejection. Setting the banner is what the combat
+ * / pick overlay recovery `$effect`s watch (`error !== errorAtSubmit`) to
+ * re-enable their Confirm button. `pushError` appends so a fresh message always
+ * differs from the prior banner, guaranteeing the overlay unlocks.
+ */
+function handleInvalidAction(_err: unknown, playerId: string): void {
+  const name = players.find((p) => p.id === playerId)?.name ?? playerId;
+  pushError(`That move wasn't legal — please choose again (${name}).`);
 }
 
 // ---------------------------------------------------------------------------
@@ -409,7 +452,11 @@ export function startNewGame(
 
   const adapters = new Map<string, HotseatAdapter>();
   for (const p of players) {
-    const adapter: HotseatAdapter = new HotseatAdapter(onBeforeTurn, onTurnStart, waitForAction);
+    const adapter: HotseatAdapter = new HotseatAdapter(
+      onBeforeTurn,
+      onTurnStart,
+      waitForAction,
+    );
     if (skipSeeding) adapter.autoSeeding = true;
     adapters.set(p.id, adapter);
   }
@@ -431,6 +478,7 @@ export function startNewGame(
     setupInput,
     adapters,
     onEvent,
+    onInvalidAction: handleInvalidAction,
   });
 
   controller.run().catch(handleGameLoopError);
@@ -456,7 +504,8 @@ export async function loadGame(key: string): Promise<void> {
   try {
     setupInput = buildSeedingSetup(players);
   } catch (err) {
-    _error = "Failed to initialize card data. Run 'bun library/build.ts' first.";
+    _error =
+      "Failed to initialize card data. Run 'bun library/build.ts' first.";
     console.error("buildSeedingSetup failed:", err);
     return;
   }
@@ -484,6 +533,7 @@ export async function loadGame(key: string): Promise<void> {
       setupInput,
       adapters,
       onEvent,
+      handleInvalidAction,
     );
   } catch (err) {
     _error = `Failed to resume game: ${err instanceof Error ? err.message : String(err)}`;
@@ -502,7 +552,13 @@ export async function loadGame(key: string): Promise<void> {
   if (state.phase === "main" && state.combatPrompt) {
     const cp = state.combatPrompt;
     _combatEvents = [
-      { type: "combat_started", row: cp.row, col: cp.col, attackerId: cp.attackerId, defenderId: cp.defenderId },
+      {
+        type: "combat_started",
+        row: cp.row,
+        col: cp.col,
+        attackerId: cp.attackerId,
+        defenderId: cp.defenderId,
+      },
     ];
   }
 

--- a/clients/web/src/lib/gameStore.svelte.ts
+++ b/clients/web/src/lib/gameStore.svelte.ts
@@ -7,6 +7,7 @@ import {
   type GameEvent,
   type GameState,
   getVisibleEvent,
+  type InvalidActionError,
   type PlayerDescriptor,
   setAutoFreeze,
   type VisibleState,
@@ -26,6 +27,7 @@ import {
   loadSession,
   saveSession,
 } from "./persistence";
+import { appendBanner } from "./promptRecovery";
 
 export type {
   ContestOutcome,
@@ -53,6 +55,11 @@ let _currentPlayerName = $state("");
 let _savedSessions = $state<string[]>([]);
 let _gamePhase = $state<"seeding" | "main" | "ended" | null>(null);
 let _error = $state<string | null>(null);
+// Monotonic counter bumped every time the engine rejects a submitted action
+// (#182). The combat/pick overlays watch this — not the error-banner string —
+// to re-enable their Confirm button after a rejection, so the banner is free
+// to dedupe/replace without the unlock silently breaking.
+let _rejectionNonce = $state(0);
 let _prevTurnStartIndex = $state(0);
 let _lastTurnStartIndex = $state(0);
 // Pending viewer for the pass-device overlay. Set in onBeforeTurn (when the
@@ -195,6 +202,11 @@ export function resolvePlayerName(id: string): string {
 export function getError() {
   return _error;
 }
+/** Monotonic count of engine action-rejections this session — the signal the
+ *  combat/pick overlays use to unlock Confirm after a rejected submission. */
+export function getRejectionNonce(): number {
+  return _rejectionNonce;
+}
 /** Events from the previous turn — shown on the pass-device overlay.
  *  Projected for the INCOMING player (who is about to read the recap),
  *  not `_visibleState.playerId` which still holds the outgoing player's
@@ -217,10 +229,11 @@ export function setError(message: string): void {
 
 /** Append a message to the current error banner, separated by a newline if
  *  another message is already showing. Replaces the old pattern of
- *  `_error = "..."` which silently clobbered prior warnings — see
- *  Finding #1 in the /review-pr findings. */
+ *  `_error = "..."` which silently clobbered prior warnings. Consecutive
+ *  identical messages are deduped so a repeated rejection re-prompt can't grow
+ *  the banner without bound. */
 function pushError(message: string): void {
-  _error = _error ? `${_error}\n${message}` : message;
+  _error = appendBanner(_error, message);
 }
 
 // ---------------------------------------------------------------------------
@@ -395,8 +408,9 @@ function onEvent(events: GameEvent[], state: GameState): void {
           console.error("Auto-save failed:", err);
           autoSaveFailCount++;
           if (autoSaveFailCount >= 3) {
-            _error =
-              "Auto-save is failing. Your progress may not be saved. Try saving manually.";
+            pushError(
+              "Auto-save is failing. Your progress may not be saved. Try saving manually.",
+            );
           }
         });
     } catch (err) {
@@ -419,14 +433,20 @@ function handleGameLoopError(err: unknown): void {
 
 /**
  * The engine rejected a submitted action at the pre-apply gate (#182). The loop
- * has already re-prompted the same decider, so `resolveAction` is freshly armed
- * — we only need to surface the rejection. Setting the banner is what the combat
- * / pick overlay recovery `$effect`s watch (`error !== errorAtSubmit`) to
- * re-enable their Confirm button. `pushError` appends so a fresh message always
- * differs from the prior banner, guaranteeing the overlay unlocks.
+ * will re-prompt the same decider on its next iteration (re-arming
+ * `resolveAction`), so here we only surface the rejection: log the offending
+ * action for debugging (a repeat rejection of a *legal* move signals a
+ * getValidActions/applyAction desync, not user error), and bump
+ * `_rejectionNonce` — the signal the combat/pick overlays watch to re-enable
+ * their Confirm button. The banner itself is just user-facing text and is
+ * deduped, so it no longer needs to differ on each rejection to drive the
+ * unlock.
  */
-function handleInvalidAction(_err: unknown, playerId: string): void {
+function handleInvalidAction(err: InvalidActionError): void {
+  console.error("Engine rejected submitted action:", err);
+  const playerId = err.actingPlayerId;
   const name = players.find((p) => p.id === playerId)?.name ?? playerId;
+  _rejectionNonce++;
   pushError(`That move wasn't legal — please choose again (${name}).`);
 }
 
@@ -580,7 +600,9 @@ export function selectAction(action: Action): void {
       "selectAction called with no pending resolver — action dropped",
       { actionType: action.type, actionPlayerId: action.playerId },
     );
-    _error = "Action dropped — please try again.";
+    pushError(
+      "That action couldn't be applied — it may already be your opponent's turn.",
+    );
     return;
   }
   const resolve = resolveAction;

--- a/clients/web/src/lib/gameStore.svelte.ts
+++ b/clients/web/src/lib/gameStore.svelte.ts
@@ -443,7 +443,11 @@ function handleGameLoopError(err: unknown): void {
  * unlock.
  */
 function handleInvalidAction(err: InvalidActionError): void {
-  console.error("Engine rejected submitted action:", err);
+  console.error(
+    `Engine rejected submitted action (${err.reason}):`,
+    err.action,
+    err,
+  );
   const playerId = err.actingPlayerId;
   const name = players.find((p) => p.id === playerId)?.name ?? playerId;
   _rejectionNonce++;

--- a/clients/web/src/lib/promptRecovery.ts
+++ b/clients/web/src/lib/promptRecovery.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure helpers for the engine-rejection recovery contract (#182), extracted so
+ * the fragile invariants can be unit-tested — the reactive `gameStore.svelte.ts`
+ * store and the `.svelte` overlays can't be imported under `bun test` (runes
+ * need Svelte compilation).
+ */
+
+/**
+ * Append `message` to the current error banner, newline-separated, deduping a
+ * consecutive identical trailing message.
+ *
+ * The rejection re-prompt pushes the same "choose again" line on every rejected
+ * submission; without the dedupe a broken client / enumerator desync would grow
+ * the banner to ~100 identical lines before the loop's give-up backstop trips.
+ * Only the *trailing* segment is compared, so distinct interleaved warnings
+ * still accumulate.
+ */
+export function appendBanner(
+  current: string | null,
+  message: string,
+): string {
+  if (!current) return message;
+  const segments = current.split("\n");
+  if (segments[segments.length - 1] === message) return current;
+  return `${current}\n${message}`;
+}
+
+/**
+ * Whether a combat/pick overlay should re-enable its Confirm button after a
+ * submit. True exactly when the overlay is mid-submit AND the monotonic
+ * rejection nonce has advanced past the value captured at submit time — i.e.
+ * the engine rejected *this* submission.
+ *
+ * Keying off the nonce (not the error-banner string) means an unrelated banner
+ * change can neither spuriously unlock Confirm nor, if two rejection messages
+ * happened to be identical, leave it permanently stuck.
+ */
+export function shouldReenableAfterRejection(
+  submitted: boolean,
+  currentNonce: number,
+  nonceAtSubmit: number,
+): boolean {
+  return submitted && currentNonce !== nonceAtSubmit;
+}

--- a/engine/src/__tests__/action-validation.test.ts
+++ b/engine/src/__tests__/action-validation.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { canonicalActionKey, isLegalAction } from "../action-validation";
+import {
+  canonicalActionKey,
+  checkActionLegality,
+  isLegalAction,
+} from "../action-validation";
 import type { Action } from "../types";
 
 // Helpers to build the payloads the enumerator emits, as plain literals — this
@@ -205,6 +209,57 @@ describe("isLegalAction", () => {
       exposeIds: [],
     };
     expect(isLegalAction(filled, valid)).toBe(false);
+  });
+});
+
+describe("checkActionLegality", () => {
+  it("returns { legal: true } for an enumerated action", () => {
+    const valid = [sitOut(["u1", "u2"])];
+    expect(checkActionLegality(sitOut(["u2", "u1"]), valid)).toEqual({
+      legal: true,
+    });
+  });
+
+  it("reports type_not_offered when no valid action shares the type", () => {
+    const valid: Action[] = [{ type: "pass", playerId: "p1" }];
+    const filled: Action = {
+      type: "seed_keep",
+      playerId: "p1",
+      keepIds: [],
+      exposeIds: [],
+    };
+    expect(checkActionLegality(filled, valid)).toEqual({
+      legal: false,
+      reason: "type_not_offered",
+    });
+  });
+
+  it("reports wrong_player when the type is offered but the playerId isn't", () => {
+    // getValidActions enumerates only the acting player's actions, so a
+    // matching type addressed to a different player is a wrong-player rejection.
+    const valid: Action[] = [
+      { type: "seed_keep", playerId: "p1", keepIds: [], exposeIds: [] },
+    ];
+    const wrongPlayer: Action = {
+      type: "seed_keep",
+      playerId: "p2",
+      keepIds: [],
+      exposeIds: [],
+    };
+    expect(checkActionLegality(wrongPlayer, valid)).toEqual({
+      legal: false,
+      reason: "wrong_player",
+    });
+  });
+
+  it("reports payload_mismatch for a deep-validated action with a bad payload", () => {
+    // type + player are offered, but the sit-out ids aren't in the enumerated
+    // legal set — the distinctively deep-validation failure.
+    const valid = [sitOut(["u1", "u2"]), sitOut(["u1", "u3"])];
+    expect(checkActionLegality(sitOut(["u1", "u9"]), valid)).toEqual({
+      legal: false,
+      reason: "payload_mismatch",
+    });
   });
 });
 

--- a/engine/src/__tests__/action-validation.test.ts
+++ b/engine/src/__tests__/action-validation.test.ts
@@ -123,6 +123,33 @@ describe("isLegalAction", () => {
     expect(isLegalAction(pick(["c2", "c3"]), valid)).toBe(false);
   });
 
+  it("rejects a resolve_pick superset of an enumerated entry", () => {
+    // The mirror of the subset case: submitting MORE ids than any enumerated
+    // entry must fail too — canonicalization is length-sensitive, so sorting
+    // collapses permutations only, never grows or shrinks the set.
+    const valid = [pick(["c1", "c2"]), pick(["c1", "c3"])];
+    expect(isLegalAction(pick(["c1", "c2", "c3"]), valid)).toBe(false);
+  });
+
+  it("rejects a scholar_reorder multiset outside the enumerated orbit", () => {
+    // The order-safety proof rests on the WHOLE permutation orbit being
+    // enumerated (so collapsing orderings can't admit an illegal action). A
+    // submission whose multiset isn't in the orbit — a duplicated id, or an
+    // id the prompt never offered — must still be rejected even though it has
+    // the orbit's length. This isolates the claim the reject side otherwise
+    // only exercises via plain subsets.
+    const orbit = [
+      pick(["c1", "c2", "c3"]),
+      pick(["c1", "c3", "c2"]),
+      pick(["c2", "c1", "c3"]),
+      pick(["c2", "c3", "c1"]),
+      pick(["c3", "c1", "c2"]),
+      pick(["c3", "c2", "c1"]),
+    ];
+    expect(isLegalAction(pick(["c1", "c1", "c2"]), orbit)).toBe(false); // duplicate
+    expect(isLegalAction(pick(["c1", "c2", "c4"]), orbit)).toBe(false); // out-of-orbit id
+  });
+
   it("returns false against an empty valid set", () => {
     expect(isLegalAction(sitOut(["u1"]), [])).toBe(false);
   });
@@ -155,6 +182,29 @@ describe("isLegalAction", () => {
       exposeIds: [],
     };
     expect(isLegalAction(wrongPlayer, valid)).toBe(false);
+  });
+
+  it("shallow-rejects a template-style action against an empty valid set", () => {
+    // The shallow branch is a distinct code path from the deep branch's
+    // empty-set reject — guard it directly.
+    const filled: Action = {
+      type: "seed_keep",
+      playerId: "p1",
+      keepIds: ["c1"],
+      exposeIds: [],
+    };
+    expect(isLegalAction(filled, [])).toBe(false);
+  });
+
+  it("shallow-rejects when only a different action type is enumerated", () => {
+    const valid: Action[] = [{ type: "pass", playerId: "p1" }];
+    const filled: Action = {
+      type: "seed_keep",
+      playerId: "p1",
+      keepIds: [],
+      exposeIds: [],
+    };
+    expect(isLegalAction(filled, valid)).toBe(false);
   });
 });
 
@@ -192,5 +242,34 @@ describe("canonicalActionKey", () => {
     const subset = canonicalActionKey(pick(["c1", "c2"]));
     expect(reordered).toBe(full); // permutation-invariant
     expect(subset).not.toBe(full); // subset-sensitive
+  });
+
+  it("drops an undefined field nested inside a decision payload", () => {
+    // The undefined-dropping recurses to any depth, not just the top level.
+    const withUndef = {
+      type: "resolve_combat_round",
+      playerId: "p1",
+      decision: { kind: "retreat", retreat: true, extra: undefined },
+    } as unknown as Action;
+    const without = {
+      type: "resolve_combat_round",
+      playerId: "p1",
+      decision: { kind: "retreat", retreat: true },
+    } as unknown as Action;
+    expect(canonicalActionKey(withUndef)).toBe(canonicalActionKey(without));
+  });
+
+  it("sorts an array of objects order-insensitively", () => {
+    // Exercises the array-of-objects comparator (each element canonicalized
+    // then stringified) directly, not just via assign_matchups.
+    const a = matchups([
+      ["a1", "d1"],
+      ["a2", "d2"],
+    ]);
+    const b = matchups([
+      ["a2", "d2"],
+      ["a1", "d1"],
+    ]);
+    expect(canonicalActionKey(a)).toBe(canonicalActionKey(b));
   });
 });

--- a/engine/src/__tests__/action-validation.test.ts
+++ b/engine/src/__tests__/action-validation.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "bun:test";
+import { canonicalActionKey, isLegalAction } from "../action-validation";
+import type { Action } from "../types";
+
+// Helpers to build the payloads the enumerator emits, as plain literals — this
+// suite exercises the pure membership check, so it needs no game state.
+function sitOut(ids: string[]): Action {
+  return {
+    type: "resolve_combat_round",
+    playerId: "p1",
+    decision: { kind: "sit_out", sitOutUnitIds: ids },
+  };
+}
+
+function matchups(pairs: [string, string][]): Action {
+  return {
+    type: "resolve_combat_round",
+    playerId: "p1",
+    decision: {
+      kind: "assign_matchups",
+      pairs: pairs.map(([attackerUnitId, defenderUnitId]) => ({
+        attackerUnitId,
+        defenderUnitId,
+      })),
+    },
+  };
+}
+
+function pick(ids: [string, ...string[]]): Action {
+  return { type: "resolve_pick", playerId: "p1", pickedCardIds: ids };
+}
+
+describe("isLegalAction", () => {
+  it("accepts an action that exactly matches an enumerated entry", () => {
+    const valid = [sitOut(["u1", "u2"]), sitOut(["u1", "u3"])];
+    expect(isLegalAction(sitOut(["u1", "u2"]), valid)).toBe(true);
+  });
+
+  it("accepts a valid sit_out submitted in a different id order (regression guard)", () => {
+    // The overlay builds sitOutUnitIds in click order; the enumerator emits
+    // them power-ascending. An order-sensitive check would false-reject this.
+    const valid = [sitOut(["u1", "u2"]), sitOut(["u1", "u3"])];
+    expect(isLegalAction(sitOut(["u2", "u1"]), valid)).toBe(true);
+  });
+
+  it("accepts assign_matchups with the pairs array reordered", () => {
+    const valid = [
+      matchups([
+        ["a1", "d1"],
+        ["a2", "d2"],
+      ]),
+    ];
+    // Same bijection, pairs listed in the other order.
+    expect(
+      isLegalAction(
+        matchups([
+          ["a2", "d2"],
+          ["a1", "d1"],
+        ]),
+        valid,
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts a deck_pick submitted in a different order than enumerated", () => {
+    const valid = [pick(["c1", "c2"]), pick(["c1", "c3"])];
+    expect(isLegalAction(pick(["c2", "c1"]), valid)).toBe(true);
+  });
+
+  it("accepts any enumerated scholar_reorder permutation", () => {
+    // scholar_reorder enumerates the whole permutation orbit; every ordering is
+    // legal, so an order-insensitive match still returns the correct verdict.
+    const valid = [
+      pick(["c1", "c2", "c3"]),
+      pick(["c1", "c3", "c2"]),
+      pick(["c2", "c1", "c3"]),
+      pick(["c2", "c3", "c1"]),
+      pick(["c3", "c1", "c2"]),
+      pick(["c3", "c2", "c1"]),
+    ];
+    expect(isLegalAction(pick(["c3", "c1", "c2"]), valid)).toBe(true);
+  });
+
+  // --- The cases the old shallow (type + playerId) gate let through ---------
+
+  it("rejects a sit_out whose id is not on the larger side", () => {
+    const valid = [sitOut(["u1", "u2"]), sitOut(["u1", "u3"])];
+    expect(isLegalAction(sitOut(["u1", "u9"]), valid)).toBe(false);
+  });
+
+  it("rejects assign_matchups pairing a defender not in the prompt", () => {
+    const valid = [
+      matchups([
+        ["a1", "d1"],
+        ["a2", "d2"],
+      ]),
+    ];
+    expect(
+      isLegalAction(
+        matchups([
+          ["a1", "d1"],
+          ["a2", "d9"],
+        ]),
+        valid,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a decision kind the prompt did not offer", () => {
+    // A sit_out prompt: submitting a retreat has the right type + playerId but
+    // an illegal payload — exactly what the shallow gate missed.
+    const valid = [sitOut(["u1", "u2"])];
+    const retreat: Action = {
+      type: "resolve_combat_round",
+      playerId: "p1",
+      decision: { kind: "retreat", retreat: true },
+    };
+    expect(isLegalAction(retreat, valid)).toBe(false);
+  });
+
+  it("rejects a resolve_pick set that isn't an enumerated subset", () => {
+    const valid = [pick(["c1", "c2"]), pick(["c1", "c3"])];
+    expect(isLegalAction(pick(["c2", "c3"]), valid)).toBe(false);
+  });
+
+  it("returns false against an empty valid set", () => {
+    expect(isLegalAction(sitOut(["u1"]), [])).toBe(false);
+  });
+
+  // Deep validation is deliberately scoped to the exhaustively-enumerated
+  // decision actions. Template-style actions (seed_keep and the rotation-bearing
+  // seeding/raze actions) keep the shallow type+playerId check, because their
+  // enumeration is a template the adapter fills — a deep-equal would false-reject.
+  it("shallow-accepts a filled seed_keep against its enumerated template", () => {
+    const valid: Action[] = [
+      { type: "seed_keep", playerId: "p1", keepIds: [], exposeIds: [] },
+    ];
+    const filled: Action = {
+      type: "seed_keep",
+      playerId: "p1",
+      keepIds: ["c1", "c2"],
+      exposeIds: ["c3"],
+    };
+    expect(isLegalAction(filled, valid)).toBe(true);
+  });
+
+  it("still rejects a template-style action for the wrong player", () => {
+    const valid: Action[] = [
+      { type: "seed_keep", playerId: "p1", keepIds: [], exposeIds: [] },
+    ];
+    const wrongPlayer: Action = {
+      type: "seed_keep",
+      playerId: "p2",
+      keepIds: [],
+      exposeIds: [],
+    };
+    expect(isLegalAction(wrongPlayer, valid)).toBe(false);
+  });
+});
+
+describe("canonicalActionKey", () => {
+  it("is invariant to object key order", () => {
+    const a: Action = {
+      type: "buy",
+      playerId: "p1",
+      cardId: "c1",
+      costIndex: 0,
+    };
+    const b = {
+      costIndex: 0,
+      cardId: "c1",
+      playerId: "p1",
+      type: "buy",
+    } as Action;
+    expect(canonicalActionKey(a)).toBe(canonicalActionKey(b));
+  });
+
+  it("treats an explicit undefined field the same as an omitted one", () => {
+    const withUndef: Action = {
+      type: "buy",
+      playerId: "p1",
+      cardId: "c1",
+      costIndex: undefined,
+    };
+    const without = { type: "buy", playerId: "p1", cardId: "c1" } as Action;
+    expect(canonicalActionKey(withUndef)).toBe(canonicalActionKey(without));
+  });
+
+  it("collapses permutations but distinguishes subsets", () => {
+    const full = canonicalActionKey(pick(["c1", "c2", "c3"]));
+    const reordered = canonicalActionKey(pick(["c3", "c1", "c2"]));
+    const subset = canonicalActionKey(pick(["c1", "c2"]));
+    expect(reordered).toBe(full); // permutation-invariant
+    expect(subset).not.toBe(full); // subset-sensitive
+  });
+});

--- a/engine/src/__tests__/controller.test.ts
+++ b/engine/src/__tests__/controller.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "bun:test";
 import { produce } from "immer";
 import { applyAction } from "../apply-action";
 import { BotAdapter } from "../bot-adapter";
-import { GameController, InvalidActionError } from "../controller";
+import {
+  GameController,
+  InvalidActionError,
+  MAX_CONSECUTIVE_REJECTIONS,
+} from "../controller";
 import type {
   Action,
   GameEvent,
@@ -251,9 +255,11 @@ describe("GameController", () => {
       const rejected: string[] = [];
 
       let deciderCalls = 0;
+      const deciderViewers: string[] = [];
       const deciderAdapter: PlayerAdapter = {
-        async chooseAction(_vis: VisibleState, valid: Action[]) {
+        async chooseAction(vis: VisibleState, valid: Action[]) {
           deciderCalls++;
+          deciderViewers.push(vis.playerId);
           if (deciderCalls === 1) {
             // Structurally-typed but illegal — rejected at the gate.
             return {
@@ -293,7 +299,7 @@ describe("GameController", () => {
           ["p2", passAdapter],
         ]),
         (evs) => events.push(...evs),
-        (_err, playerId) => rejected.push(playerId),
+        (err) => rejected.push(err.actingPlayerId),
       );
 
       // The loop survives the rejection and keeps running; with only passes the
@@ -302,6 +308,10 @@ describe("GameController", () => {
 
       expect(rejected).toEqual(["p1"]); // re-prompted exactly once, same decider
       expect(deciderCalls).toBeGreaterThanOrEqual(2);
+      // The re-prompt routed back to the SAME decider (p1), not the active
+      // player: both of the first two prompts projected p1's view. Guards
+      // against an accidental p2 turn slipping between the reject and re-prompt.
+      expect(deciderViewers.slice(0, 2)).toEqual(["p1", "p1"]);
       expect(events.filter((e) => e.type === "combat_resolved")).toHaveLength(
         1,
       );
@@ -333,10 +343,21 @@ describe("GameController", () => {
         },
       });
 
-      await expect(controller.run()).rejects.toBeInstanceOf(InvalidActionError);
-      // It re-prompted many times before giving up, rather than throwing on the
-      // first rejection or looping forever.
-      expect(rejections).toBeGreaterThan(1);
+      // Giving up wraps the last rejection in an annotated terminal error
+      // (with the raw InvalidActionError as `cause`), rather than re-throwing
+      // the bare InvalidActionError or looping forever.
+      const err = await controller.run().then(
+        () => {
+          throw new Error("expected run() to reject");
+        },
+        (e: unknown) => e as Error,
+      );
+      expect(err.message).toMatch(/gave up after \d+ consecutive/);
+      expect(err.cause).toBeInstanceOf(InvalidActionError);
+      // It gave up at the *consecutive-rejection* boundary (100), not the
+      // max-actions guard (10,000) — the callback fires once per rejection up
+      // to but excluding the give-up iteration.
+      expect(rejections).toBe(MAX_CONSECUTIVE_REJECTIONS);
     });
   });
 

--- a/engine/src/__tests__/controller.test.ts
+++ b/engine/src/__tests__/controller.test.ts
@@ -366,6 +366,38 @@ describe("GameController", () => {
       // to but excluding the give-up iteration.
       expect(rejections).toBe(MAX_CONSECUTIVE_REJECTIONS);
     });
+
+    // The rejection cap is injectable like maxActions — a caller can tighten it.
+    it("run() honors a custom maxConsecutiveRejections cap", async () => {
+      let rejections = 0;
+      const alwaysInvalid: PlayerAdapter = {
+        async chooseAction() {
+          return { type: "deploy", playerId: "p1", cardId: "fake" };
+        },
+      };
+      const controller = new GameController({
+        config: DEFAULT_CONFIG,
+        players: TWO_PLAYERS,
+        seed: SEED,
+        setupInput: MAIN_SETUP_INPUT,
+        adapters: new Map<string, PlayerAdapter>([
+          ["p1", alwaysInvalid],
+          ["p2", alwaysInvalid],
+        ]),
+        onInvalidAction: () => {
+          rejections++;
+        },
+      });
+
+      const err = await controller.run(undefined, 3).then(
+        () => {
+          throw new Error("expected run() to reject");
+        },
+        (e: unknown) => e as Error,
+      );
+      expect(err.message).toMatch(/gave up after 3 consecutive/);
+      expect(rejections).toBe(3); // gave up at the custom cap, not the default
+    });
   });
 
   describe("run", () => {

--- a/engine/src/__tests__/controller.test.ts
+++ b/engine/src/__tests__/controller.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from "bun:test";
 import { produce } from "immer";
 import { applyAction } from "../apply-action";
 import { BotAdapter } from "../bot-adapter";
-import { GameController } from "../controller";
+import { GameController, InvalidActionError } from "../controller";
 import type {
   Action,
-  SetupInput,
   GameEvent,
   GameState,
   MainGameState,
   PlayerAdapter,
   Session,
+  SetupInput,
   VisibleState,
 } from "../types";
 import {
@@ -115,7 +115,11 @@ describe("GameController", () => {
         ]),
       });
 
-      await expect(controller.playTurn()).rejects.toThrow("invalid action");
+      // playTurn keeps its throw-based contract for programmatic callers, and
+      // the throw is now the typed InvalidActionError that run() keys off of.
+      await expect(controller.playTurn()).rejects.toBeInstanceOf(
+        InvalidActionError,
+      );
     });
   });
 
@@ -162,7 +166,9 @@ describe("GameController", () => {
       };
       const attackerAdapter: PlayerAdapter = {
         async chooseAction() {
-          throw new Error("attacker adapter must not be asked while combat is suspended");
+          throw new Error(
+            "attacker adapter must not be asked while combat is suspended",
+          );
         },
       };
 
@@ -190,8 +196,147 @@ describe("GameController", () => {
         await controller.playTurn();
       }
 
-      expect((controller.getState() as MainGameState).combatPrompt).toBeUndefined();
-      expect(events.filter((e) => e.type === "combat_resolved")).toHaveLength(1);
+      expect(
+        (controller.getState() as MainGameState).combatPrompt,
+      ).toBeUndefined();
+      expect(events.filter((e) => e.type === "combat_resolved")).toHaveLength(
+        1,
+      );
+    });
+
+    // Deep-validation gate (#182 A): a resolve_combat_round with the right type
+    // and playerId but a bogus matchup payload passed the old shallow gate and
+    // was left for applyAction to throw. It must now be rejected at playTurn.
+    it("deep-rejects a malformed combat decision at the playTurn gate", async () => {
+      const suspended = buildSuspendedCombat();
+      const malformedAdapter: PlayerAdapter = {
+        async chooseAction() {
+          return {
+            type: "resolve_combat_round",
+            playerId: "p1",
+            decision: {
+              kind: "assign_matchups",
+              pairs: [{ attackerUnitId: "nope", defenderUnitId: "nope" }],
+            },
+          };
+        },
+      };
+      const session: Session = {
+        version: "0.1.0",
+        config: DEFAULT_CONFIG,
+        players: TWO_PLAYERS,
+        seed: SEED,
+        actions: [],
+        snapshot: suspended,
+      };
+      const controller = GameController.fromSession(
+        session,
+        MAIN_SETUP_INPUT,
+        new Map<string, PlayerAdapter>([
+          ["p1", malformedAdapter],
+          ["p2", malformedAdapter],
+        ]),
+      );
+
+      await expect(controller.playTurn()).rejects.toBeInstanceOf(
+        InvalidActionError,
+      );
+    });
+
+    // Loop survival (#182 B): a rejected submission must not tear down run().
+    // The decider is re-prompted and a subsequent legal action is applied.
+    it("run() survives a rejected action and re-prompts the same decider", async () => {
+      const suspended = buildSuspendedCombat();
+      const events: GameEvent[] = [];
+      const rejected: string[] = [];
+
+      let deciderCalls = 0;
+      const deciderAdapter: PlayerAdapter = {
+        async chooseAction(_vis: VisibleState, valid: Action[]) {
+          deciderCalls++;
+          if (deciderCalls === 1) {
+            // Structurally-typed but illegal — rejected at the gate.
+            return {
+              type: "resolve_combat_round",
+              playerId: "p1",
+              decision: {
+                kind: "assign_matchups",
+                pairs: [{ attackerUnitId: "nope", defenderUnitId: "nope" }],
+              },
+            };
+          }
+          return valid[0]; // greedy default on the re-prompt
+        },
+      };
+      // After the fight resolves the attacker resumes; keep the loop cheap with
+      // passes so it winds down to the max-actions guard (the game never ends on
+      // passes alone).
+      const passAdapter: PlayerAdapter = {
+        async chooseAction(_vis: VisibleState, valid: Action[]) {
+          return valid.find((a) => a.type === "pass") ?? valid[0];
+        },
+      };
+
+      const session: Session = {
+        version: "0.1.0",
+        config: DEFAULT_CONFIG,
+        players: TWO_PLAYERS,
+        seed: SEED,
+        actions: [],
+        snapshot: suspended,
+      };
+      const controller = GameController.fromSession(
+        session,
+        MAIN_SETUP_INPUT,
+        new Map<string, PlayerAdapter>([
+          ["p1", deciderAdapter],
+          ["p2", passAdapter],
+        ]),
+        (evs) => events.push(...evs),
+        (_err, playerId) => rejected.push(playerId),
+      );
+
+      // The loop survives the rejection and keeps running; with only passes the
+      // game never ends, so the max-actions guard is the terminal signal.
+      await expect(controller.run(20)).rejects.toThrow("exceeded 20 actions");
+
+      expect(rejected).toEqual(["p1"]); // re-prompted exactly once, same decider
+      expect(deciderCalls).toBeGreaterThanOrEqual(2);
+      expect(events.filter((e) => e.type === "combat_resolved")).toHaveLength(
+        1,
+      );
+      expect(
+        (controller.getState() as MainGameState).combatPrompt,
+      ).toBeUndefined();
+    });
+
+    // A persistently-broken adapter must not spin forever — the consecutive
+    // rejection guard converts it into a clean terminal throw.
+    it("run() gives up after too many consecutive rejected submissions", async () => {
+      let rejections = 0;
+      const alwaysInvalid: PlayerAdapter = {
+        async chooseAction() {
+          return { type: "deploy", playerId: "p1", cardId: "fake" };
+        },
+      };
+      const controller = new GameController({
+        config: DEFAULT_CONFIG,
+        players: TWO_PLAYERS,
+        seed: SEED,
+        setupInput: MAIN_SETUP_INPUT,
+        adapters: new Map<string, PlayerAdapter>([
+          ["p1", alwaysInvalid],
+          ["p2", alwaysInvalid],
+        ]),
+        onInvalidAction: () => {
+          rejections++;
+        },
+      });
+
+      await expect(controller.run()).rejects.toBeInstanceOf(InvalidActionError);
+      // It re-prompted many times before giving up, rather than throwing on the
+      // first rejection or looping forever.
+      expect(rejections).toBeGreaterThan(1);
     });
   });
 

--- a/engine/src/__tests__/controller.test.ts
+++ b/engine/src/__tests__/controller.test.ts
@@ -242,9 +242,16 @@ describe("GameController", () => {
         ]),
       );
 
-      await expect(controller.playTurn()).rejects.toBeInstanceOf(
-        InvalidActionError,
+      const err = await controller.playTurn().then(
+        () => {
+          throw new Error("expected playTurn() to reject");
+        },
+        (e: unknown) => e as InvalidActionError,
       );
+      expect(err).toBeInstanceOf(InvalidActionError);
+      // The bogus matchup has the right type + player, so it's specifically a
+      // payload-level rejection — the reason the deep gate exists to catch.
+      expect(err.reason).toBe("payload_mismatch");
     });
 
     // Loop survival (#182 B): a rejected submission must not tear down run().

--- a/engine/src/action-validation.ts
+++ b/engine/src/action-validation.ts
@@ -18,11 +18,35 @@ const DEEP_VALIDATED_ACTION_TYPES: ReadonlySet<Action["type"]> = new Set<
 >(["resolve_combat_round", "resolve_pick"]);
 
 /**
- * Legality check for an adapter-submitted action against the enumerated set.
+ * Why an adapter-submitted action failed the legality gate. Distinguishing these
+ * lets a rejection be logged with its cause instead of a bare "not legal":
+ * - `type_not_offered`: no enumerated action of this type for the player to act
+ *   (e.g. a `deploy` when only `pass`/`activate` are available).
+ * - `wrong_player`: the type is offered, but the submitted `playerId` isn't the
+ *   player to act — `getValidActions` enumerates only that player's actions, so
+ *   this means the adapter addressed the action to the wrong player.
+ * - `payload_mismatch`: a deep-validated decision action (see
+ *   `DEEP_VALIDATED_ACTION_TYPES`) whose type+player are offered but whose
+ *   decision payload isn't in the enumerated legal set (bad sit-out ids, wrong
+ *   matchup pairs, an unoffered kind, …).
+ */
+export type ActionRejectionReason =
+  | "type_not_offered"
+  | "wrong_player"
+  | "payload_mismatch";
+
+/** Result of {@link checkActionLegality}: legal, or illegal with a reason. */
+export type ActionLegality =
+  | { legal: true }
+  | { legal: false; reason: ActionRejectionReason };
+
+/**
+ * Legality check for an adapter-submitted action against the enumerated set,
+ * returning *why* on rejection (see {@link ActionRejectionReason}).
  *
- * For exhaustively-enumerated decision actions (see above) this is structural
- * membership of `action` in `validActions`, compared via canonical keys. For
- * everything else it falls back to the shallow type+playerId match.
+ * For exhaustively-enumerated decision actions (see above) legality is
+ * structural membership of `action` in `validActions`, compared via canonical
+ * keys. For everything else it falls back to the shallow type+playerId match.
  *
  * Order-insensitivity: the canonical key sorts every array, because several
  * payloads are set-semantic and the client builds them in a different order
@@ -36,17 +60,35 @@ const DEEP_VALIDATED_ACTION_TYPES: ReadonlySet<Action["type"]> = new Set<
  * Sorting collapses *permutations* only, never subsets, so a submitted subset
  * of a larger enumerated set still fails to match.
  */
+export function checkActionLegality(
+  action: Action,
+  validActions: readonly Action[],
+): ActionLegality {
+  const typeMatches = validActions.filter((va) => va.type === action.type);
+  if (typeMatches.length === 0) {
+    return { legal: false, reason: "type_not_offered" };
+  }
+  if (!typeMatches.some((va) => va.playerId === action.playerId)) {
+    return { legal: false, reason: "wrong_player" };
+  }
+  // Shallow types are legal on type+player alone — their payload is an
+  // adapter-filled template, so applyAction remains the payload validator.
+  if (!DEEP_VALIDATED_ACTION_TYPES.has(action.type)) {
+    return { legal: true };
+  }
+  const key = canonicalActionKey(action);
+  if (validActions.some((va) => canonicalActionKey(va) === key)) {
+    return { legal: true };
+  }
+  return { legal: false, reason: "payload_mismatch" };
+}
+
+/** Boolean convenience wrapper over {@link checkActionLegality}. */
 export function isLegalAction(
   action: Action,
   validActions: readonly Action[],
 ): boolean {
-  if (!DEEP_VALIDATED_ACTION_TYPES.has(action.type)) {
-    return validActions.some(
-      (va) => va.type === action.type && va.playerId === action.playerId,
-    );
-  }
-  const key = canonicalActionKey(action);
-  return validActions.some((va) => canonicalActionKey(va) === key);
+  return checkActionLegality(action, validActions).legal;
 }
 
 /**

--- a/engine/src/action-validation.ts
+++ b/engine/src/action-validation.ts
@@ -1,0 +1,82 @@
+import type { Action } from "./types";
+
+/**
+ * Action types whose `getValidActions` enumeration is *exhaustive* — every legal
+ * payload is listed, with no player-filled fields left blank — so legality
+ * reduces to structural membership and we can deep-validate the whole payload.
+ *
+ * Deliberately narrow (#182): these are the two decision actions the ticket
+ * targets. Other actions carry template fields the enumeration leaves for the
+ * adapter to fill (`seed_keep`'s keepIds/exposeIds, the optional `rotation` on
+ * `seed_steal` / `seed_place_location` / `raze`), so a deep-equal against the
+ * enumerated template would wrongly reject a legitimately-filled submission.
+ * Those keep the shallow type+playerId check (unchanged behavior); applyAction
+ * remains their payload validator.
+ */
+const DEEP_VALIDATED_ACTION_TYPES: ReadonlySet<string> = new Set([
+  "resolve_combat_round",
+  "resolve_pick",
+]);
+
+/**
+ * Legality check for an adapter-submitted action against the enumerated set.
+ *
+ * For exhaustively-enumerated decision actions (see above) this is structural
+ * membership of `action` in `validActions`, compared via canonical keys. For
+ * everything else it falls back to the shallow type+playerId match.
+ *
+ * Order-insensitivity: the canonical key sorts every array, because several
+ * payloads are set-semantic and the client builds them in a different order
+ * than the enumerator emits — e.g. `sit_out.sitOutUnitIds` (click order vs.
+ * power-ascending), `deck_pick` `resolve_pick.pickedCardIds`, and
+ * `assign_matchups.pairs` (a bijection is a *set* of pairs). Sorting is safe
+ * against false-accepts: the only payload where element order carries legal
+ * meaning is `scholar_reorder` (a `resolve_pick` whose submission order *is*
+ * the outcome), and there `getValidActions` enumerates the entire permutation
+ * orbit as legal — so collapsing orderings can never admit an illegal action.
+ * Sorting collapses *permutations* only, never subsets, so a submitted subset
+ * of a larger enumerated set still fails to match.
+ */
+export function isLegalAction(
+  action: Action,
+  validActions: readonly Action[],
+): boolean {
+  if (!DEEP_VALIDATED_ACTION_TYPES.has(action.type)) {
+    return validActions.some(
+      (va) => va.type === action.type && va.playerId === action.playerId,
+    );
+  }
+  const key = canonicalActionKey(action);
+  return validActions.some((va) => canonicalActionKey(va) === key);
+}
+
+/**
+ * A stable, order-insensitive string key for an action. Two actions share a key
+ * iff they are structurally equal up to array ordering and object key ordering.
+ * Exported for direct testing.
+ */
+export function canonicalActionKey(action: Action): string {
+  return JSON.stringify(canonicalize(action));
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize).sort((a, b) => {
+      const sa = JSON.stringify(a) ?? "";
+      const sb = JSON.stringify(b) ?? "";
+      return sa < sb ? -1 : sa > sb ? 1 : 0;
+    });
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    // Sort keys so object field order can't affect the key. Drop `undefined`
+    // values so an explicit `costIndex: undefined` matches an omitted one.
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      const v = (value as Record<string, unknown>)[key];
+      if (v === undefined) continue;
+      out[key] = canonicalize(v);
+    }
+    return out;
+  }
+  return value;
+}

--- a/engine/src/action-validation.ts
+++ b/engine/src/action-validation.ts
@@ -13,10 +13,9 @@ import type { Action } from "./types";
  * Those keep the shallow type+playerId check (unchanged behavior); applyAction
  * remains their payload validator.
  */
-const DEEP_VALIDATED_ACTION_TYPES: ReadonlySet<string> = new Set([
-  "resolve_combat_round",
-  "resolve_pick",
-]);
+const DEEP_VALIDATED_ACTION_TYPES: ReadonlySet<Action["type"]> = new Set<
+  Action["type"]
+>(["resolve_combat_round", "resolve_pick"]);
 
 /**
  * Legality check for an adapter-submitted action against the enumerated set.
@@ -61,6 +60,11 @@ export function canonicalActionKey(action: Action): string {
 
 function canonicalize(value: unknown): unknown {
   if (Array.isArray(value)) {
+    // The `?? ""` guards the case where an element serializes to `undefined`
+    // (a bare `undefined`/function element). Current deep-validated `Action`
+    // payloads only hold string ids and plain pair objects, which always
+    // stringify to a defined value — so the guard is defensive, not
+    // load-bearing today.
     return value.map(canonicalize).sort((a, b) => {
       const sa = JSON.stringify(a) ?? "";
       const sb = JSON.stringify(b) ?? "";

--- a/engine/src/controller.ts
+++ b/engine/src/controller.ts
@@ -28,9 +28,9 @@ export interface ControllerOptions {
    * pre-apply legality gate. Lets an interactive client surface the rejection
    * (and re-prompt the same decider) instead of the loop tearing down. Not
    * invoked on the direct `playTurn()` path — that throws for programmatic
-   * callers.
+   * callers. The offending player is `error.actingPlayerId`.
    */
-  onInvalidAction?: (error: InvalidActionError, actingPlayerId: string) => void;
+  onInvalidAction?: (error: InvalidActionError) => void;
 }
 
 const DEFAULT_MAX_ACTIONS = 10_000;
@@ -43,7 +43,7 @@ const DEFAULT_MAX_ACTIONS = 10_000;
  * getValidActions/applyAction desync, turning an infinite re-prompt into a
  * clean terminal error.
  */
-const MAX_CONSECUTIVE_REJECTIONS = 100;
+export const MAX_CONSECUTIVE_REJECTIONS = 100;
 
 /**
  * Thrown by `playTurn()` when an adapter returns an action outside the legal
@@ -71,10 +71,7 @@ export class GameController {
   private state: GameState;
   private adapters: Map<string, PlayerAdapter>;
   private onEvent?: (events: GameEvent[], state: GameState) => void;
-  private onInvalidAction?: (
-    error: InvalidActionError,
-    actingPlayerId: string,
-  ) => void;
+  private onInvalidAction?: (error: InvalidActionError) => void;
   private readonly seed: string;
   private readonly playerDescriptors: PlayerDescriptor[];
 
@@ -98,10 +95,7 @@ export class GameController {
     setupInput: SetupInput,
     adapters: Map<string, PlayerAdapter>,
     onEvent?: (events: GameEvent[], state: GameState) => void,
-    onInvalidAction?: (
-      error: InvalidActionError,
-      actingPlayerId: string,
-    ) => void,
+    onInvalidAction?: (error: InvalidActionError) => void,
   ): GameController {
     const controller = new GameController({
       config: session.config,
@@ -129,6 +123,7 @@ export class GameController {
             `Session replay failed at action ${i + 1}/${session.actions.length} ` +
               `(type: "${action.type}", player: "${action.playerId}"): ` +
               `${err instanceof Error ? err.message : err}`,
+            { cause: err },
           );
         }
       }
@@ -139,10 +134,13 @@ export class GameController {
 
   /** Run the game loop until the game ends. */
   async run(maxActions = DEFAULT_MAX_ACTIONS): Promise<Session> {
+    // Counts *applied* actions only — a rejected submission never reaches
+    // applyAction, so it must not draw down the budget meant to bound real
+    // progress. Runaway re-prompts are caught by MAX_CONSECUTIVE_REJECTIONS.
     let actionCount = 0;
     let consecutiveRejections = 0;
     while (this.state.phase !== "ended") {
-      if (++actionCount > maxActions) {
+      if (actionCount >= maxActions) {
         const activePlayer = getActivePlayerId(this.state);
         const round =
           this.state.phase === "main" ? this.state.turn.round : "N/A";
@@ -155,14 +153,27 @@ export class GameController {
       try {
         await this.playTurn();
         consecutiveRejections = 0;
+        actionCount++;
       } catch (err) {
         // A rejected submission is recoverable: surface it and re-prompt the
         // same decider on the next iteration (applyAction never ran, so state
         // is unchanged and re-deriving valid actions is sound). Any other error
         // is a genuine engine fault — propagate it unchanged.
         if (!(err instanceof InvalidActionError)) throw err;
-        this.onInvalidAction?.(err, err.actingPlayerId);
-        if (++consecutiveRejections > MAX_CONSECUTIVE_REJECTIONS) throw err;
+        // Check the backstop *before* surfacing the rejection, so a terminal
+        // give-up doesn't emit a "choose again" re-prompt to the client
+        // immediately followed by a fatal throw. On give-up, wrap the last
+        // rejection with the count + context so the terminal error is
+        // self-explanatory (the raw InvalidActionError is kept as `cause`).
+        if (++consecutiveRejections > MAX_CONSECUTIVE_REJECTIONS) {
+          throw new Error(
+            `Game loop gave up after ${MAX_CONSECUTIVE_REJECTIONS} consecutive ` +
+              `rejected submissions from player "${err.actingPlayerId}". ` +
+              `Last invalid action: ${JSON.stringify(err.action)}`,
+            { cause: err },
+          );
+        }
+        this.onInvalidAction?.(err);
       }
     }
     return this.toSession();

--- a/engine/src/controller.ts
+++ b/engine/src/controller.ts
@@ -1,14 +1,15 @@
+import { isLegalAction } from "./action-validation";
 import { applyAction } from "./apply-action";
 import { createGame } from "./create-game";
 import type {
   Action,
-  SetupInput,
   GameConfig,
   GameEvent,
   GameState,
   PlayerAdapter,
   PlayerDescriptor,
   Session,
+  SetupInput,
 } from "./types";
 import { getActivePlayerId, getDeciderId } from "./types";
 import { getValidActions } from "./valid-actions";
@@ -22,9 +23,45 @@ export interface ControllerOptions {
   adapters: Map<string, PlayerAdapter>;
   /** Called after each action is applied. */
   onEvent?: (events: GameEvent[], state: GameState) => void;
+  /**
+   * Called by `run()` when an adapter submits an action that fails the
+   * pre-apply legality gate. Lets an interactive client surface the rejection
+   * (and re-prompt the same decider) instead of the loop tearing down. Not
+   * invoked on the direct `playTurn()` path — that throws for programmatic
+   * callers.
+   */
+  onInvalidAction?: (error: InvalidActionError, actingPlayerId: string) => void;
 }
 
 const DEFAULT_MAX_ACTIONS = 10_000;
+
+/**
+ * Upper bound on consecutive rejected submissions for a single decider before
+ * `run()` gives up and throws. Not a gameplay limit — a human re-prompts and
+ * fixes their input (≤1 rejection in practice) and a bot submits a legal
+ * action outright, so this only ever trips on a broken client or a
+ * getValidActions/applyAction desync, turning an infinite re-prompt into a
+ * clean terminal error.
+ */
+const MAX_CONSECUTIVE_REJECTIONS = 100;
+
+/**
+ * Thrown by `playTurn()` when an adapter returns an action outside the legal
+ * set enumerated by `getValidActions`. Typed so `run()` can distinguish a
+ * recoverable bad submission (re-prompt) from a genuine engine error (propagate).
+ */
+export class InvalidActionError extends Error {
+  constructor(
+    readonly actingPlayerId: string,
+    readonly action: Action,
+  ) {
+    super(
+      `Adapter for player "${actingPlayerId}" returned an invalid action: ` +
+        `${JSON.stringify(action)}`,
+    );
+    this.name = "InvalidActionError";
+  }
+}
 
 /**
  * Orchestrates the game loop. Manages session state, routes turns to
@@ -34,6 +71,10 @@ export class GameController {
   private state: GameState;
   private adapters: Map<string, PlayerAdapter>;
   private onEvent?: (events: GameEvent[], state: GameState) => void;
+  private onInvalidAction?: (
+    error: InvalidActionError,
+    actingPlayerId: string,
+  ) => void;
   private readonly seed: string;
   private readonly playerDescriptors: PlayerDescriptor[];
 
@@ -46,6 +87,7 @@ export class GameController {
     );
     this.adapters = options.adapters;
     this.onEvent = options.onEvent;
+    this.onInvalidAction = options.onInvalidAction;
     this.seed = options.seed;
     this.playerDescriptors = options.players;
   }
@@ -56,6 +98,10 @@ export class GameController {
     setupInput: SetupInput,
     adapters: Map<string, PlayerAdapter>,
     onEvent?: (events: GameEvent[], state: GameState) => void,
+    onInvalidAction?: (
+      error: InvalidActionError,
+      actingPlayerId: string,
+    ) => void,
   ): GameController {
     const controller = new GameController({
       config: session.config,
@@ -64,6 +110,7 @@ export class GameController {
       setupInput,
       adapters,
       onEvent,
+      onInvalidAction,
     });
 
     if (session.snapshot) {
@@ -93,6 +140,7 @@ export class GameController {
   /** Run the game loop until the game ends. */
   async run(maxActions = DEFAULT_MAX_ACTIONS): Promise<Session> {
     let actionCount = 0;
+    let consecutiveRejections = 0;
     while (this.state.phase !== "ended") {
       if (++actionCount > maxActions) {
         const activePlayer = getActivePlayerId(this.state);
@@ -104,7 +152,18 @@ export class GameController {
             `active player: "${activePlayer}"`,
         );
       }
-      await this.playTurn();
+      try {
+        await this.playTurn();
+        consecutiveRejections = 0;
+      } catch (err) {
+        // A rejected submission is recoverable: surface it and re-prompt the
+        // same decider on the next iteration (applyAction never ran, so state
+        // is unchanged and re-deriving valid actions is sound). Any other error
+        // is a genuine engine fault — propagate it unchanged.
+        if (!(err instanceof InvalidActionError)) throw err;
+        this.onInvalidAction?.(err, err.actingPlayerId);
+        if (++consecutiveRejections > MAX_CONSECUTIVE_REJECTIONS) throw err;
+      }
     }
     return this.toSession();
   }
@@ -128,15 +187,13 @@ export class GameController {
     const validActions = getValidActions(this.state, actingPlayerId);
     const action = await adapter.chooseAction(visibleState, validActions);
 
-    // Validate the adapter returned a legal action
-    const isValid = validActions.some(
-      (va) => va.type === action.type && va.playerId === action.playerId,
-    );
-    if (!isValid) {
-      throw new Error(
-        `Adapter for player "${actingPlayerId}" returned an invalid action: ` +
-          `${JSON.stringify(action)}`,
-      );
+    // Deep-validate the whole payload against the enumerated legal set, not just
+    // type + playerId — a malformed decision payload (bad sit-out ids, wrong
+    // matchup pairs, an unoffered kind) must be caught here rather than relied
+    // upon applyAction to throw. `run()` treats this as recoverable; direct
+    // callers get the throw.
+    if (!isLegalAction(action, validActions)) {
+      throw new InvalidActionError(actingPlayerId, action);
     }
 
     return this.applyAction(action);

--- a/engine/src/controller.ts
+++ b/engine/src/controller.ts
@@ -39,11 +39,12 @@ export interface ControllerOptions {
 const DEFAULT_MAX_ACTIONS = 10_000;
 
 /**
- * Upper bound on consecutive rejected submissions for a single decider before
- * `run()` gives up and throws. Not a gameplay limit — a human re-prompts and
- * fixes their input (≤1 rejection in practice) and a bot submits a legal
- * action outright, so this only ever trips on a broken client or a
- * getValidActions/applyAction desync, turning an infinite re-prompt into a
+ * Default upper bound on consecutive rejected submissions before `run()` gives
+ * up and throws — the default for its `maxConsecutiveRejections` parameter, the
+ * rejection-side counterpart to `DEFAULT_MAX_ACTIONS`. Not a gameplay limit — a
+ * human re-prompts and fixes their input (≤1 rejection in practice) and a bot
+ * submits a legal action outright, so this only ever trips on a broken client
+ * or a getValidActions/applyAction desync, turning an infinite re-prompt into a
  * clean terminal error.
  */
 export const MAX_CONSECUTIVE_REJECTIONS = 100;
@@ -136,8 +137,20 @@ export class GameController {
     return controller;
   }
 
-  /** Run the game loop until the game ends. */
-  async run(maxActions = DEFAULT_MAX_ACTIONS): Promise<Session> {
+  /**
+   * Run the game loop until the game ends.
+   *
+   * @param maxActions upper bound on *applied* actions before the loop throws
+   *   (guards against a non-terminating game).
+   * @param maxConsecutiveRejections upper bound on consecutive rejected
+   *   submissions before the loop gives up and throws (guards against a broken
+   *   client / desync). Injectable like `maxActions`; defaults to
+   *   {@link MAX_CONSECUTIVE_REJECTIONS}.
+   */
+  async run(
+    maxActions = DEFAULT_MAX_ACTIONS,
+    maxConsecutiveRejections = MAX_CONSECUTIVE_REJECTIONS,
+  ): Promise<Session> {
     // Counts *applied* actions only — a rejected submission never reaches
     // applyAction, so it must not draw down the budget meant to bound real
     // progress. Runaway re-prompts are caught by MAX_CONSECUTIVE_REJECTIONS.
@@ -169,9 +182,9 @@ export class GameController {
         // immediately followed by a fatal throw. On give-up, wrap the last
         // rejection with the count + context so the terminal error is
         // self-explanatory (the raw InvalidActionError is kept as `cause`).
-        if (++consecutiveRejections > MAX_CONSECUTIVE_REJECTIONS) {
+        if (++consecutiveRejections > maxConsecutiveRejections) {
           throw new Error(
-            `Game loop gave up after ${MAX_CONSECUTIVE_REJECTIONS} consecutive ` +
+            `Game loop gave up after ${maxConsecutiveRejections} consecutive ` +
               `rejected submissions from player "${err.actingPlayerId}". ` +
               `Last invalid action (${err.reason}): ${JSON.stringify(err.action)}`,
             { cause: err },

--- a/engine/src/controller.ts
+++ b/engine/src/controller.ts
@@ -1,4 +1,7 @@
-import { isLegalAction } from "./action-validation";
+import {
+  type ActionRejectionReason,
+  checkActionLegality,
+} from "./action-validation";
 import { applyAction } from "./apply-action";
 import { createGame } from "./create-game";
 import type {
@@ -54,10 +57,11 @@ export class InvalidActionError extends Error {
   constructor(
     readonly actingPlayerId: string,
     readonly action: Action,
+    readonly reason: ActionRejectionReason,
   ) {
     super(
-      `Adapter for player "${actingPlayerId}" returned an invalid action: ` +
-        `${JSON.stringify(action)}`,
+      `Adapter for player "${actingPlayerId}" returned an invalid action ` +
+        `(${reason}): ${JSON.stringify(action)}`,
     );
     this.name = "InvalidActionError";
   }
@@ -169,7 +173,7 @@ export class GameController {
           throw new Error(
             `Game loop gave up after ${MAX_CONSECUTIVE_REJECTIONS} consecutive ` +
               `rejected submissions from player "${err.actingPlayerId}". ` +
-              `Last invalid action: ${JSON.stringify(err.action)}`,
+              `Last invalid action (${err.reason}): ${JSON.stringify(err.action)}`,
             { cause: err },
           );
         }
@@ -202,9 +206,10 @@ export class GameController {
     // type + playerId — a malformed decision payload (bad sit-out ids, wrong
     // matchup pairs, an unoffered kind) must be caught here rather than relied
     // upon applyAction to throw. `run()` treats this as recoverable; direct
-    // callers get the throw.
-    if (!isLegalAction(action, validActions)) {
-      throw new InvalidActionError(actingPlayerId, action);
+    // callers get the throw. The reason is carried on the error for logging.
+    const legality = checkActionLegality(action, validActions);
+    if (!legality.legal) {
+      throw new InvalidActionError(actingPlayerId, action, legality.reason);
     }
 
     return this.applyAction(action);

--- a/engine/src/index.ts
+++ b/engine/src/index.ts
@@ -18,7 +18,7 @@ export {
 } from "./card-loader";
 export type { ControllerOptions } from "./controller";
 // Controller
-export { GameController } from "./controller";
+export { GameController, InvalidActionError } from "./controller";
 export { createGame } from "./create-game";
 export { deriveCombatOutcome } from "./apply-main";
 export { decideKillVsInjure } from "./unit-helpers";

--- a/engine/src/index.ts
+++ b/engine/src/index.ts
@@ -16,6 +16,12 @@ export {
   loadCardDefinitions,
   loadCardDefinitionsFromBuild,
 } from "./card-loader";
+// Action legality gate
+export type {
+  ActionLegality,
+  ActionRejectionReason,
+} from "./action-validation";
+export { checkActionLegality, isLegalAction } from "./action-validation";
 export type { ControllerOptions } from "./controller";
 // Controller
 export { GameController, InvalidActionError } from "./controller";


### PR DESCRIPTION
## Summary

- **Deep-validate adapter actions at the controller boundary:** `Controller.playTurn()` currently validates a submitted action on `type` + `playerId` only, never the decision payload (`kind`, `sitOutUnitIds`, `pairs`, retreat, `pickedCardIds`, etc.), even though `getValidActions` already enumerated the full legal set. Validate the payload against that enumerated set — defense-in-depth at the boundary. This surface grew with each combat decision kind (#167 sit-out, #168 retreat).
- **Survive engine rejection:** when the engine throws on a bad payload, the exception propagates out of `Controller.run()`'s loop and permanently exits it. In the web client `run()` is fire-and-forget, leaving a dead-but-visible combat overlay with a false "retry" affordance. Make the loop surface the error and re-prompt the same decider instead of tearing down.
- The engine's own `applyAction()` validation stays (used by programmatic/replay paths) — this is an added boundary check + loop-survival behavior, not a move.
- Both gaps are pre-existing (predate #167, shared with the #165/#166 `resolve_combat_round` machinery); carved out of #167 during the PR #181 review.

Closes #182

## Implementation

**(A) Deep validation — `engine/src/action-validation.ts`.** `isLegalAction(action, validActions)` tests structural membership against the enumerated set via an **order-insensitive canonical key** (arrays sorted before serialization). Order-insensitivity is required because set-semantic payloads are built in a different order than the enumerator emits (`sitOutUnitIds` click-order vs. power-ascending, `deck_pick` picks, `assign_matchups` pairs), and it is safe against false-accepts: the only order-meaningful payload, `scholar_reorder`, has its entire permutation orbit enumerated as legal. Sorting collapses permutations only, never subsets.

**Scoping (found during implementation).** `getValidActions` is **not** exhaustive for every action type — `seed_keep` (empty `keepIds`/`exposeIds`) and the optional `rotation` on `seed_steal` / `seed_place_location` / `raze` are enumerated as *templates* the adapter fills. A blanket deep-equal false-rejects those (caught by the integration seeding tests). So deep validation is scoped by an allowlist to the two exhaustively-enumerated decision actions the ticket targets — **`resolve_combat_round` and `resolve_pick`**; all other types keep the shallow `type`+`playerId` check, with `applyAction` as their payload validator.

**(B) Loop survival — `engine/src/controller.ts`.** `playTurn()` throws a typed `InvalidActionError` on gate failure (preserving the programmatic throw contract). `run()` catches it, invokes a new `onInvalidAction` callback, and re-prompts the same decider instead of tearing down — with a `MAX_CONSECUTIVE_REJECTIONS` guard so a broken adapter fails cleanly rather than looping forever. Every other error propagates unchanged. `applyAction` never ran on a rejected turn, so state is unchanged and re-deriving valid actions on retry is sound.

**Web client — `clients/web/src/lib/gameStore.svelte.ts`.** Wires `onInvalidAction` (new-game + load-from-session paths) to `pushError`. The re-prompt re-arms `resolveAction` and the changed error banner trips the combat/pick overlay recovery `$effect`, re-enabling Confirm — closing the dead-overlay / "Action dropped" gap. No overlay changes needed.

### Tests
- `action-validation.test.ts` (new, 15 cases): exact match, order-insensitive accepts (sit-out / matchups / deck-pick / scholar-reorder), malformed-payload rejects that the old shallow gate let through, template-action shallow fallback, canonical-key properties.
- `controller.test.ts`: existing shallow-behavior test tightened to assert `InvalidActionError`; new — deep gate rejects a malformed combat decision at `playTurn`, `run()` survives a rejection and re-prompts the same decider, guard gives up after too many consecutive rejections.
- Full suite green (640 engine / 93 web) + typecheck + svelte-check clean. (Counts as of iteration 4; iterations 2–4 added the review-fix coverage.)

### Follow-up
- #186 — client integration test for the reactive recovery chain (deferred, off v0.1; the recovery logic is covered engine-side + manual smoke).

## Iterations
| # | Push | Change |
|---|------|--------|
| 1 | `5e95ad2`, `8e7ea6e` | Initial implementation: deep-validation helper (scoped to `resolve_combat_round`/`resolve_pick`), typed `InvalidActionError`, `run()` re-prompt + guard, `onInvalidAction` client wiring, tests. |
| 2 | `57e7767`, `5528079` | `/review-pr` pass (5 agents → 23 findings, 0 critical). Engine: type `DEEP_VALIDATED_ACTION_TYPES` as `ReadonlySet<Action["type"]>`, drop the redundant `onInvalidAction` player arg, self-explanatory give-up throw (count + player + last action, raw error as `cause`), `maxActions` counts *applied* actions only, `fromSession` preserves `cause`, richer validation/loop tests. Web: replace the fragile error-string overlay unlock with a monotonic **rejection nonce** shared by both overlays, log the rejected action (was discarded), dedupe the banner, extract + unit-test a pure `promptRecovery.ts` helper, docstring/stale-comment fixes. |
| 3 | `c425fd5` | Finding #12: `checkActionLegality` returns a typed rejection reason (`type_not_offered` / `wrong_player` / `payload_mismatch`) carried on `InvalidActionError` for logging; `isLegalAction` kept as a boolean wrapper. |
| 4 | `b03b5d3` | Finding #17: make the consecutive-rejection backstop an injectable `run()` param (`maxConsecutiveRejections`), symmetric with `maxActions`. |
