### PR TITLE
203: Render↔keyword data contract: machine-readable glossary + keyword value syntax (render-accuracy blocker)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,17 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # Build the library first: the generated build/*.json (e.g. @library/all.json)
+      # is a gitignored artifact that cards-web's typecheck imports, so it must
+      # exist before typecheck runs.
+      - name: Build library
+        run: bun run build:library
+
       - name: Typecheck (all workspaces)
         run: bun --filter '*' typecheck
 
-      - name: Test (build library + engine/web/test suites)
-        run: bun run test
+      - name: Test (engine/web/test suites)
+        run: bun --filter '*' test
 
       - name: Renderer smoke tests (Python)
         run: bun run test:renderer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Cancel superseded runs on the same ref (e.g. rapid PR pushes).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck (all workspaces)
+        run: bun --filter '*' typecheck
+
+      - name: Test (build library + engine/web/test suites)
+        run: bun run test
+
+      - name: Renderer smoke tests (Python)
+        run: bun run test:renderer

--- a/design/moderntrek-template.py
+++ b/design/moderntrek-template.py
@@ -109,7 +109,7 @@ def _stroke(color, width, opacity=1, style="solid"):
 # Data
 # ---------------------------------------------------------------------------
 
-def parse_glossary():
+def parse_glossary(path=None, rules_path=None):
     """Load the machine-readable keyword glossary emitted by the library build
     (`library/build/glossary.json`, the #203 render↔data contract) into
     `{keyword_id: {name, scope, timing, apCost?, valued, reminder}}`.
@@ -119,9 +119,14 @@ def parse_glossary():
     the renderer reads one contract instead of re-parsing prose. It's a build
     output: run the build to (re)generate it. If it's missing, unreadable, or
     older than the rules it derives from, the renderer warns and degrades to
-    blank keyword reminders rather than failing the whole export."""
-    path = os.path.join(SCRIPT_DIR, "..", "library", "build", "glossary.json")
-    rules_path = os.path.join(SCRIPT_DIR, "..", "rules", "README.md")
+    blank keyword reminders rather than failing the whole export.
+
+    `path`/`rules_path` default to the real artifact and rules locations; they're
+    parameterised so tests can drive the degradation paths against fixtures."""
+    if path is None:
+        path = os.path.join(SCRIPT_DIR, "..", "library", "build", "glossary.json")
+    if rules_path is None:
+        rules_path = os.path.join(SCRIPT_DIR, "..", "rules", "README.md")
     if not os.path.exists(path):
         print(f"WARNING: glossary artifact not found at {path} — run "
               f"`bun library/build.ts` to generate it; keyword reminders will be "
@@ -134,12 +139,22 @@ def parse_glossary():
         print(f"WARNING: glossary artifact unreadable at {path}: {exc} — keyword "
               f"reminders will be blank", file=sys.stderr)
         return {}
+    if not isinstance(glossary, dict):
+        print(f"WARNING: glossary artifact at {path} is not a JSON object (got "
+              f"{type(glossary).__name__}) — keyword reminders will be blank",
+              file=sys.stderr)
+        return {}
+    # mtime is a cheap staleness *proxy*, not a guarantee: an operation that
+    # rewrites rules/README.md without rebuilding the (git-ignored) artifact —
+    # e.g. a git checkout/stash — can trip a false "stale" warning. Fine for a
+    # non-blocking heads-up.
     try:
         if os.path.getmtime(path) < os.path.getmtime(rules_path):
             print(f"WARNING: {path} is older than rules/README.md — it may be "
                   f"stale; re-run `bun library/build.ts`", file=sys.stderr)
-    except OSError:
-        pass
+    except OSError as exc:
+        print(f"WARNING: could not compare glossary/rules timestamps ({exc}) — "
+              f"staleness not checked", file=sys.stderr)
     return glossary
 
 
@@ -151,17 +166,35 @@ _ABILITY_TOKEN = re.compile(r"^([A-Za-z][A-Za-z-]*)(?:\[(\d+)\])?$")
 def keyword_reminder(ability, glossary):
     """Split an `abilities` token into (label, reminder). Value-bearing keywords
     like `Commander[3]` substitute the value into the glossary's X placeholder;
-    the pill label renders the value space-separated (`COMMANDER 3`)."""
+    the pill label renders the value space-separated (`COMMANDER 3`). Degrades to
+    a blank reminder — never raises — on an unknown keyword, a malformed token, or
+    a malformed/incomplete glossary entry (see parse_glossary's shape note)."""
     m = _ABILITY_TOKEN.match(ability.strip())
     if not m:
         return ability.upper(), ""
     name, value = m.group(1), m.group(2)
     entry = glossary.get(name.lower())
-    if not entry:
-        # Unknown keyword — render the label as written, no reminder.
+    if not isinstance(entry, dict) or "reminder" not in entry:
+        # Unknown keyword, or a wrong-shape artifact entry — label as written, no
+        # reminder. Guarding here (not just entry truthiness) keeps a corrupt
+        # glossary.json from crashing the export deep in shape-building.
         return (f"{name} {value}" if value else name).upper(), ""
-    reminder = re.sub(r"\bX\b", value, entry["reminder"]) if value else entry["reminder"]
-    label = f"{entry['name']} {value}" if value else entry["name"]
+    display = entry.get("name", name)
+    reminder = entry["reminder"]
+    valued = entry.get("valued", "X" in reminder)
+    # Arity mismatches the full build would have caught (reachable on a partial
+    # build or hand-edited data) — warn and degrade, never print a literal "X" or
+    # a bogus magnitude.
+    if valued and value is None:
+        print(f"WARNING: keyword '{display}' needs a value but none was given in "
+              f"'{ability}' — reminder blanked", file=sys.stderr)
+        return display.upper(), ""
+    if not valued and value is not None:
+        print(f"WARNING: keyword '{display}' takes no value but '{ability}' "
+              f"supplies one — value ignored", file=sys.stderr)
+        return display.upper(), reminder
+    reminder = re.sub(r"\bX\b", value, reminder) if value else reminder
+    label = f"{display} {value}" if value else display
     return label.upper(), reminder
 
 

