### PR TITLE
130: Engine: item activate actions aren't enumerated (Philosopher's Stone)

### DIFF
--- a/engine/src/__tests__/activate-item.test.ts
+++ b/engine/src/__tests__/activate-item.test.ts
@@ -18,18 +18,20 @@ function gameWith(fn: (draft: MainGameState) => void): MainGameState {
 }
 
 /** An item carrying a single activatable action (Philosopher's Stone shape). */
-function actionItem(name: string, effect: string, apCost = 1): ItemCard {
+function actionItem(name: string, effect: string, apCost = 1, owner: string = ACTIVE): ItemCard {
   return makeItem({
-    ownerId: ACTIVE,
+    ownerId: owner,
     name,
     definitionId: "philosophers-stone",
     actions: [{ name: "transmute", apCost, effect }],
   });
 }
 
-function activatesFor(state: MainGameState, cardId: string): MainAction[] {
+type ActivateAction = Extract<MainAction, { type: "activate" }>;
+
+function activatesFor(state: MainGameState, cardId: string): ActivateAction[] {
   return getValidActions(state, ACTIVE).filter(
-    (a): a is MainAction => a.type === "activate" && a.cardId === cardId,
+    (a): a is ActivateAction => a.type === "activate" && a.cardId === cardId,
   );
 }
 
@@ -51,7 +53,11 @@ describe("item activate — enumeration (#130)", () => {
     expect(activatesFor(state, stone.id)).toHaveLength(0);
   });
 
-  it("grid item equipped to a unit is activatable (unit is co-located)", () => {
+  it("grid item equipped to a unit is activatable (the bearer satisfies the co-located gate)", () => {
+    // There is no equip-specific activation path — an equipped item is activatable
+    // because its bearer is, by construction, a friendly unit in the item's cell,
+    // which is exactly the generic hasControllingUnitAt gate. `equippedTo` is set
+    // to model a realistic bearer scenario, not because equip is checked directly.
     const stone = actionItem("Philosopher's Stone", "gold[3]");
     const state = gameWith((d) => {
       const unit = makeUnit({ ownerId: ACTIVE, name: "Bearer" });
@@ -61,6 +67,24 @@ describe("item activate — enumeration (#130)", () => {
       d.grid[0][0].items.push(stone);
     });
     expect(activatesFor(state, stone.id)).toHaveLength(1);
+  });
+
+  it("enumerates every action of a multi-action item independently", () => {
+    const relic = makeItem({
+      ownerId: ACTIVE,
+      name: "Alchemist's Relic",
+      definitionId: "philosophers-stone",
+      actions: [
+        { name: "transmute", apCost: 1, effect: "gold[3]" },
+        { name: "brew", apCost: 1, effect: "gold[5]" },
+      ],
+    });
+    const state = gameWith((d) => {
+      d.players[ACTIVE_IDX].hq.push(makeUnit({ ownerId: ACTIVE, name: "Guard" }));
+      d.players[ACTIVE_IDX].hq.push(relic);
+    });
+    const names = activatesFor(state, relic.id).map((a) => a.actionName).sort();
+    expect(names).toEqual(["brew", "transmute"]);
   });
 
   it("grid stored item is activatable only while a friendly unit shares the cell", () => {
@@ -90,6 +114,16 @@ describe("item activate — enumeration (#130)", () => {
     expect(activatesFor(state, stone.id)).toHaveLength(0);
   });
 
+  it("an enemy-controlled item is not enumerated even with a friendly unit present", () => {
+    const enemyStone = actionItem("Philosopher's Stone", "gold[3]", 1, OPPONENT);
+    const state = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(makeUnit({ ownerId: ACTIVE, name: "Operator" }));
+      d.grid[0][0].items.push(enemyStone);
+    });
+    expect(activatesFor(state, enemyStone.id)).toHaveLength(0);
+  });
+
   it("does not offer the action when AP is below the action cost", () => {
     const stone = actionItem("Philosopher's Stone", "gold[3]", 2);
     const state = gameWith((d) => {
@@ -109,6 +143,7 @@ describe("item activate — application (#130)", () => {
       d.players[ACTIVE_IDX].hq.push(stone);
     });
     const goldBefore = state.players[ACTIVE_IDX].gold;
+    const apBefore = state.turn.actionPointsRemaining;
 
     const { state: next, events } = applyAction(state, {
       type: "activate",
@@ -118,12 +153,15 @@ describe("item activate — application (#130)", () => {
     });
 
     expect((next as MainGameState).players[ACTIVE_IDX].gold).toBe(goldBefore + 3);
+    // AP is spent by the activation (apCost 1) — the deduction, not just the gate.
+    expect((next as MainGameState).turn.actionPointsRemaining).toBe(apBefore - 1);
     expect(events.find((e) => e.type === "card_activated")).toMatchObject({
       type: "card_activated",
       playerId: ACTIVE,
       cardId: stone.id,
       cardName: "Philosopher's Stone",
       actionName: "transmute",
+      target: undefined,
     });
   });
 
@@ -147,7 +185,8 @@ describe("item activate — application (#130)", () => {
     expect((next as MainGameState).players[ACTIVE_IDX].gold).toBe(goldBefore + 3);
   });
 
-  it("positional grid item resolves its own cell (Siege Engine-style)", () => {
+  it("a positional-effect item resolves its own grid cell (Siege-Engine-style effect)", () => {
+    // The item name is cosmetic; what matters is the positional effect shape:
     // buff.strength(all + friendly) carries no targetId, so execution routes
     // through getActingPosition — the item-grid fallback added for #130. The
     // friendly unit in the item's cell is buffed; one in another cell is not.
@@ -169,7 +208,10 @@ describe("item activate — application (#130)", () => {
     const ns = next as MainGameState;
     const near = ns.grid[0][0].units.find((u) => u.name === "Near") as UnitCard;
     const far = ns.grid[1][1].units.find((u) => u.name === "Far") as UnitCard;
-    expect(near.statModifiers?.some((m) => m.stat === "strength" && m.delta === 2)).toBe(true);
+    const nearMod = near.statModifiers?.find((m) => m.stat === "strength" && m.delta === 2);
+    expect(nearMod).toBeDefined();
+    // The modifier's source carries the acting item's identity (actingCardSource).
+    expect(nearMod?.source).toMatchObject({ type: "item", cardId: engine.id });
     expect(far.statModifiers ?? []).toHaveLength(0);
   });
 
@@ -186,5 +228,40 @@ describe("item activate — application (#130)", () => {
         actionName: "transmute",
       }),
     ).toThrow(/no controlling unit co-located/);
+  });
+
+  it("rejects activating an item the player does not control", () => {
+    const enemyStone = actionItem("Philosopher's Stone", "gold[3]", 1, OPPONENT);
+    const state = gameWith((d) => {
+      // A friendly unit is present, so the co-located gate would pass — the
+      // controllerId check must reject first.
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(makeUnit({ ownerId: ACTIVE, name: "Operator" }));
+      d.grid[0][0].items.push(enemyStone);
+    });
+    expect(() =>
+      applyAction(state, {
+        type: "activate",
+        playerId: ACTIVE,
+        cardId: enemyStone.id,
+        actionName: "transmute",
+      }),
+    ).toThrow(/not owned by/);
+  });
+
+  it("rejects an item activation naming an action the item does not have", () => {
+    const stone = actionItem("Philosopher's Stone", "gold[3]");
+    const state = gameWith((d) => {
+      d.players[ACTIVE_IDX].hq.push(makeUnit({ ownerId: ACTIVE, name: "Guard" }));
+      d.players[ACTIVE_IDX].hq.push(stone);
+    });
+    expect(() =>
+      applyAction(state, {
+        type: "activate",
+        playerId: ACTIVE,
+        cardId: stone.id,
+        actionName: "nonexistent",
+      }),
+    ).toThrow(/not found on item/);
   });
 });

--- a/engine/src/__tests__/activate-item.test.ts
+++ b/engine/src/__tests__/activate-item.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { produce } from "immer";
+import { applyAction } from "../apply-action";
+import { getValidActions } from "../valid-actions";
+import type { ItemCard, MainAction, MainGameState, UnitCard } from "../types";
+import { createTestGame, makeItem, makeLocation, makeUnit, resetIds } from "./helpers";
+
+beforeEach(() => resetIds());
+
+// Same active-player assumption as activate-hq.test.ts — the SEED shuffle puts
+// p2 first, so player index 0 is the active player after createTestGame().
+const ACTIVE = "p2";
+const ACTIVE_IDX = 0;
+const OPPONENT = "p1";
+
+function gameWith(fn: (draft: MainGameState) => void): MainGameState {
+  return produce(createTestGame(), fn);
+}
+
+/** An item carrying a single activatable action (Philosopher's Stone shape). */
+function actionItem(name: string, effect: string, apCost = 1): ItemCard {
+  return makeItem({
+    ownerId: ACTIVE,
+    name,
+    definitionId: "philosophers-stone",
+    actions: [{ name: "transmute", apCost, effect }],
+  });
+}
+
+function activatesFor(state: MainGameState, cardId: string): MainAction[] {
+  return getValidActions(state, ACTIVE).filter(
+    (a): a is MainAction => a.type === "activate" && a.cardId === cardId,
+  );
+}
+
+describe("item activate — enumeration (#130)", () => {
+  it("HQ item offers its action when a controlling unit is co-located", () => {
+    const stone = actionItem("Philosopher's Stone", "gold[3]");
+    const state = gameWith((d) => {
+      d.players[ACTIVE_IDX].hq.push(makeUnit({ ownerId: ACTIVE, name: "Guard" }));
+      d.players[ACTIVE_IDX].hq.push(stone);
+    });
+    expect(activatesFor(state, stone.id)).toHaveLength(1);
+  });
+
+  it("HQ item offers nothing when no unit is present to operate it", () => {
+    const stone = actionItem("Philosopher's Stone", "gold[3]");
+    const state = gameWith((d) => {
+      d.players[ACTIVE_IDX].hq.push(stone); // item alone, no unit
+    });
+    expect(activatesFor(state, stone.id)).toHaveLength(0);
+  });
+
+  it("grid item equipped to a unit is activatable (unit is co-located)", () => {
+    const stone = actionItem("Philosopher's Stone", "gold[3]");
+    const state = gameWith((d) => {
+      const unit = makeUnit({ ownerId: ACTIVE, name: "Bearer" });
+      stone.equippedTo = unit.id;
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(unit);
+      d.grid[0][0].items.push(stone);
+    });
+    expect(activatesFor(state, stone.id)).toHaveLength(1);
+  });
+
+  it("grid stored item is activatable only while a friendly unit shares the cell", () => {
+    const stone = actionItem("Philosopher's Stone", "gold[3]");
+    const withUnit = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(makeUnit({ ownerId: ACTIVE, name: "Operator" }));
+      d.grid[0][0].items.push(stone);
+    });
+    expect(activatesFor(withUnit, stone.id)).toHaveLength(1);
+
+    const stoneAlone = actionItem("Philosopher's Stone", "gold[3]");
+    const noUnit = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].items.push(stoneAlone);
+    });
+    expect(activatesFor(noUnit, stoneAlone.id)).toHaveLength(0);
+  });
+
+  it("an enemy unit in the cell does not satisfy the co-located gate", () => {
+    const stone = actionItem("Philosopher's Stone", "gold[3]");
+    const state = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(makeUnit({ ownerId: OPPONENT, name: "Enemy" }));
+      d.grid[0][0].items.push(stone);
+    });
+    expect(activatesFor(state, stone.id)).toHaveLength(0);
+  });
+
+  it("does not offer the action when AP is below the action cost", () => {
+    const stone = actionItem("Philosopher's Stone", "gold[3]", 2);
+    const state = gameWith((d) => {
+      d.turn.actionPointsRemaining = 1;
+      d.players[ACTIVE_IDX].hq.push(makeUnit({ ownerId: ACTIVE, name: "Guard" }));
+      d.players[ACTIVE_IDX].hq.push(stone);
+    });
+    expect(activatesFor(state, stone.id)).toHaveLength(0);
+  });
+});
+
+describe("item activate — application (#130)", () => {
+  it("HQ Philosopher's Stone applies its effect and emits card_activated", () => {
+    const stone = actionItem("Philosopher's Stone", "gold[3]");
+    const state = gameWith((d) => {
+      d.players[ACTIVE_IDX].hq.push(makeUnit({ ownerId: ACTIVE, name: "Guard" }));
+      d.players[ACTIVE_IDX].hq.push(stone);
+    });
+    const goldBefore = state.players[ACTIVE_IDX].gold;
+
+    const { state: next, events } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: stone.id,
+      actionName: "transmute",
+    });
+
+    expect((next as MainGameState).players[ACTIVE_IDX].gold).toBe(goldBefore + 3);
+    expect(events.find((e) => e.type === "card_activated")).toMatchObject({
+      type: "card_activated",
+      playerId: ACTIVE,
+      cardId: stone.id,
+      cardName: "Philosopher's Stone",
+      actionName: "transmute",
+    });
+  });
+
+  it("equipped grid item applies its effect", () => {
+    const stone = actionItem("Philosopher's Stone", "gold[3]");
+    const state = gameWith((d) => {
+      const unit = makeUnit({ ownerId: ACTIVE, name: "Bearer" });
+      stone.equippedTo = unit.id;
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(unit);
+      d.grid[0][0].items.push(stone);
+    });
+    const goldBefore = state.players[ACTIVE_IDX].gold;
+
+    const { state: next } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: stone.id,
+      actionName: "transmute",
+    });
+    expect((next as MainGameState).players[ACTIVE_IDX].gold).toBe(goldBefore + 3);
+  });
+
+  it("positional grid item resolves its own cell (Siege Engine-style)", () => {
+    // buff.strength(all + friendly) carries no targetId, so execution routes
+    // through getActingPosition — the item-grid fallback added for #130. The
+    // friendly unit in the item's cell is buffed; one in another cell is not.
+    const engine = actionItem("Siege Engine", "buff.strength(all + friendly)[2]~turn");
+    const state = gameWith((d) => {
+      d.grid[0][0].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[1][1].location = makeLocation({ ownerId: ACTIVE });
+      d.grid[0][0].units.push(makeUnit({ ownerId: ACTIVE, name: "Near" }));
+      d.grid[1][1].units.push(makeUnit({ ownerId: ACTIVE, name: "Far" }));
+      d.grid[0][0].items.push(engine);
+    });
+
+    const { state: next } = applyAction(state, {
+      type: "activate",
+      playerId: ACTIVE,
+      cardId: engine.id,
+      actionName: "transmute",
+    });
+    const ns = next as MainGameState;
+    const near = ns.grid[0][0].units.find((u) => u.name === "Near") as UnitCard;
+    const far = ns.grid[1][1].units.find((u) => u.name === "Far") as UnitCard;
+    expect(near.statModifiers?.some((m) => m.stat === "strength" && m.delta === 2)).toBe(true);
+    expect(far.statModifiers ?? []).toHaveLength(0);
+  });
+
+  it("rejects activating an item with no co-located controlling unit", () => {
+    const stone = actionItem("Philosopher's Stone", "gold[3]");
+    const state = gameWith((d) => {
+      d.players[ACTIVE_IDX].hq.push(stone); // no unit in HQ
+    });
+    expect(() =>
+      applyAction(state, {
+        type: "activate",
+        playerId: ACTIVE,
+        cardId: stone.id,
+        actionName: "transmute",
+      }),
+    ).toThrow(/no controlling unit co-located/);
+  });
+});

