### PR TITLE
Docs: link the live card gallery from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Card Game Project
 
+> 🃏 **[Browse the card gallery →](https://lalli-oni.github.io/cards/)** — all rendered cards (units, locations, items, events, policies).
+
 This repository houses a card game [name pending] with the following aspects:
 
 1. Completely free. Only monetization is through donations, if I can be bothered.


### PR DESCRIPTION
Adds a prominent link to the GitHub Pages card gallery (https://lalli-oni.github.io/cards/) at the top of the README, so it's reachable from the repo landing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)