--- a/design/moderntrek-template.py
+++ b/design/moderntrek-template.py
@@ -14,8 +14,9 @@ Rules-faithful choices (the library is the source of truth, not the design; #202
   timing/trigger/text, effect/seeding_effect) — cleanly separated, no blob.
 - Where a type has only a freeform `text` blob (units, location actions), it is
   rendered as-is; per-effect structuring is tracked with the keyword work (#203).
-- Unit keyword pills come from `abilities` + the rules glossary; dormant until
-  cards populate `abilities` (#194/#198) and the value syntax lands (#203).
+- Unit keyword pills come from `abilities` + the glossary artifact
+  (`library/build/glossary.json`, the #203 render↔data contract); dormant until
+  cards populate `abilities` (#194/#198).
 
 Deliberately deferred for v1: type/attribute glyph icons (#204), the diagonal
 hatch texture, and the event hazard-stripe top edge (solid bar for now).
@@ -109,55 +110,59 @@ def _stroke(color, width, opacity=1, style="solid"):
 # ---------------------------------------------------------------------------
 
 def parse_glossary():
-    """Parse the keyword glossary table(s) in rules/README.md into
-    {keyword_lower: (timing, definition)}.
+    """Load the machine-readable keyword glossary emitted by the library build
+    (`library/build/glossary.json`, the #203 render↔data contract) into
+    `{keyword_id: {name, scope, timing, apCost?, valued, reminder}}`.
 
-    Only rows belonging to a table whose header is `| Keyword | Timing |
-    Definition |` are captured; other 3-column tables in the README (e.g. the
-    Actions table) are ignored so an action name can't masquerade as a keyword.
-    Provisional pending #203."""
-    path = os.path.join(SCRIPT_DIR, "..", "rules", "README.md")
-    glossary = {}
+    `rules/README.md` stays the human-authored source; `bun library/build.ts`
+    derives this artifact from it (and validates card `abilities` against it), so
+    the renderer reads one contract instead of re-parsing prose. It's a build
+    output: run the build to (re)generate it. If it's missing, unreadable, or
+    older than the rules it derives from, the renderer warns and degrades to
+    blank keyword reminders rather than failing the whole export."""
+    path = os.path.join(SCRIPT_DIR, "..", "library", "build", "glossary.json")
+    rules_path = os.path.join(SCRIPT_DIR, "..", "rules", "README.md")
+    if not os.path.exists(path):
+        print(f"WARNING: glossary artifact not found at {path} — run "
+              f"`bun library/build.ts` to generate it; keyword reminders will be "
+              f"blank", file=sys.stderr)
+        return {}
     try:
         with open(path) as f:
-            in_glossary = False
-            for line in f:
-                stripped = line.strip()
-                if not stripped.startswith("|"):
-                    in_glossary = False           # a blank/non-table line ends the table
-                    continue
-                cells = [c.strip() for c in stripped.strip("|").split("|")]
-                if len(cells) != 3:
-                    in_glossary = False           # a differently-shaped table
-                    continue
-                if cells[0] == "Keyword":         # glossary header row -> start capturing
-                    in_glossary = True
-                    continue
-                if "---" in cells[1]:             # separator row -> keep state
-                    continue
-                if in_glossary:
-                    glossary[cells[0].lower()] = (cells[1], cells[2])
-    except OSError as exc:
-        print(f"WARNING: keyword glossary unreadable at {path}: {exc} — "
-              f"keyword reminders will be blank", file=sys.stderr)
-        return glossary
-    if not glossary:
-        print(f"WARNING: no keyword rows parsed from {path} (table format may have "
-              f"changed) — keyword reminders will be blank", file=sys.stderr)
+            glossary = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"WARNING: glossary artifact unreadable at {path}: {exc} — keyword "
+              f"reminders will be blank", file=sys.stderr)
+        return {}
+    try:
+        if os.path.getmtime(path) < os.path.getmtime(rules_path):
+            print(f"WARNING: {path} is older than rules/README.md — it may be "
+                  f"stale; re-run `bun library/build.ts`", file=sys.stderr)
+    except OSError:
+        pass
     return glossary
 
 
+# `ident value?` where a value is `[N]` — mirrors the library's ABILITY_TOKEN
+# (library/glossary.ts) and the effect-DSL `token` grammar (#203).
+_ABILITY_TOKEN = re.compile(r"^([A-Za-z][A-Za-z-]*)(?:\[(\d+)\])?$")
+
+
 def keyword_reminder(ability, glossary):
-    """Split an `abilities` entry into (label, reminder). Value-bearing keywords
-    like 'Commander 3' substitute the value into the glossary's X placeholder."""
-    parts = ability.split()
-    value = parts[-1] if len(parts) > 1 and parts[-1].isdigit() else None
-    name = " ".join(parts[:-1]) if value else ability
+    """Split an `abilities` token into (label, reminder). Value-bearing keywords
+    like `Commander[3]` substitute the value into the glossary's X placeholder;
+    the pill label renders the value space-separated (`COMMANDER 3`)."""
+    m = _ABILITY_TOKEN.match(ability.strip())
+    if not m:
+        return ability.upper(), ""
+    name, value = m.group(1), m.group(2)
     entry = glossary.get(name.lower())
-    reminder = ""
-    if entry:
-        reminder = re.sub(r"\bX\b", value, entry[1]) if value else entry[1]
-    return ability.upper(), reminder
+    if not entry:
+        # Unknown keyword — render the label as written, no reminder.
+        return (f"{name} {value}" if value else name).upper(), ""
+    reminder = re.sub(r"\bX\b", value, entry["reminder"]) if value else entry["reminder"]
+    label = f"{entry['name']} {value}" if value else entry["name"]
+    return label.upper(), reminder
 
 
 def parse_card(row, index):

--- a/design/test_moderntrek_template.py
+++ b/design/test_moderntrek_template.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Smoke tests for the glossary consumer in moderntrek-template.py (#203).
+
+The renderer is Python while the rest of the suite is bun/TS, so these run
+standalone:  python3 design/test_moderntrek_template.py  (exit 0 = pass).
+
+Covers parse_glossary's degradation paths (missing / non-JSON / wrong-shape /
+valid / stale) and keyword_reminder's bracket parse, X-substitution, unknown /
+malformed-token / arity-mismatch degradation — the branches that would otherwise
+ship unverified.
+"""
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, SCRIPT_DIR)  # so the module's `from penpot import ...` resolves
+
+_spec = importlib.util.spec_from_file_location(
+    "moderntrek_template", os.path.join(SCRIPT_DIR, "moderntrek-template.py"))
+mt = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mt)
+
+GLOSSARY = {
+    "commander": {"id": "commander", "name": "Commander", "scope": "unit",
+                  "timing": "static", "valued": True,
+                  "reminder": "Friendly units get +X to all stats"},
+    "lethal": {"id": "lethal", "name": "Lethal", "scope": "unit",
+               "timing": "static", "valued": False,
+               "reminder": "The loser is killed instead of injured"},
+}
+
+_failures = []
+
+
+def check(name, cond):
+    print(f"  {'ok  ' if cond else 'FAIL'} {name}")
+    if not cond:
+        _failures.append(name)
+
+
+@contextlib.contextmanager
+def _tmp_json(obj_or_text):
+    """Write a temp file (dict → JSON, str → raw) and yield its path."""
+    fd, path = tempfile.mkstemp(suffix=".json")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(obj_or_text if isinstance(obj_or_text, str) else json.dumps(obj_or_text))
+        yield path
+    finally:
+        os.remove(path)
+
+
+def _quiet(fn, *args):
+    """Call fn, swallowing stderr; return (result, stderr_text)."""
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        result = fn(*args)
+    return result, buf.getvalue()
+
+
+def test_parse_glossary():
+    print("parse_glossary:")
+    # Missing file → {} + a warning.
+    res, err = _quiet(mt.parse_glossary, os.path.join(SCRIPT_DIR, "does-not-exist.json"))
+    check("missing file → {}", res == {})
+    check("missing file → warns", "not found" in err.lower() or "blank" in err.lower())
+
+    # Valid JSON object → dict passthrough.
+    with _tmp_json({"commander": GLOSSARY["commander"]}) as p:
+        res, _ = _quiet(mt.parse_glossary, p, __file__)
+        check("valid JSON → dict", isinstance(res, dict) and "commander" in res)
+
+    # Non-object JSON (a list) → {} + warning, no crash.
+    with _tmp_json([1, 2, 3]) as p:
+        res, err = _quiet(mt.parse_glossary, p, __file__)
+        check("non-object JSON → {}", res == {})
+        check("non-object JSON → warns", "not a json object" in err.lower())
+
+    # Invalid JSON text → {} + warning, no crash.
+    with _tmp_json("{ not json ") as p:
+        res, err = _quiet(mt.parse_glossary, p, __file__)
+        check("unreadable JSON → {}", res == {})
+
+    # Stale (artifact older than rules) → warns but still returns the data.
+    with _tmp_json({"commander": GLOSSARY["commander"]}) as p:
+        os.utime(p, (0, 0))  # far in the past, older than any rules file
+        res, err = _quiet(mt.parse_glossary, p, __file__)
+        check("stale artifact → still returns data", "commander" in res)
+        check("stale artifact → warns", "stale" in err.lower())
+
+
+def test_keyword_reminder():
+    print("keyword_reminder:")
+    label, reminder = mt.keyword_reminder("Commander[3]", GLOSSARY)
+    check("valued → COMMANDER 3 label", label == "COMMANDER 3")
+    check("valued → X substituted", reminder == "Friendly units get +3 to all stats")
+
+    label, reminder = mt.keyword_reminder("commander[3]", GLOSSARY)
+    check("mis-cased → canonical label", label == "COMMANDER 3")
+
+    label, reminder = mt.keyword_reminder("Lethal", GLOSSARY)
+    check("value-less → LETHAL label", label == "LETHAL")
+    check("value-less → full reminder", reminder == "The loser is killed instead of injured")
+
+    label, reminder = mt.keyword_reminder("Mystery[9]", GLOSSARY)
+    check("unknown → label as written", label == "MYSTERY 9")
+    check("unknown → blank reminder", reminder == "")
+
+    label, reminder = mt.keyword_reminder("Bogus{x}", GLOSSARY)
+    check("malformed token → no crash, blank reminder", label == "BOGUS{X}" and reminder == "")
+
+    # Wrong-shape entry (missing "reminder") must degrade, not KeyError.
+    (label, reminder), _ = _quiet(mt.keyword_reminder, "Commander[3]", {"commander": {"scope": "unit"}})
+    check("wrong-shape entry → degrades (no crash)", reminder == "")
+
+    # Arity mismatch: valued keyword without a value → warn + blank (no literal X).
+    (label, reminder), err = _quiet(mt.keyword_reminder, "Commander", GLOSSARY)
+    check("valued w/o value → blank reminder (no literal X)", reminder == "")
+    check("valued w/o value → warns", "needs a value" in err.lower())
+
+    # Arity mismatch: value-less keyword given a value → warn, value dropped.
+    (label, reminder), err = _quiet(mt.keyword_reminder, "Lethal[2]", GLOSSARY)
+    check("value-less w/ value → label drops value", label == "LETHAL")
+    check("value-less w/ value → warns", "takes no value" in err.lower())
+
+
+if __name__ == "__main__":
+    test_parse_glossary()
+    test_keyword_reminder()
+    if _failures:
+        print(f"\n{len(_failures)} FAILED: {', '.join(_failures)}")
+        sys.exit(1)
+    print("\nAll renderer smoke tests passed.")

--- a/library/build.ts
+++ b/library/build.ts
@@ -18,7 +18,7 @@ import {
   EVENT_TYPES,
   ITEM_TYPES,
 } from "../engine/src/card-categories";
-import { parseGlossary, parseAbilityToken, type Glossary } from "./glossary";
+import { parseGlossary, parseAbilityToken, type Glossary, type KeywordDef } from "./glossary";
 
 const LIBRARY_DIR = join(import.meta.dir);
 const SETS_DIR = join(LIBRARY_DIR, "sets");
@@ -252,11 +252,11 @@ export function validate(
   }
 
   // Keyword `abilities` — render-accuracy checks only (#203). We validate the
-  // value *syntax* (`Keyword` or `Keyword[N]`) always, and value-arity for
-  // keywords the glossary knows. Whether unknown keywords are *rejected*
-  // (governance) is deferred to #194, so an unlisted keyword is skipped here,
-  // not flagged. Runs only when a glossary is supplied (i.e. the full build);
-  // unit tests calling `validate(type, card)` skip it.
+  // value *syntax* (`Keyword` or `Keyword[N]`) for every token, plus canonical
+  // Title-case and value-arity for the keywords the glossary knows. Whether
+  // unknown keywords are *rejected* (governance) is deferred to #194, so an
+  // unlisted keyword is warned-about but not failed here. Runs only when a
+  // glossary is supplied (the full build); `validate(type, card)` skips it.
   if (glossary) {
     const abilities = (card.abilities as string[] | undefined) ?? [];
     for (const raw of abilities) {
@@ -265,12 +265,23 @@ export function validate(
         errors.push({ card: id, field: "abilities", message: `malformed keyword "${raw}" (expected "Keyword" or "Keyword[N]")` });
         continue;
       }
-      const def = glossary[token.id];
-      if (!def) continue; // unknown keyword — governance is #194's call, not #203's
+      const def: KeywordDef | undefined = glossary[token.id];
+      if (!def) {
+        // Unknown keyword — rejecting it is #194's call, not #203's. Warn so a
+        // fat-fingered *known* keyword (e.g. "Commmander") surfaces in build
+        // output instead of silently rendering with no reminder text.
+        console.warn(`  Warning: card "${id}" uses unknown keyword "${token.name}" (no glossary entry; not validated)`);
+        continue;
+      }
+      if (token.name !== def.name) {
+        errors.push({ card: id, field: "abilities", message: `keyword "${token.name}" must be written "${def.name}" (Title-case matching the glossary)` });
+      }
       if (def.valued && token.value === null) {
-        errors.push({ card: id, field: "abilities", message: `keyword "${token.name}" requires a value, e.g. ${token.name}[1]` });
+        errors.push({ card: id, field: "abilities", message: `keyword "${def.name}" requires a value, e.g. ${def.name}[1]` });
       } else if (!def.valued && token.value !== null) {
-        errors.push({ card: id, field: "abilities", message: `keyword "${token.name}" does not take a value (got "${raw}")` });
+        errors.push({ card: id, field: "abilities", message: `keyword "${def.name}" does not take a value (got "${raw}")` });
+      } else if (def.valued && token.value !== null && token.value < 1) {
+        errors.push({ card: id, field: "abilities", message: `keyword "${def.name}" value must be a positive magnitude (got ${token.value})` });
       }
     }
   }

--- a/library/build.ts
+++ b/library/build.ts
@@ -18,10 +18,12 @@ import {
   EVENT_TYPES,
   ITEM_TYPES,
 } from "../engine/src/card-categories";
+import { parseGlossary, parseAbilityToken, type Glossary } from "./glossary";
 
 const LIBRARY_DIR = join(import.meta.dir);
 const SETS_DIR = join(LIBRARY_DIR, "sets");
 const BUILD_DIR = join(LIBRARY_DIR, "build");
+const RULES_README = join(LIBRARY_DIR, "..", "rules", "README.md");
 
 const CARD_TYPES = ["units", "locations", "items", "events", "policies"] as const;
 export type CardType = (typeof CARD_TYPES)[number];
@@ -188,7 +190,11 @@ export function transformCard(type: CardType, raw: Record<string, string>): Reco
 
 export type ValidationError = { card: string; field: string; message: string };
 
-export function validate(type: CardType, card: Record<string, unknown>): ValidationError[] {
+export function validate(
+  type: CardType,
+  card: Record<string, unknown>,
+  glossary?: Glossary,
+): ValidationError[] {
   const errors: ValidationError[] = [];
   const id = (card.id as string) || "unknown";
 
@@ -245,6 +251,30 @@ export function validate(type: CardType, card: Record<string, unknown>): Validat
     }
   }
 
+  // Keyword `abilities` — render-accuracy checks only (#203). We validate the
+  // value *syntax* (`Keyword` or `Keyword[N]`) always, and value-arity for
+  // keywords the glossary knows. Whether unknown keywords are *rejected*
+  // (governance) is deferred to #194, so an unlisted keyword is skipped here,
+  // not flagged. Runs only when a glossary is supplied (i.e. the full build);
+  // unit tests calling `validate(type, card)` skip it.
+  if (glossary) {
+    const abilities = (card.abilities as string[] | undefined) ?? [];
+    for (const raw of abilities) {
+      const token = parseAbilityToken(raw);
+      if (!token) {
+        errors.push({ card: id, field: "abilities", message: `malformed keyword "${raw}" (expected "Keyword" or "Keyword[N]")` });
+        continue;
+      }
+      const def = glossary[token.id];
+      if (!def) continue; // unknown keyword — governance is #194's call, not #203's
+      if (def.valued && token.value === null) {
+        errors.push({ card: id, field: "abilities", message: `keyword "${token.name}" requires a value, e.g. ${token.name}[1]` });
+      } else if (!def.valued && token.value !== null) {
+        errors.push({ card: id, field: "abilities", message: `keyword "${token.name}" does not take a value (got "${raw}")` });
+      }
+    }
+  }
+
   // DSL effect validation — skipped for policies (action.effect is
   // human-readable prose; executable DSL lives in POLICY_ACTIONS).
   const actions = card.actions as { name: string; apCost: number; effect: string }[] | undefined;
@@ -272,7 +302,7 @@ export function validate(type: CardType, card: Record<string, unknown>): Validat
 
 // --- Main ---
 
-function buildSet(setName: string): { cards: Record<string, unknown>[]; errors: ValidationError[] } {
+function buildSet(setName: string, glossary: Glossary): { cards: Record<string, unknown>[]; errors: ValidationError[] } {
   const setDir = join(SETS_DIR, setName);
   const cards: Record<string, unknown>[] = [];
   const errors: ValidationError[] = [];
@@ -289,7 +319,7 @@ function buildSet(setName: string): { cards: Record<string, unknown>[]; errors: 
 
     for (const row of rows) {
       const card = transformCard(type, row);
-      errors.push(...validate(type, card));
+      errors.push(...validate(type, card, glossary));
       cards.push(card);
     }
   }
@@ -300,6 +330,12 @@ function buildSet(setName: string): { cards: Record<string, unknown>[]; errors: 
 function main() {
   const targetSet = process.argv[2];
   mkdirSync(BUILD_DIR, { recursive: true });
+
+  // Derive the keyword glossary from rules/README.md and emit the render↔data
+  // contract artifact (#203). Also used to validate card `abilities` below.
+  const glossary = parseGlossary(readFileSync(RULES_README, "utf-8"));
+  writeFileSync(join(BUILD_DIR, "glossary.json"), JSON.stringify(glossary, null, 2));
+  console.log(`Glossary: ${Object.keys(glossary).length} keywords → build/glossary.json`);
 
   const sets = targetSet
     ? [targetSet]
@@ -313,7 +349,7 @@ function main() {
 
   for (const setName of sets) {
     console.log(`Building set: ${setName}`);
-    const { cards, errors } = buildSet(setName);
+    const { cards, errors } = buildSet(setName, glossary);
 
     writeFileSync(join(BUILD_DIR, `${setName}.json`), JSON.stringify(cards, null, 2));
     console.log(`  ${cards.length} cards`);

--- a/library/build.ts
+++ b/library/build.ts
@@ -274,7 +274,11 @@ export function validate(
         continue;
       }
       if (token.name !== def.name) {
+        // Report only the casing problem for a mis-cased token — its arity is
+        // checked on the next build once the name is fixed, so we avoid emitting
+        // two errors that refer to the keyword by two different casings.
         errors.push({ card: id, field: "abilities", message: `keyword "${token.name}" must be written "${def.name}" (Title-case matching the glossary)` });
+        continue;
       }
       if (def.valued && token.value === null) {
         errors.push({ card: id, field: "abilities", message: `keyword "${def.name}" requires a value, e.g. ${def.name}[1]` });

--- a/library/glossary.ts
+++ b/library/glossary.ts
@@ -1,0 +1,134 @@
+/**
+ * Keyword glossary — the machine-readable render↔data contract (#203).
+ *
+ * `rules/README.md` stays the human-authored source of truth. This module
+ * derives a structured glossary from its "## Keyword System" tables so the
+ * build, the Penpot renderer (`design/compose-cards.py`), and eventually the
+ * engine all read one artifact instead of re-parsing prose. The build writes
+ * the derived form to `library/build/glossary.json`.
+ *
+ * Keyword value syntax (decided in #203): a card's `abilities` field is a
+ * `;`-separated list of tokens shaped like the effect-DSL `token` rule —
+ * `ident value?` where a value is `[N]` (e.g. `Commander[3];Lethal`). Values
+ * are magnitudes; the sign lives in the reminder text ("get -X").
+ */
+
+export type KeywordScope = "unit" | "equipment" | "location";
+export type KeywordTiming = "static" | "triggered" | "activated";
+
+export interface KeywordDef {
+  /** Lowercased lookup id (e.g. `commander`). */
+  id: string;
+  /** Title-case display name matching the glossary (e.g. `Commander`). */
+  name: string;
+  scope: KeywordScope;
+  timing: KeywordTiming;
+  /** AP cost for Activated keywords (e.g. Heal → 1), when the glossary states one. */
+  apCost?: number;
+  /** Whether the keyword carries a value — inferred from an `X` in the definition. */
+  valued: boolean;
+  /**
+   * Reminder-text template. Keeps the glossary's `X` placeholder; consumers
+   * substitute the card's value (value-less keywords have no `X`).
+   */
+  reminder: string;
+}
+
+export type Glossary = Record<string, KeywordDef>;
+
+const SCOPE_HEADINGS: Record<string, KeywordScope> = {
+  "unit keywords": "unit",
+  "equipment keywords": "equipment",
+  "location keywords": "location",
+};
+
+const VALID_TIMINGS: KeywordTiming[] = ["static", "triggered", "activated"];
+
+/** A standalone `X` placeholder (matches `+X`, `-X`, `X` — not words like `max`). */
+const VALUE_PLACEHOLDER = /\bX\b/;
+
+/**
+ * Parse the keyword glossary out of `rules/README.md`.
+ *
+ * Scoped to the `## Keyword System` section (up to the next top-level `## `),
+ * reading the `#### Unit/Equipment/Location keywords` markdown tables. Throws
+ * if the section or its tables can't be found, so a rules refactor fails the
+ * build loudly instead of silently emitting an empty contract.
+ */
+export function parseGlossary(readmeContent: string): Glossary {
+  const start = readmeContent.indexOf("## Keyword System");
+  if (start === -1) {
+    throw new Error("glossary: '## Keyword System' section not found in rules/README.md");
+  }
+  // End at the next top-level heading after the section start.
+  const rest = readmeContent.slice(start + "## Keyword System".length);
+  const nextTop = rest.search(/\n## /);
+  const section = nextTop === -1 ? rest : rest.slice(0, nextTop);
+
+  const glossary: Glossary = {};
+  let scope: KeywordScope | null = null;
+
+  for (const line of section.split("\n")) {
+    const heading = line.match(/^####\s+(.+?)\s*$/);
+    if (heading) {
+      scope = SCOPE_HEADINGS[heading[1].trim().toLowerCase()] ?? null;
+      continue;
+    }
+
+    if (!scope || !line.trimStart().startsWith("|")) continue;
+
+    const cells = line.split("|").slice(1, -1).map((c) => c.trim());
+    if (cells.length < 3) continue;
+    const [keyword, timingCell, definition] = cells;
+    // Skip the header row and the `|---|` separator.
+    if (keyword.toLowerCase() === "keyword" || /^-+$/.test(keyword)) continue;
+
+    const timingWord = (timingCell.match(/^([A-Za-z]+)/)?.[1] ?? "").toLowerCase() as KeywordTiming;
+    if (!VALID_TIMINGS.includes(timingWord)) {
+      throw new Error(`glossary: '${keyword}' has unrecognized timing "${timingCell}"`);
+    }
+    const apCost = timingCell.match(/\((\d+)\s*AP\)/i)?.[1];
+
+    const def: KeywordDef = {
+      id: keyword.toLowerCase(),
+      name: keyword,
+      scope,
+      timing: timingWord,
+      valued: VALUE_PLACEHOLDER.test(definition),
+      reminder: definition,
+    };
+    if (apCost !== undefined) def.apCost = parseInt(apCost, 10);
+    glossary[def.id] = def;
+  }
+
+  if (Object.keys(glossary).length === 0) {
+    throw new Error("glossary: no keywords parsed from the '## Keyword System' tables");
+  }
+  return glossary;
+}
+
+export interface AbilityToken {
+  /** Lowercased glossary lookup id. */
+  id: string;
+  /** As-written keyword name. */
+  name: string;
+  /** Parsed value, or null for a value-less keyword. */
+  value: number | null;
+}
+
+/** `ident value?` where value is `[N]` — e.g. `Commander[3]` or `Lethal`. */
+const ABILITY_TOKEN = /^([A-Za-z][A-Za-z-]*)(?:\[(\d+)\])?$/;
+
+/**
+ * Parse a single `abilities` token (`Commander[3]` / `Lethal`). Returns null
+ * if malformed — the caller decides whether that's an error.
+ */
+export function parseAbilityToken(raw: string): AbilityToken | null {
+  const m = raw.trim().match(ABILITY_TOKEN);
+  if (!m) return null;
+  return {
+    id: m[1].toLowerCase(),
+    name: m[1],
+    value: m[2] !== undefined ? parseInt(m[2], 10) : null,
+  };
+}

--- a/library/glossary.ts
+++ b/library/glossary.ts
@@ -3,10 +3,9 @@
  *
  * `rules/README.md` stays the human-authored source of truth. This module
  * derives a structured glossary from its "## Keyword System" tables and the
- * build writes it to `library/build/glossary.json`. Today only the build reads
- * that artifact; the Penpot renderer (`design/moderntrek-template.py`) and,
- * eventually, the engine are intended to migrate onto it instead of each
- * re-parsing the prose (they still re-parse it for now).
+ * build writes it to `library/build/glossary.json`. The build and the Penpot
+ * renderer (`design/moderntrek-template.py`) both read that artifact; the engine
+ * is intended to migrate onto it too (it still re-parses the prose for now).
  *
  * Keyword value syntax (decided in #203): a card's `abilities` field is a
  * `;`-separated list of tokens shaped like the effect-DSL `token` rule —
@@ -79,15 +78,35 @@ export function parseGlossary(readmeContent: string): Glossary {
   const glossary: Glossary = {};
   const scopesSeen: Set<KeywordScope> = new Set();
   let scope: KeywordScope | null = null;
+  let sawTableLine: boolean = false;
 
   for (const line of section.split("\n")) {
     const heading: RegExpMatchArray | null = line.match(/^####\s+(.+?)\s*$/);
     if (heading) {
-      scope = SCOPE_HEADINGS[heading[1].trim().toLowerCase()] ?? null;
+      const headingText: string = heading[1].trim();
+      scope = SCOPE_HEADINGS[headingText.toLowerCase()] ?? null;
+      sawTableLine = false;
+      // A `#### ... keywords` heading that isn't a known scope is almost
+      // certainly a renamed/typo'd scope table — fail loud rather than silently
+      // dropping its rows. (The scopesSeen guard below only catches a *canonical*
+      // scope going empty, not a fourth-category table under a new heading.)
+      if (!scope && headingText.toLowerCase().endsWith("keywords")) {
+        throw new Error(`glossary: unrecognized keyword-scope heading '#### ${headingText}' — expected Unit/Equipment/Location keywords`);
+      }
       continue;
     }
 
-    if (!scope || !line.trimStart().startsWith("|")) continue;
+    if (!line.trimStart().startsWith("|")) {
+      // A non-pipe line after a table's rows ends that table's scope, so stray
+      // pipe-leading prose before the next heading isn't parsed as keyword rows.
+      if (sawTableLine) {
+        scope = null;
+        sawTableLine = false;
+      }
+      continue;
+    }
+    if (!scope) continue;
+    sawTableLine = true;
 
     // Strip the (optional) outer pipes, then split on unescaped `|`. This keeps
     // a row that omits its trailing pipe, or embeds an escaped `\|` in the
@@ -96,22 +115,25 @@ export function parseGlossary(readmeContent: string): Glossary {
     const cells: string[] = inner.split(/(?<!\\)\|/).map((c: string) => c.trim().replace(/\\\|/g, "|"));
     const [keyword, timingCell, definition] = cells;
 
-    // Skip the header row and any alignment separator (`---`, `:--:`, `--:`).
+    // A fully-empty row (any column count) is ignorable table filler.
+    if (cells.every((c: string) => c === "")) continue;
+
+    // Skip the header row and any alignment separator. A separator only counts
+    // as one when *every* cell is dashes (optionally colon-aligned), so a real
+    // data row can't be mistaken for scaffolding.
     if (
       keyword.toLowerCase() === "keyword" ||
       timingCell?.toLowerCase() === "timing" ||
-      /^:?-+:?$/.test(keyword)
+      cells.every((c: string) => /^:?-+:?$/.test(c))
     ) {
       continue;
     }
 
-    // A real data row has all three columns. A content-bearing short row is
-    // malformed (throw, don't silently skip); a fully-empty one is ignorable.
-    if (cells.length < 3) {
-      if (cells.some((c: string) => c !== "")) {
-        throw new Error(`glossary: malformed table row "${line.trim()}" (expected 3 columns: Keyword | Timing | Definition)`);
-      }
-      continue;
+    // A real data row has exactly three columns. Too few or too many (e.g. an
+    // unescaped `|` in the definition) is malformed — throw rather than silently
+    // truncate. (Fully-empty rows were already skipped above.)
+    if (cells.length !== 3) {
+      throw new Error(`glossary: malformed table row "${line.trim()}" — expected 3 columns (Keyword | Timing | Definition); escape any literal '|' in the definition as '\\|'`);
     }
 
     const timingWord: KeywordTiming = (timingCell.match(/^([A-Za-z]+)/)?.[1] ?? "").toLowerCase() as KeywordTiming;
@@ -170,7 +192,12 @@ export interface AbilityToken {
   value: number | null;
 }
 
-/** `ident value?` where value is `[N]` — e.g. `Commander[3]` or `Lethal`. */
+/**
+ * `ident value?` where value is `[N]` — e.g. `Commander[3]` or `Lethal`.
+ * NOTE: kept byte-identical to `_ABILITY_TOKEN` in `design/moderntrek-template.py`
+ * (the renderer's copy) — the render↔data contract depends on both agreeing, so
+ * edit them together.
+ */
 const ABILITY_TOKEN = /^([A-Za-z][A-Za-z-]*)(?:\[(\d+)\])?$/;
 
 /**

--- a/library/glossary.ts
+++ b/library/glossary.ts
@@ -2,10 +2,11 @@
  * Keyword glossary — the machine-readable render↔data contract (#203).
  *
  * `rules/README.md` stays the human-authored source of truth. This module
- * derives a structured glossary from its "## Keyword System" tables so the
- * build, the Penpot renderer (`design/compose-cards.py`), and eventually the
- * engine all read one artifact instead of re-parsing prose. The build writes
- * the derived form to `library/build/glossary.json`.
+ * derives a structured glossary from its "## Keyword System" tables and the
+ * build writes it to `library/build/glossary.json`. Today only the build reads
+ * that artifact; the Penpot renderer (`design/moderntrek-template.py`) and,
+ * eventually, the engine are intended to migrate onto it instead of each
+ * re-parsing the prose (they still re-parse it for now).
  *
  * Keyword value syntax (decided in #203): a card's `abilities` field is a
  * `;`-separated list of tokens shaped like the effect-DSL `token` rule —
@@ -34,6 +35,9 @@ export interface KeywordDef {
   reminder: string;
 }
 
+/** Keyed by `KeywordDef.id` (the lowercased keyword) — the key and the entry's
+ *  `id` are always the same string, and `parseGlossary` is the only sanctioned
+ *  way to build one so that invariant (and the lowercasing) holds. */
 export type Glossary = Record<string, KeywordDef>;
 
 const SCOPE_HEADINGS: Record<string, KeywordScope> = {
@@ -43,8 +47,13 @@ const SCOPE_HEADINGS: Record<string, KeywordScope> = {
 };
 
 const VALID_TIMINGS: KeywordTiming[] = ["static", "triggered", "activated"];
+const VALID_SCOPES: KeywordScope[] = ["unit", "equipment", "location"];
 
-/** A standalone `X` placeholder (matches `+X`, `-X`, `X` — not words like `max`). */
+/**
+ * A standalone uppercase `X` placeholder — matches `+X`, `-X`, and a bare `X`,
+ * but not an `X` embedded in a word (e.g. `MAX`, `EXIT`). A lowercase `x` (as in
+ * `max`) is excluded by case, since the pattern is case-sensitive.
+ */
 const VALUE_PLACEHOLDER = /\bX\b/;
 
 /**
@@ -56,7 +65,9 @@ const VALUE_PLACEHOLDER = /\bX\b/;
  * build loudly instead of silently emitting an empty contract.
  */
 export function parseGlossary(readmeContent: string): Glossary {
-  const start = readmeContent.indexOf("## Keyword System");
+  // Anchor on the heading as a whole line so a stray inline mention of the
+  // phrase (or a longer heading like `## Keyword Systems`) can't re-anchor us.
+  const start = readmeContent.search(/^## Keyword System\s*$/m);
   if (start === -1) {
     throw new Error("glossary: '## Keyword System' section not found in rules/README.md");
   }
@@ -66,10 +77,11 @@ export function parseGlossary(readmeContent: string): Glossary {
   const section = nextTop === -1 ? rest : rest.slice(0, nextTop);
 
   const glossary: Glossary = {};
+  const scopesSeen: Set<KeywordScope> = new Set();
   let scope: KeywordScope | null = null;
 
   for (const line of section.split("\n")) {
-    const heading = line.match(/^####\s+(.+?)\s*$/);
+    const heading: RegExpMatchArray | null = line.match(/^####\s+(.+?)\s*$/);
     if (heading) {
       scope = SCOPE_HEADINGS[heading[1].trim().toLowerCase()] ?? null;
       continue;
@@ -77,32 +89,74 @@ export function parseGlossary(readmeContent: string): Glossary {
 
     if (!scope || !line.trimStart().startsWith("|")) continue;
 
-    const cells = line.split("|").slice(1, -1).map((c) => c.trim());
-    if (cells.length < 3) continue;
+    // Strip the (optional) outer pipes, then split on unescaped `|`. This keeps
+    // a row that omits its trailing pipe, or embeds an escaped `\|` in the
+    // definition, from being silently truncated or dropped (#203 render↔data drift).
+    const inner: string = line.trim().replace(/^\|/, "").replace(/\|$/, "");
+    const cells: string[] = inner.split(/(?<!\\)\|/).map((c: string) => c.trim().replace(/\\\|/g, "|"));
     const [keyword, timingCell, definition] = cells;
-    // Skip the header row and the `|---|` separator.
-    if (keyword.toLowerCase() === "keyword" || /^-+$/.test(keyword)) continue;
 
-    const timingWord = (timingCell.match(/^([A-Za-z]+)/)?.[1] ?? "").toLowerCase() as KeywordTiming;
+    // Skip the header row and any alignment separator (`---`, `:--:`, `--:`).
+    if (
+      keyword.toLowerCase() === "keyword" ||
+      timingCell?.toLowerCase() === "timing" ||
+      /^:?-+:?$/.test(keyword)
+    ) {
+      continue;
+    }
+
+    // A real data row has all three columns. A content-bearing short row is
+    // malformed (throw, don't silently skip); a fully-empty one is ignorable.
+    if (cells.length < 3) {
+      if (cells.some((c: string) => c !== "")) {
+        throw new Error(`glossary: malformed table row "${line.trim()}" (expected 3 columns: Keyword | Timing | Definition)`);
+      }
+      continue;
+    }
+
+    const timingWord: KeywordTiming = (timingCell.match(/^([A-Za-z]+)/)?.[1] ?? "").toLowerCase() as KeywordTiming;
     if (!VALID_TIMINGS.includes(timingWord)) {
       throw new Error(`glossary: '${keyword}' has unrecognized timing "${timingCell}"`);
     }
-    const apCost = timingCell.match(/\((\d+)\s*AP\)/i)?.[1];
+    const apCost: string | undefined = timingCell.match(/\((\d+)\s*AP\)/i)?.[1];
+    // AP cost and Activated timing must agree — catches a `Static (2 AP)` typo,
+    // or an Activated row that forgot its `(N AP)`.
+    if (apCost !== undefined && timingWord !== "activated") {
+      throw new Error(`glossary: '${keyword}' has an AP cost but timing "${timingWord}" (only Activated keywords take AP)`);
+    }
+    if (timingWord === "activated" && apCost === undefined) {
+      throw new Error(`glossary: Activated keyword '${keyword}' is missing its "(N AP)" cost`);
+    }
 
+    const id: string = keyword.toLowerCase();
+    if (glossary[id]) {
+      throw new Error(`glossary: duplicate keyword '${keyword}'`);
+    }
     const def: KeywordDef = {
-      id: keyword.toLowerCase(),
+      id,
       name: keyword,
       scope,
       timing: timingWord,
+      // `valued` caches "does `reminder` contain the X placeholder" so consumers
+      // needn't re-run the regex; it must stay in sync with `reminder`.
       valued: VALUE_PLACEHOLDER.test(definition),
       reminder: definition,
     };
     if (apCost !== undefined) def.apCost = parseInt(apCost, 10);
-    glossary[def.id] = def;
+    glossary[id] = def;
+    scopesSeen.add(scope);
   }
 
   if (Object.keys(glossary).length === 0) {
     throw new Error("glossary: no keywords parsed from the '## Keyword System' tables");
+  }
+  // A renamed/typo'd `#### ... keywords` heading silently drops a whole scope
+  // while leaving the glossary non-empty, so the empty-guard above wouldn't fire.
+  // Require every scope to have contributed at least one keyword.
+  for (const s of VALID_SCOPES) {
+    if (!scopesSeen.has(s)) {
+      throw new Error(`glossary: no '${s}' keywords parsed — a '#### ... keywords' heading was renamed or its table is malformed`);
+    }
   }
   return glossary;
 }

--- a/library/schema.md
+++ b/library/schema.md
@@ -111,9 +111,9 @@ sign lives in the reminder text — `Radiated[2]` → "get **-2** …"). Only
 `Commander`, `Radiated`, and `Fortified` take a value today — they are the
 keywords whose glossary Definition contains an `X`. That standalone `X` is the
 marker the build reads to make a keyword value-bearing, so it must be preserved
-when editing a definition. (Note: the Keyword System intro in `rules/README.md`
-mentions "Shield X", but Shield's Definition row has no `X`, so the contract
-treats Shield as value-less until that row is updated.)
+when editing a definition. (Shield, though a variable-value keyword in concept,
+has no `X` in its Definition row, so the contract treats it as value-less until
+that row is updated.)
 
 **Glossary artifact.** `library/build.ts` derives a machine-readable glossary
 from the `rules/README.md` tables and writes `library/build/glossary.json`

--- a/library/schema.md
+++ b/library/schema.md
@@ -103,20 +103,26 @@ where a value is `[N]`:
 | Written | Meaning |
 |---------|---------|
 | `Lethal` | value-less keyword |
-| `Commander[3]` | keyword with value 3 (renders `COMMANDER 3`) |
+| `Commander[3]` | keyword with value 3 (magnitude 3) |
 | `Commander[3];Resolute` | two keywords |
 
 Keywords are Title-case matching the glossary; values are **magnitudes** (the
 sign lives in the reminder text — `Radiated[2]` → "get **-2** …"). Only
-`Commander`, `Radiated`, and `Fortified` take a value today (glossary definitions
-containing `X`).
+`Commander`, `Radiated`, and `Fortified` take a value today — they are the
+keywords whose glossary Definition contains an `X`. That standalone `X` is the
+marker the build reads to make a keyword value-bearing, so it must be preserved
+when editing a definition. (Note: the Keyword System intro in `rules/README.md`
+mentions "Shield X", but Shield's Definition row has no `X`, so the contract
+treats Shield as value-less until that row is updated.)
 
 **Glossary artifact.** `library/build.ts` derives a machine-readable glossary
 from the `rules/README.md` tables and writes `library/build/glossary.json`
 (keyword `id → {name, scope, timing, apCost?, valued, reminder}`). `rules/README.md`
-stays the human-authored source; the artifact is the render↔data contract that
-`design/compose-cards.py` (keyword pills + reminder text) and, eventually, the
-engine consume. See #203.
+stays the human-authored source. Today the build itself is the only consumer of
+the artifact; the Penpot renderer (`design/moderntrek-template.py`) and,
+eventually, the engine are meant to migrate onto it for keyword pills + reminder
+text (both still re-parse the prose for now, and the renderer still expects the
+space-separated `Commander 3` form rather than `Commander[3]`). See #203.
 
 The build validates the ability **value syntax** and value-arity for known
 keywords (a valued keyword must carry `[N]`; a value-less one must not). Whether

--- a/library/schema.md
+++ b/library/schema.md
@@ -16,7 +16,7 @@ Every card type includes these columns:
 | cost     | string | yes      | Gold cost to deploy/play. Multiple costs separated by `\|` (player pays one) |
 | text     | string | no       | Card text — rules text, abilities, effects |
 | flavor   | string | no       | Flavor text |
-| abilities  | string | no     | Semicolon-separated mechanical keyword-effects (e.g. `Lethal;Taunt`). Things the card *does*. These are what the rules call **Keywords** (see the Keyword Glossary in `rules/README.md` / `rules/attributes.md`) — the column was named `abilities` in #119 to disambiguate from the thematic `keywords` that moved to `attributes`. Free-text: not vocabulary-validated. |
+| abilities  | string | no     | Semicolon-separated mechanical keywords, `Keyword` or `Keyword[N]` (e.g. `Lethal;Commander[3]`). Things the card *does*. These are what the rules call **Keywords** (see the Keyword Glossary in `rules/README.md`) — the column was named `abilities` in #119 to disambiguate from the thematic `keywords` that moved to `attributes`. Value syntax + the generated glossary artifact are documented under [Keyword abilities](#keyword-abilities). |
 | attributes | string | no     | Semicolon-separated cross-type synergy labels (e.g. `Knowledge;Engineering`). Governed closed set — see [Governed vocabularies](#governed-vocabularies). |
 
 ## Units
@@ -91,8 +91,38 @@ on any unknown value (exact spelling, case-sensitive).
 `attributes` is the *cross-type* axis — the same value means the same thing on
 any card type. The three `*_type` columns are the *per-type* category
 axis (a card's own kind within its type) — mostly flavor today; governing them
-and wiring them into mechanics is tracked post-v0.1 in #160. `abilities` is not
-vocabulary-validated (freeform mechanical keyword-effects).
+and wiring them into mechanics is tracked post-v0.1 in #160.
+
+## Keyword abilities
+
+The `abilities` column is a `;`-separated list of **mechanical keywords** drawn
+from the Keyword Glossary in [`rules/README.md`](../rules/README.md) (`## Keyword
+System`). Each token is shaped like the effect-DSL `token` rule — `ident value?`,
+where a value is `[N]`:
+
+| Written | Meaning |
+|---------|---------|
+| `Lethal` | value-less keyword |
+| `Commander[3]` | keyword with value 3 (renders `COMMANDER 3`) |
+| `Commander[3];Resolute` | two keywords |
+
+Keywords are Title-case matching the glossary; values are **magnitudes** (the
+sign lives in the reminder text — `Radiated[2]` → "get **-2** …"). Only
+`Commander`, `Radiated`, and `Fortified` take a value today (glossary definitions
+containing `X`).
+
+**Glossary artifact.** `library/build.ts` derives a machine-readable glossary
+from the `rules/README.md` tables and writes `library/build/glossary.json`
+(keyword `id → {name, scope, timing, apCost?, valued, reminder}`). `rules/README.md`
+stays the human-authored source; the artifact is the render↔data contract that
+`design/compose-cards.py` (keyword pills + reminder text) and, eventually, the
+engine consume. See #203.
+
+The build validates the ability **value syntax** and value-arity for known
+keywords (a valued keyword must carry `[N]`; a value-less one must not). Whether
+*unknown* keywords are rejected (full governance of the `abilities` vocabulary)
+is deferred to #194 — until then an unlisted keyword is allowed and simply
+won't resolve to glossary reminder text.
 
 ## Requirement Checks
 

--- a/library/schema.md
+++ b/library/schema.md
@@ -118,11 +118,11 @@ treats Shield as value-less until that row is updated.)
 **Glossary artifact.** `library/build.ts` derives a machine-readable glossary
 from the `rules/README.md` tables and writes `library/build/glossary.json`
 (keyword `id → {name, scope, timing, apCost?, valued, reminder}`). `rules/README.md`
-stays the human-authored source. Today the build itself is the only consumer of
-the artifact; the Penpot renderer (`design/moderntrek-template.py`) and,
-eventually, the engine are meant to migrate onto it for keyword pills + reminder
-text (both still re-parse the prose for now, and the renderer still expects the
-space-separated `Commander 3` form rather than `Commander[3]`). See #203.
+stays the human-authored source. The build and the Penpot renderer
+(`design/moderntrek-template.py`, keyword pills + reminder text) both consume the
+artifact; the engine is expected to migrate onto it too. Because it's a build
+output, run `bun library/build.ts` before rendering so the renderer picks up any
+glossary changes. See #203.
 
 The build validates the ability **value syntax** and value-arity for known
 keywords (a valued keyword must carry `[N]`; a value-less one must not). Whether

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:library": "bun library/build.ts",
     "build:rules": "bun engine/src/rules-config.ts",
     "test": "bun run build:library && bun --filter '*' test",
+    "test:renderer": "python3 design/test_moderntrek_template.py",
     "typecheck": "bun --filter '*' typecheck"
   },
   "devDependencies": {

--- a/rules/README.md
+++ b/rules/README.md
@@ -472,7 +472,7 @@ more expensive or powerful than a legendary.
 
 Keywords are shorthand abilities referenced by name (bolded text or
 icons) on cards. Each keyword has a fixed definition in the glossary
-below. Some keywords have variable values (e.g. Shield X) where X
+below. Some keywords have variable values (e.g. Commander X) where X
 differs per card.
 
 ### Timing

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { readFileSync } from "fs";
 import { join } from "path";
 import {
@@ -220,6 +220,56 @@ describe("keyword glossary — parseGlossary (synthetic + throw guards)", () => 
     const g = parseGlossary(keywordSystem(body));
     expect(g.notrail).toMatchObject({ scope: "unit", timing: "static" });
   });
+
+  test("keeps an escaped pipe in the definition (not a column break)", () => {
+    const body = FULL.replace(
+      "| Lethal | Static | The loser is killed instead of injured |",
+      "| Split | Static | Deal +X to left \\| right |",
+    );
+    const g = parseGlossary(keywordSystem(body));
+    expect(g.split.reminder).toBe("Deal +X to left | right");
+  });
+
+  test("throws on an unescaped pipe that over-splits the definition", () => {
+    const body = FULL.replace(
+      "| Lethal | Static | The loser is killed instead of injured |",
+      "| Split | Static | gain A | B extra |",
+    );
+    expect(() => parseGlossary(keywordSystem(body))).toThrow(/malformed table row/);
+  });
+
+  test("throws on an unrecognized `#### ... keywords` scope heading", () => {
+    const body = FULL + "\n#### Structure keywords\n| Keyword | Timing | Definition |\n|---|---|---|\n| Wall | Static | Blocks |\n";
+    expect(() => parseGlossary(keywordSystem(body))).toThrow(/unrecognized keyword-scope heading/);
+  });
+
+  test("ignores a fully-empty table row without dropping its neighbours", () => {
+    const body = FULL.replace(
+      "| Commander | Static | Friendly units get +X to all stats |",
+      "| Commander | Static | Friendly units get +X to all stats |\n|   |   |   |",
+    );
+    const g = parseGlossary(keywordSystem(body));
+    expect(g.commander).toBeDefined();
+    expect(Object.keys(g)).toContain("lethal");
+  });
+
+  test("skips a stray header-like row keyed on the Timing column", () => {
+    // keyword col is NOT "Keyword" but timing col is "Timing" — must be skipped.
+    const body = FULL.replace(
+      "| Commander | Static | Friendly units get +X to all stats |",
+      "| Name | Timing | Meaning |\n| Commander | Static | Friendly units get +X to all stats |",
+    );
+    const g = parseGlossary(keywordSystem(body));
+    expect(g.name).toBeUndefined();
+    expect(g.commander).toBeDefined();
+  });
+
+  test("anchors on the real heading despite an inline mention or a plural heading", () => {
+    const noise = "Earlier prose that says ## Keyword System inline.\n\n## Keyword Systems (overview)\n\nBlah.\n";
+    const g = parseGlossary(`# Rules\n\n${noise}\n${keywordSystem(FULL)}`);
+    expect(g.commander).toBeDefined();
+    expect(Object.keys(g).length).toBe(5);
+  });
 });
 
 describe("keyword glossary — parseGlossary", () => {
@@ -245,9 +295,27 @@ describe("keyword glossary — parseGlossary", () => {
     expect(g.commander.reminder).toBe("Friendly units get +X to all stats");
   });
 
-  test("skips header/separator rows and parses all 13 live keywords", () => {
+  test("skips header and separator rows (no scaffolding entries)", () => {
     expect(GLOSSARY.keyword).toBeUndefined();
+  });
+
+  // Canary on the live rules content: bump this when a keyword is added to
+  // rules/README.md's Keyword System tables.
+  test("parses every keyword currently in the rules glossary (count canary)", () => {
     expect(Object.keys(GLOSSARY).length).toBe(13);
+  });
+
+  test("emits the exact field shape the Python renderer reads (JSON contract)", () => {
+    // design/moderntrek-template.py reads entry.name/reminder/scope/timing/valued
+    // and joins on the lowercased id key. Pin those field names so a rename fails
+    // here, not silently in the renderer.
+    const roundTripped = JSON.parse(JSON.stringify(GLOSSARY));
+    const entry = roundTripped.commander;
+    expect(Object.keys(entry).sort()).toEqual(["id", "name", "reminder", "scope", "timing", "valued"]);
+    expect(entry.id).toBe("commander"); // top-level key === lowercased id
+    expect(typeof entry.name).toBe("string");
+    expect(typeof entry.reminder).toBe("string");
+    expect(typeof entry.valued).toBe("boolean");
   });
 });
 
@@ -299,7 +367,28 @@ describe("build validation — ability value syntax (#203)", () => {
   });
 
   test("allows an unknown keyword (governance deferred to #194)", () => {
-    expect(checkAbilities("Mystery")).toEqual([]);
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(checkAbilities("Mystery")).toEqual([]);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test("warns (not errors) on an unknown keyword so a typo of a known one is visible", () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      // A fat-fingered known keyword: no glossary entry, so it warns and skips.
+      expect(checkAbilities("Commmander[3]")).toEqual([]);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toContain("Commmander");
+      // A correctly-spelled known keyword must NOT warn.
+      warn.mockClear();
+      checkAbilities("Commander[3]");
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   test("rejects a mis-cased keyword (Title-case must match the glossary)", () => {

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -115,9 +115,117 @@ describe("build validation — cost is a numeric gold amount", () => {
 // checks — while confirming governance of *unknown* keywords stays deferred.
 // ---------------------------------------------------------------------------
 
+// Synthetic `rules/README.md` fixtures — exercise parseGlossary's logic and its
+// throw guards independently of the live rules content (#203).
+function keywordSystem(body: string): string {
+  return `# Rules\n\n## Keyword System\n\n### Keyword Glossary\n${body}\n\n## Economy\n`;
+}
+
+const UNIT_TABLE: string = [
+  "#### Unit keywords",
+  "| Keyword | Timing | Definition |",
+  "|---------|--------|------------|",
+  "| Commander | Static | Friendly units get +X to all stats |",
+  "| Lethal | Static | The loser is killed instead of injured |",
+  "| Heal | Activated (1 AP) | Remove the injured status |",
+].join("\n");
+const EQUIP_TABLE: string = [
+  "#### Equipment keywords",
+  "| Keyword | Timing | Definition |",
+  "|---------|--------|------------|",
+  "| Flying | Static | Ignores blocked edges |",
+].join("\n");
+const LOCATION_TABLE: string = [
+  "#### Location keywords",
+  "| Keyword | Timing | Definition |",
+  "|---------|--------|------------|",
+  "| Radiated | Static | Units get -X to all stats |",
+].join("\n");
+// A minimal well-formed section covering all three required scopes.
+const FULL: string = `\n${UNIT_TABLE}\n\n${EQUIP_TABLE}\n\n${LOCATION_TABLE}\n`;
+
+describe("keyword glossary — parseGlossary (synthetic + throw guards)", () => {
+  test("parses a well-formed synthetic section", () => {
+    const g = parseGlossary(keywordSystem(FULL));
+    expect(g.commander).toMatchObject({ scope: "unit", timing: "static", valued: true });
+    expect(g.heal).toMatchObject({ timing: "activated", apCost: 1 });
+    expect(g.flying.scope).toBe("equipment");
+    expect(g.radiated.scope).toBe("location");
+  });
+
+  test("throws when the `## Keyword System` section is missing", () => {
+    expect(() => parseGlossary("# Rules\n\nNothing here.\n")).toThrow(/Keyword System/);
+  });
+
+  test("throws on an unrecognized timing", () => {
+    const bad = FULL.replace("| Lethal | Static |", "| Lethal | Bogus |");
+    expect(() => parseGlossary(keywordSystem(bad))).toThrow(/unrecognized timing/);
+  });
+
+  test("throws when no keywords parse (heading present, no rows)", () => {
+    const empty = "\n#### Unit keywords\n| Keyword | Timing | Definition |\n|---|---|---|\n";
+    expect(() => parseGlossary(keywordSystem(empty))).toThrow(/no keywords parsed/);
+  });
+
+  test("throws when a whole scope's heading is renamed (partial corruption)", () => {
+    const renamed = FULL.replace("#### Location keywords", "#### Location Keywords (core)");
+    expect(() => parseGlossary(keywordSystem(renamed))).toThrow(/no 'location' keywords/);
+  });
+
+  test("throws on a duplicate keyword", () => {
+    const dup = FULL.replace(
+      "| Lethal | Static | The loser is killed instead of injured |",
+      "| Lethal | Static | The loser is killed instead of injured |\n| Commander | Static | Duplicate |",
+    );
+    expect(() => parseGlossary(keywordSystem(dup))).toThrow(/duplicate keyword/);
+  });
+
+  test("throws on a content-bearing malformed row", () => {
+    const short = FULL.replace(
+      "| Lethal | Static | The loser is killed instead of injured |",
+      "| Lonely |",
+    );
+    expect(() => parseGlossary(keywordSystem(short))).toThrow(/malformed table row/);
+  });
+
+  test("throws when AP cost and timing disagree", () => {
+    const apStatic = FULL.replace("| Commander | Static |", "| Commander | Static (2 AP) |");
+    expect(() => parseGlossary(keywordSystem(apStatic))).toThrow(/AP cost but timing/);
+    const noAp = FULL.replace("| Heal | Activated (1 AP) |", "| Heal | Activated |");
+    expect(() => parseGlossary(keywordSystem(noAp))).toThrow(/missing its "\(N AP\)"/);
+  });
+
+  test("infers valued from a standalone X, not an X inside a word", () => {
+    const body = FULL.replace(
+      "| Lethal | Static | The loser is killed instead of injured |",
+      "| Boost | Static | Gain +X power |\n| Taxman | Static | Costs MAX gold |",
+    );
+    const g = parseGlossary(keywordSystem(body));
+    expect(g.boost.valued).toBe(true); // standalone +X
+    expect(g.taxman.valued).toBe(false); // X only inside MAX
+  });
+
+  test("tolerates a missing trailing pipe and markdown alignment separators", () => {
+    const body = [
+      "",
+      "#### Unit keywords",
+      "| Keyword | Timing | Definition |",
+      "|:--------|:------:|--------:|", // alignment colons
+      "| NoTrail | Static | Works without a trailing pipe", // no trailing |
+      "",
+      EQUIP_TABLE,
+      "",
+      LOCATION_TABLE,
+    ].join("\n");
+    const g = parseGlossary(keywordSystem(body));
+    expect(g.notrail).toMatchObject({ scope: "unit", timing: "static" });
+  });
+});
+
 describe("keyword glossary — parseGlossary", () => {
   test("parses timing, scope, and apCost", () => {
     expect(GLOSSARY.commander).toMatchObject({ name: "Commander", scope: "unit", timing: "static" });
+    expect(GLOSSARY.commander.apCost).toBeUndefined();
     expect(GLOSSARY.heal).toMatchObject({ timing: "activated", apCost: 1 });
     expect(GLOSSARY.flying.scope).toBe("equipment");
     expect(GLOSSARY.radiated.scope).toBe("location");
@@ -132,8 +240,14 @@ describe("keyword glossary — parseGlossary", () => {
     expect(GLOSSARY.taunt.valued).toBe(false);
   });
 
-  test("keeps the X placeholder in the reminder template", () => {
-    expect(GLOSSARY.commander.reminder).toContain("+X");
+  test("keeps the definition verbatim as the reminder (incl. its X)", () => {
+    const g = parseGlossary(keywordSystem(FULL));
+    expect(g.commander.reminder).toBe("Friendly units get +X to all stats");
+  });
+
+  test("skips header/separator rows and parses all 13 live keywords", () => {
+    expect(GLOSSARY.keyword).toBeUndefined();
+    expect(Object.keys(GLOSSARY).length).toBe(13);
   });
 });
 
@@ -146,6 +260,18 @@ describe("parseAbilityToken", () => {
   test("returns null on malformed tokens", () => {
     expect(parseAbilityToken("Bogus{x}")).toBeNull();
     expect(parseAbilityToken("Commander(3)")).toBeNull();
+  });
+
+  test("trims surrounding whitespace and parses multi-digit values", () => {
+    expect(parseAbilityToken(" Commander[10] ")).toEqual({ id: "commander", name: "Commander", value: 10 });
+  });
+
+  test("allows a hyphenated ident", () => {
+    expect(parseAbilityToken("Some-Word")).toEqual({ id: "some-word", name: "Some-Word", value: null });
+  });
+
+  test("parses [0] at the token level (arity/positivity is validate()'s call)", () => {
+    expect(parseAbilityToken("Commander[0]")).toEqual({ id: "commander", name: "Commander", value: 0 });
   });
 });
 
@@ -174,6 +300,25 @@ describe("build validation — ability value syntax (#203)", () => {
 
   test("allows an unknown keyword (governance deferred to #194)", () => {
     expect(checkAbilities("Mystery")).toEqual([]);
+  });
+
+  test("rejects a mis-cased keyword (Title-case must match the glossary)", () => {
+    expect(checkAbilities("commander[3]").some((e) => e.message.includes('must be written "Commander"'))).toBe(true);
+  });
+
+  test("rejects a zero magnitude on a valued keyword", () => {
+    expect(checkAbilities("Commander[0]").some((e) => e.message.includes("positive magnitude"))).toBe(true);
+  });
+
+  test("reports each token independently in a multi-keyword field", () => {
+    // One malformed + one valid → exactly the malformed one flagged.
+    const mixed = checkAbilities("Bogus{x};Commander[3]");
+    expect(mixed).toHaveLength(1);
+    expect(mixed[0].message).toContain("malformed");
+    // Two distinct arity errors in one field both surface.
+    const both = checkAbilities("Commander;Lethal[2]");
+    expect(both.some((e) => e.message.includes("requires a value"))).toBe(true);
+    expect(both.some((e) => e.message.includes("does not take a value"))).toBe(true);
   });
 
   test("skips ability validation when no glossary is supplied", () => {

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
 import {
   transformCard,
   validate,
   type CardType,
 } from "../library/build";
+import { parseGlossary, parseAbilityToken } from "../library/glossary";
+
+const GLOSSARY = parseGlossary(readFileSync(join(import.meta.dir, "../rules/README.md"), "utf-8"));
 
 // ---------------------------------------------------------------------------
 // Build-time governed-vocabulary validation (#119)
@@ -98,5 +103,82 @@ describe("build validation — cost is a numeric gold amount", () => {
   test("rejects when any alternative-cost option is non-numeric", () => {
     const errors = check("units", { cost: "4|X", attributes: "Military" });
     expect(errors.some((e) => e.field === "cost")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Keyword glossary — the render↔data contract (#203)
+//
+// `parseGlossary` derives the machine-readable glossary from rules/README.md;
+// `validate` uses it to check ability value-syntax. These pin the derivation
+// (a rules refactor that breaks the tables fails here) and the render-accuracy
+// checks — while confirming governance of *unknown* keywords stays deferred.
+// ---------------------------------------------------------------------------
+
+describe("keyword glossary — parseGlossary", () => {
+  test("parses timing, scope, and apCost", () => {
+    expect(GLOSSARY.commander).toMatchObject({ name: "Commander", scope: "unit", timing: "static" });
+    expect(GLOSSARY.heal).toMatchObject({ timing: "activated", apCost: 1 });
+    expect(GLOSSARY.flying.scope).toBe("equipment");
+    expect(GLOSSARY.radiated.scope).toBe("location");
+  });
+
+  test("infers valued-ness from an X placeholder in the definition", () => {
+    // Only the +X / -X keywords take a value.
+    expect(GLOSSARY.commander.valued).toBe(true);
+    expect(GLOSSARY.radiated.valued).toBe(true);
+    expect(GLOSSARY.fortified.valued).toBe(true);
+    expect(GLOSSARY.lethal.valued).toBe(false);
+    expect(GLOSSARY.taunt.valued).toBe(false);
+  });
+
+  test("keeps the X placeholder in the reminder template", () => {
+    expect(GLOSSARY.commander.reminder).toContain("+X");
+  });
+});
+
+describe("parseAbilityToken", () => {
+  test("parses value-less and valued tokens", () => {
+    expect(parseAbilityToken("Lethal")).toEqual({ id: "lethal", name: "Lethal", value: null });
+    expect(parseAbilityToken("Commander[3]")).toEqual({ id: "commander", name: "Commander", value: 3 });
+  });
+
+  test("returns null on malformed tokens", () => {
+    expect(parseAbilityToken("Bogus{x}")).toBeNull();
+    expect(parseAbilityToken("Commander(3)")).toBeNull();
+  });
+});
+
+describe("build validation — ability value syntax (#203)", () => {
+  /** transformCard + validate WITH the glossary, returning ability errors. */
+  function checkAbilities(abilities: string) {
+    return validate("units", transformCard("units", row({ abilities })), GLOSSARY)
+      .filter((e) => e.field === "abilities");
+  }
+
+  test("accepts correct arity", () => {
+    expect(checkAbilities("Commander[3];Lethal")).toEqual([]);
+  });
+
+  test("rejects a valued keyword with no value", () => {
+    expect(checkAbilities("Commander").some((e) => e.message.includes("requires a value"))).toBe(true);
+  });
+
+  test("rejects a value-less keyword given a value", () => {
+    expect(checkAbilities("Lethal[2]").some((e) => e.message.includes("does not take a value"))).toBe(true);
+  });
+
+  test("rejects a malformed token", () => {
+    expect(checkAbilities("Bogus{x}").some((e) => e.message.includes("malformed"))).toBe(true);
+  });
+
+  test("allows an unknown keyword (governance deferred to #194)", () => {
+    expect(checkAbilities("Mystery")).toEqual([]);
+  });
+
+  test("skips ability validation when no glossary is supplied", () => {
+    // The 2-arg form (used elsewhere) must not touch abilities.
+    expect(validate("units", transformCard("units", row({ abilities: "Commander" })))
+      .some((e) => e.field === "abilities")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Establishes the **render↔keyword data contract** — the machine-readable glossary and value syntax the renderer needs to render keyword-effects accurately, wires the renderer onto it, and adds CI to guard it. Distinct from #194's keyword *scope* decision; scoped to render-accuracy.

## Deliverable 1 — keyword value syntax: `Keyword[N]`

Valued keywords in the `abilities` column use square-bracket values, **matching the effect-DSL `token` grammar** (`ident value?`, `value = "[" int "]"` — e.g. `draw[2]`):

```
abilities:  Commander[3];Lethal
```

One value convention across actions *and* keywords, so the engine can reuse its existing tokenizer. Values are **magnitudes** (the sign lives in the reminder text); keywords are Title-case matching the glossary; value-less keywords are a bare ident.

## Deliverable 2 — machine-readable glossary artifact

- **`library/glossary.ts`** — derives a structured glossary from `rules/README.md`'s `## Keyword System` tables (`id → {name, scope, timing, apCost?, valued, reminder}`). `valued` is inferred from a standalone `X`; `apCost` from `Activated (N AP)`. Also parses `abilities` tokens.
- **`library/build.ts`** — emits `build/glossary.json` (gitignored) and validates ability **value-syntax, arity, canonical Title-case, and positive magnitudes** for known keywords.
- The parser **fails loud** on structural corruption: missing/empty section, unrecognized timing, duplicate keywords, malformed rows (too few *or too many* columns — an unescaped `|` is an error), AP/timing mismatch, a renamed scope heading, or an unrecognized `#### … keywords` heading. `rules/README.md` stays the human-authored source.

## Deliverable 3 — renderer consumes the artifact

- **`design/moderntrek-template.py`** — `parse_glossary()` **loads `build/glossary.json`** (no longer re-parses prose) and `keyword_reminder()` parses the `Keyword[N]` token, rendering the pill label `COMMANDER 3` and substituting the value into the glossary's `X` placeholder.
- Robust degradation: a missing / unreadable / **wrong-shape** / stale artifact, an unknown keyword, a malformed token, or an arity mismatch all degrade to a blank reminder with a warning — never a crash or a literal `X`.

## Deliverable 4 — CI

- **`.github/workflows/ci.yml`** — on PRs + pushes to `main`: `bun install --frozen-lockfile` → typecheck (all workspaces) → `bun run test` → `bun run test:renderer`. Guards the contract against silent drift (field renames, dropped rows, TS↔Python `ABILITY_TOKEN` divergence). Free on this public repo.

### Scope boundary — render-accuracy vs governance
The build flags malformed tokens, value-arity, casing, and non-positive magnitudes for **known** keywords. Whether **unknown** keywords are *rejected* (full governance) is deferred to **#194** — until then an unlisted keyword is allowed (warned, not failed) and won't resolve to reminder text.

## Hardening — two local `/review-pr` passes

Two multi-agent review rounds (round 1 on the initial commits, round 2 on the migration) surfaced 51 findings; all applied. Highlights: the loud-fail parser guards above; the renderer shape-guarding + arity degradation; corrected docs; and the cross-language JSON-shape contract now pinned by a test.

## Out of scope (follow-ups)
- **Engine adoption of `build/glossary.json`** — the remaining consumer expected to migrate onto the artifact.
- **Structured `warnings[]` channel** in `validate()` (unknown-keyword notices are `console.warn` today; testability is covered by a `spyOn` test).
- Applying the in-scope keyword set to cards → **#194**.

## Docs & tests
- `library/schema.md` — "Keyword abilities" section (value syntax + artifact contract + the #203/#194 boundary).
- `test/build.test.ts` — parseGlossary throw-guards, token edge cases, ability-syntax validation, escaped/unescaped-pipe handling, the build↔renderer JSON-shape contract, and a `spyOn` assertion on the unknown-keyword warning.
- `design/test_moderntrek_template.py` (+ `test:renderer` script) — first renderer tests: degradation paths + bracket parsing.
- Full suite green (**engine 656 / web 93 / test 65**, renderer smoke **21/21**); typecheck clean across all workspaces.

Closes #203