--- a/engine/src/__tests__/card-loader.test.ts
+++ b/engine/src/__tests__/card-loader.test.ts
@@ -475,6 +475,7 @@ describe("instantiateCard", () => {
 
   test("item card without actions leaves actions undefined", () => {
     const card = instantiateCard(VALID_ITEM, "player-1", counter);
+    expect(card.type).toBe("item");
     if (card.type === "item") {
       expect(card.actions).toBeUndefined();
     }

--- a/engine/src/__tests__/card-loader.test.ts
+++ b/engine/src/__tests__/card-loader.test.ts
@@ -457,6 +457,29 @@ describe("instantiateCard", () => {
     }
   });
 
+  test("creates item card carrying its parsed actions (#130)", () => {
+    const stone: CardDefinition = {
+      ...VALID_ITEM,
+      id: "philosophers-stone",
+      name: "Philosopher's Stone",
+      actions: [{ name: "transmute", apCost: 1, effect: "gold[3]" }],
+    };
+    const card = instantiateCard(stone, "player-1", counter);
+    expect(card.type).toBe("item");
+    if (card.type === "item") {
+      expect(card.actions).toEqual([
+        { name: "transmute", apCost: 1, effect: "gold[3]" },
+      ]);
+    }
+  });
+
+  test("item card without actions leaves actions undefined", () => {
+    const card = instantiateCard(VALID_ITEM, "player-1", counter);
+    if (card.type === "item") {
+      expect(card.actions).toBeUndefined();
+    }
+  });
+
   test("creates event card", () => {
     const card = instantiateCard(VALID_EVENT, "player-1", counter);
     expect(card.type).toBe("event");

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -4,7 +4,7 @@ import { fromState, uniformIntDistribution } from "./rng";
 import { parseCost, spendAP, spendGold } from "./cost-helpers";
 import { drawLocationFromProspect, drawMarketCard, drawOneCard } from "./deck-helpers";
 import { checkMissionRequirements, parseRequirements, parseRewards } from "./mission-helpers";
-import { findItemPosition, findUnitPosition, getUnitsAtPosition, samePosition } from "./position-helpers";
+import { findItemPosition, findUnitPosition, getUnitsAtPosition, hasControllingUnitAt, samePosition } from "./position-helpers";
 import {
   areFacingEdgesOpen,
   findUnitOnGrid,
@@ -1308,14 +1308,13 @@ function handleActivate(
   } else if (locatedItem) {
     // Item action (e.g. Philosopher's Stone). Operated by a unit, so it requires
     // a controlling unit co-located with the item — the same gate getValidActions
-    // enumerates under. `actingUnitId` stays the item id: the executor resolves an
-    // item's grid cell for positional verbs; on grid it stays with the item.
+    // enumerates under (hasControllingUnitAt is the shared definition). `actingUnitId`
+    // stays the item id so the executor resolves the item's own grid cell for
+    // positional verbs.
     const card = locatedItem.item as Draft<ItemCard>;
     if (!card.actions) throw new Error(`Card "${cardId}" has no actions`);
     if (card.controllerId !== playerId) throw new Error(`Card "${cardId}" not owned by "${playerId}"`);
-    const hasCoLocatedUnit = getUnitsAtPosition(draft.players, draft.grid, locatedItem.position)
-      .some((u) => u.controllerId === playerId);
-    if (!hasCoLocatedUnit) {
+    if (!hasControllingUnitAt(draft.players, draft.grid, locatedItem.position, playerId)) {
       throw new Error(`Item "${cardId}" has no controlling unit co-located to activate it`);
     }
     actionDef = card.actions.find((a) => a.name === actionName);

--- a/engine/src/apply-main.ts
+++ b/engine/src/apply-main.ts
@@ -1295,6 +1295,8 @@ function handleActivate(
   let cardName: string;
   let actingCardSource: ModifierSource;
 
+  const locatedItem = located ? null : findItemPosition(draft.players, draft.grid, cardId);
+
   if (located) {
     const card = located.unit as Draft<UnitCard>;
     if (!card.actions) throw new Error(`Card "${cardId}" has no actions`);
@@ -1303,8 +1305,25 @@ function handleActivate(
     if (!actionDef) throw new Error(`Action "${actionName}" not found on unit "${cardId}"`);
     cardName = card.name;
     actingCardSource = { type: "unit", cardId: card.id, definitionId: card.definitionId };
+  } else if (locatedItem) {
+    // Item action (e.g. Philosopher's Stone). Operated by a unit, so it requires
+    // a controlling unit co-located with the item — the same gate getValidActions
+    // enumerates under. `actingUnitId` stays the item id: the executor resolves an
+    // item's grid cell for positional verbs; on grid it stays with the item.
+    const card = locatedItem.item as Draft<ItemCard>;
+    if (!card.actions) throw new Error(`Card "${cardId}" has no actions`);
+    if (card.controllerId !== playerId) throw new Error(`Card "${cardId}" not owned by "${playerId}"`);
+    const hasCoLocatedUnit = getUnitsAtPosition(draft.players, draft.grid, locatedItem.position)
+      .some((u) => u.controllerId === playerId);
+    if (!hasCoLocatedUnit) {
+      throw new Error(`Item "${cardId}" has no controlling unit co-located to activate it`);
+    }
+    actionDef = card.actions.find((a) => a.name === actionName);
+    if (!actionDef) throw new Error(`Action "${actionName}" not found on item "${cardId}"`);
+    cardName = card.name;
+    actingCardSource = { type: "item", cardId: card.id, definitionId: card.definitionId };
   } else {
-    // Not a unit — try active policies.
+    // Not a unit or item — try active policies.
     const owner = draft.players.find((p) => p.id === playerId);
     const policy = owner?.activePolicies.find((p) => p.id === cardId);
     if (!policy) throw new Error(`Card "${cardId}" not found on grid, HQ, or active policies`);

--- a/engine/src/card-loader.ts
+++ b/engine/src/card-loader.ts
@@ -364,6 +364,7 @@ export function instantiateCard(
           def.itemType && def.itemType.length > 0
             ? (def.itemType as ItemType[])
             : undefined,
+        actions: def.actions ?? undefined,
       } satisfies ItemCard;
 
     case "event": {

--- a/engine/src/effect-dsl/executor.ts
+++ b/engine/src/effect-dsl/executor.ts
@@ -40,7 +40,9 @@ export interface ExecutionContext {
  *  acting card is usually a unit, but an item can activate too (Philosopher's
  *  Stone, Siege Engine) — for a grid item the id is an item id, so fall back to
  *  the item grid so positional item effects target the item's own cell. HQ
- *  cards resolve to neither and stay position-less (their effects are HQ-safe). */
+ *  cards resolve to neither and stay position-less, so positional verbs no-op
+ *  cleanly (HQ-safety of *enumerated* actions is enforced upstream in
+ *  valid-actions.ts's isHqSafeVerb gate; this function does not itself filter). */
 function getActingPosition(ctx: ExecutionContext): { row: number; col: number } | undefined {
   if (!ctx.actingUnitId) return undefined;
   const unit = findUnitOnGrid(ctx.draft.grid, ctx.actingUnitId);

--- a/engine/src/effect-dsl/executor.ts
+++ b/engine/src/effect-dsl/executor.ts
@@ -7,7 +7,7 @@ import type { QueryListener, EmitFn } from "../listeners/types";
 import { getPlayerById, getConfigNumber } from "../state-helpers";
 import { drawOneCard } from "../deck-helpers";
 import { killUnit, injureUnit, decideKillVsInjure, computeContestPower } from "../unit-helpers";
-import { findUnitOnGrid } from "../grid-helpers";
+import { findItemOnGrid, findUnitOnGrid } from "../grid-helpers";
 import { getModifiedStatWithSources } from "../listeners/query";
 
 // ---------------------------------------------------------------------------
@@ -36,11 +36,17 @@ export interface ExecutionContext {
   _razedLocation?: Draft<LocationCard>;
 }
 
-/** Resolve the acting unit's current position from the grid (lazy, always fresh). */
+/** Resolve the acting card's current grid position (lazy, always fresh). The
+ *  acting card is usually a unit, but an item can activate too (Philosopher's
+ *  Stone, Siege Engine) — for a grid item the id is an item id, so fall back to
+ *  the item grid so positional item effects target the item's own cell. HQ
+ *  cards resolve to neither and stay position-less (their effects are HQ-safe). */
 function getActingPosition(ctx: ExecutionContext): { row: number; col: number } | undefined {
   if (!ctx.actingUnitId) return undefined;
-  const found = findUnitOnGrid(ctx.draft.grid, ctx.actingUnitId);
-  return found ? { row: found.row, col: found.col } : undefined;
+  const unit = findUnitOnGrid(ctx.draft.grid, ctx.actingUnitId);
+  if (unit) return { row: unit.row, col: unit.col };
+  const item = findItemOnGrid(ctx.draft.grid, ctx.actingUnitId);
+  return item ? { row: item.row, col: item.col } : undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/src/grid-helpers.ts
+++ b/engine/src/grid-helpers.ts
@@ -1,4 +1,4 @@
-import type { Grid, UnitCard } from "./types";
+import type { Grid, ItemCard, UnitCard } from "./types";
 
 /** True if every cell on the grid has a location. */
 export function isFull(grid: Grid): boolean {
@@ -16,6 +16,22 @@ export function findUnitOnGrid(
     for (let c = 0; c < grid[r].length; c++) {
       const unit = grid[r][c].units.find((u) => u.id === unitId);
       if (unit) return { row: r, col: c, unit };
+    }
+  }
+  return null;
+}
+
+/** Find an item on the grid by instance ID. Returns its position or null.
+ *  Used to resolve an item's cell when it is the acting card of an activate
+ *  (a stored or equipped item running a positional effect). */
+export function findItemOnGrid(
+  grid: Grid,
+  itemId: string,
+): { row: number; col: number; item: ItemCard } | null {
+  for (let r = 0; r < grid.length; r++) {
+    for (let c = 0; c < grid[r].length; c++) {
+      const item = grid[r][c].items.find((i) => i.id === itemId);
+      if (item) return { row: r, col: c, item };
     }
   }
   return null;

--- a/engine/src/grid-helpers.ts
+++ b/engine/src/grid-helpers.ts
@@ -23,7 +23,14 @@ export function findUnitOnGrid(
 
 /** Find an item on the grid by instance ID. Returns its position or null.
  *  Used to resolve an item's cell when it is the acting card of an activate
- *  (a stored or equipped item running a positional effect). */
+ *  (a stored or equipped item running a positional effect).
+ *
+ *  Deliberately grid-only: an HQ item resolves to null here so its positional
+ *  verbs no-op (contrast `findItemPosition` in position-helpers.ts, which spans
+ *  HQ *and* grid). Equipped items are located via their cell: this assumes an
+ *  equipped item stays listed in its bearer's cell `items` array (how equip
+ *  models storage today) — if that ever changes, positional equipped-item
+ *  effects would silently no-op and this lookup would need the bearer's cell. */
 export function findItemOnGrid(
   grid: Grid,
   itemId: string,

--- a/engine/src/position-helpers.ts
+++ b/engine/src/position-helpers.ts
@@ -73,6 +73,19 @@ export function getUnitsAtPosition(
   return grid[position.row]?.[position.col]?.units ?? [];
 }
 
+/** True if a unit controlled by `playerId` shares `position`. This is the single
+ *  definition of the "item can be operated here" gate — items are operated by a
+ *  co-located friendly unit, so both enumeration (valid-actions.ts) and execution
+ *  (apply-main.ts's handleActivate) gate on this predicate. */
+export function hasControllingUnitAt(
+  players: readonly PlayerState[],
+  grid: Grid,
+  position: BoardPosition,
+  playerId: string,
+): boolean {
+  return getUnitsAtPosition(players, grid, position).some((u) => u.controllerId === playerId);
+}
+
 /** Get all items at a position. */
 export function getItemsAtPosition(
   players: readonly PlayerState[],

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -229,6 +229,10 @@ export interface ItemCard extends CardBase {
    *  Named `itemType` to avoid colliding with the `type` discriminant. The
    *  militarist policy discount keys off this (see effects.ts). */
   itemType?: ItemType[];
+  /** Activatable actions (e.g. Philosopher's Stone's `transmute`). Enumerated
+   *  by `getValidActions` and run by `handleActivate` only when a controlling
+   *  unit is co-located with the item (items are operated by units). */
+  actions?: ActionDef[];
 }
 
 interface EventCardBase extends CardBase {

--- a/engine/src/valid-actions.ts
+++ b/engine/src/valid-actions.ts
@@ -501,6 +501,39 @@ function getMainValidActions(
         }
       }
     }
+
+    // Item actions (e.g. Philosopher's Stone). Items are operated by units, so
+    // an action surfaces only when a controlling unit is co-located — `units`
+    // above already filtered to the player's units at this position, so a
+    // non-empty list is exactly that gate. Equipped items pass automatically
+    // (their unit travels with them); a lone/stored item with no friendly unit
+    // present offers nothing.
+    if (units.length > 0) {
+      const items = getItemsAtPosition(state.players, state.grid, pos)
+        .filter((i) => ownerFilter || i.controllerId === playerId);
+      for (const item of items) {
+        if (!item.actions) continue;
+        for (const actionDef of item.actions) {
+          if (ap < actionDef.apCost) continue;
+          const targets = inferActivateTargets(
+            state,
+            item.id,
+            actionDef.effect,
+            pos,
+            playerId,
+          );
+          for (const t of targets) {
+            actions.push({
+              type: "activate",
+              playerId,
+              cardId: item.id,
+              actionName: actionDef.name,
+              ...t,
+            });
+          }
+        }
+      }
+    }
   }
 
   // activate — policy actions (HQ-origin: no grid position)

--- a/engine/src/valid-actions.ts
+++ b/engine/src/valid-actions.ts
@@ -3,7 +3,7 @@ import type { Primitive } from "./effect-dsl/types";
 import { tryParseCost } from "./cost-helpers";
 import { checkMissionRequirements, parseRequirements } from "./mission-helpers";
 import type { BoardPosition } from "./position-helpers";
-import { getItemsAtPosition, getUnitsAtPosition } from "./position-helpers";
+import { getItemsAtPosition, getUnitsAtPosition, hasControllingUnitAt } from "./position-helpers";
 import {
   areFacingEdgesOpen,
   getAdjacentCells,
@@ -503,14 +503,15 @@ function getMainValidActions(
     }
 
     // Item actions (e.g. Philosopher's Stone). Items are operated by units, so
-    // an action surfaces only when a controlling unit is co-located — `units`
-    // above already filtered to the player's units at this position, so a
-    // non-empty list is exactly that gate. Equipped items pass automatically
-    // (their unit travels with them); a lone/stored item with no friendly unit
-    // present offers nothing.
-    if (units.length > 0) {
+    // an action surfaces only while a unit the player controls shares the item's
+    // cell (hasControllingUnitAt — the same gate handleActivate enforces). An
+    // equipped item satisfies this via its own bearer, who is by construction a
+    // friendly unit in the cell; a lone/stored item with no friendly unit present
+    // offers nothing. Unlike units, an item's controllerId can diverge from where
+    // it sits, so filter items by controllerId even in HQ (no ownerFilter shortcut).
+    if (hasControllingUnitAt(state.players, state.grid, pos, playerId)) {
       const items = getItemsAtPosition(state.players, state.grid, pos)
-        .filter((i) => ownerFilter || i.controllerId === playerId);
+        .filter((i) => i.controllerId === playerId);
       for (const item of items) {
         if (!item.actions) continue;
         for (const actionDef of item.actions) {


### PR DESCRIPTION
## Summary

- Item cards with an `Action:` ability (e.g. Philosopher's Stone's `transmute:1:gain_3_gold`) are parsed from CSV but silently dropped: `ItemCard` has no `actions` field, the card loader doesn't wire it through, `getValidActions` never inspects items, and `handleActivate` throws for item ids.
- Add `actions?: ActionDef[]` to `ItemCard`, populate it in the loader, extend `getValidActions` to enumerate `activate` candidates for items in HQ and on the grid (HQ items gated by `isHqSafeVerb`, grid items positioned at their cell).
- Extend `handleActivate` to look up items by id when not found as a unit/policy.
- Open design question to resolve: should equipped item actions be activatable only by the equipped unit's player, or also when stored at a location?

Closes #130