### PR TITLE
213: build.ts: structured warnings[] channel for unknown keywords

### DIFF
--- a/library/build.ts
+++ b/library/build.ts
@@ -188,6 +188,13 @@ export function transformCard(type: CardType, raw: Record<string, string>): Reco
 
 export type ValidationError = { card: string; field: string; message: string };
 
+// Non-failing build notices (e.g. a missing per-type CSV). Structured like
+// `ValidationError` so the summary printer renders both uniformly and callers
+// can assert on them via the return value — but warnings never fail the build.
+// Governance that *should* fail (unknown keyword/attribute, bad DSL) lives in
+// `validate()`'s `errors[]` instead. See #213.
+export type BuildWarning = { card: string; field: string; message: string };
+
 export function validate(
   type: CardType,
   card: Record<string, unknown>,
@@ -290,15 +297,23 @@ export function validate(
 
 // --- Main ---
 
-function buildSet(setName: string): { cards: Record<string, unknown>[]; errors: ValidationError[] } {
-  const setDir = join(SETS_DIR, setName);
+export function buildSet(setName: string, setsDir: string = SETS_DIR): {
+  cards: Record<string, unknown>[];
+  errors: ValidationError[];
+  warnings: BuildWarning[];
+} {
+  const setDir = join(setsDir, setName);
   const cards: Record<string, unknown>[] = [];
   const errors: ValidationError[] = [];
+  const warnings: BuildWarning[] = [];
 
   for (const type of CARD_TYPES) {
     const csvPath = join(setDir, `${type}.csv`);
     if (!existsSync(csvPath)) {
-      console.warn(`  Warning: ${type}.csv not found in ${setName}, skipping`);
+      // Non-failing: a set may legitimately omit a card type. Surfaced as a
+      // structured warning (not `console.warn`) so it lands in the summary and
+      // is assertable via the return value.
+      warnings.push({ card: setName, field: type, message: `${type}.csv not found, skipping` });
       continue;
     }
 
@@ -312,7 +327,7 @@ function buildSet(setName: string): { cards: Record<string, unknown>[]; errors: 
     }
   }
 
-  return { cards, errors };
+  return { cards, errors, warnings };
 }
 
 function main() {
@@ -328,16 +343,18 @@ function main() {
 
   let allCards: Record<string, unknown>[] = [];
   let totalErrors: ValidationError[] = [];
+  let totalWarnings: BuildWarning[] = [];
 
   for (const setName of sets) {
     console.log(`Building set: ${setName}`);
-    const { cards, errors } = buildSet(setName);
+    const { cards, errors, warnings } = buildSet(setName);
 
     writeFileSync(join(BUILD_DIR, `${setName}.json`), JSON.stringify(cards, null, 2));
     console.log(`  ${cards.length} cards`);
 
     allCards = allCards.concat(cards);
     totalErrors = totalErrors.concat(errors);
+    totalWarnings = totalWarnings.concat(warnings);
   }
 
   // Write merged output
@@ -354,7 +371,13 @@ function main() {
     ),
   );
 
-  // Report
+  // Report — warnings first (non-failing), then errors (which fail the build).
+  if (totalWarnings.length > 0) {
+    console.warn(`\n${totalWarnings.length} warning(s):`);
+    for (const w of totalWarnings) {
+      console.warn(`  [${w.card}] ${w.field}: ${w.message}`);
+    }
+  }
   if (totalErrors.length > 0) {
     console.error(`\n${totalErrors.length} validation error(s):`);
     for (const e of totalErrors) {

--- a/library/build.ts
+++ b/library/build.ts
@@ -22,8 +22,11 @@ import {
 } from "../engine/src/card-categories";
 
 const LIBRARY_DIR = join(import.meta.dir);
-const SETS_DIR = join(LIBRARY_DIR, "sets");
-const BUILD_DIR = join(LIBRARY_DIR, "build");
+// `CARDS_SETS_DIR` / `CARDS_BUILD_DIR` override the input/output roots so a test
+// can drive `main()` against a temp fixture without touching `library/`. Default
+// to the real locations.
+const SETS_DIR = process.env.CARDS_SETS_DIR ?? join(LIBRARY_DIR, "sets");
+const BUILD_DIR = process.env.CARDS_BUILD_DIR ?? join(LIBRARY_DIR, "build");
 
 const CARD_TYPES = ["units", "locations", "items", "events", "policies"] as const;
 export type CardType = (typeof CARD_TYPES)[number];
@@ -186,14 +189,25 @@ export function transformCard(type: CardType, raw: Record<string, string>): Reco
 
 // --- Validation ---
 
-export type ValidationError = { card: string; field: string; message: string };
+// A build notice: a card/field-addressed message. The `severity` discriminant
+// keeps the two channels non-interchangeable — a failing `ValidationError`
+// cannot be silently routed into the non-failing `BuildWarning` list — while
+// still letting one `printNotice` render both with the same line format.
+type BuildNotice = {
+  readonly card: string;
+  readonly field: string;
+  readonly message: string;
+};
 
-// Non-failing build notices (e.g. a missing per-type CSV). Structured like
-// `ValidationError` so the summary printer renders both uniformly and callers
-// can assert on them via the return value — but warnings never fail the build.
-// Governance that *should* fail (unknown keyword/attribute, bad DSL) lives in
-// `validate()`'s `errors[]` instead. See #213.
-export type BuildWarning = { card: string; field: string; message: string };
+// Governance that *should* fail the build: unknown keyword/attribute, bad DSL,
+// a missing/typo'd set, etc. Produced by `validate()` and `buildSet()`.
+export type ValidationError = BuildNotice & { readonly severity: "error" };
+
+// Non-failing notices that never affect the exit code — currently only a set
+// legitimately omitting a per-type CSV (see `buildSet`). Returned via
+// `buildSet().warnings` (not `console.warn`) so they land in the summary and are
+// assertable via the return value. See #213.
+export type BuildWarning = BuildNotice & { readonly severity: "warning" };
 
 export function validate(
   type: CardType,
@@ -201,12 +215,18 @@ export function validate(
 ): ValidationError[] {
   const errors: ValidationError[] = [];
   const id = (card.id as string) || "unknown";
+  const err = (field: string, message: string): ValidationError => ({
+    card: id,
+    field,
+    message,
+    severity: "error",
+  });
 
-  if (!card.id) errors.push({ card: id, field: "id", message: "missing id" });
-  if (!card.name) errors.push({ card: id, field: "name", message: "missing name" });
-  if (!card.set) errors.push({ card: id, field: "set", message: "missing set" });
+  if (!card.id) errors.push(err("id", "missing id"));
+  if (!card.name) errors.push(err("name", "missing name"));
+  if (!card.set) errors.push(err("set", "missing set"));
   if (!RARITIES.includes(card.rarity as any)) {
-    errors.push({ card: id, field: "rarity", message: `invalid rarity: ${card.rarity}` });
+    errors.push(err("rarity", `invalid rarity: ${card.rarity}`));
   }
 
   // Cost is a required gold amount (or `|`-separated alternatives, stored as a
@@ -216,12 +236,12 @@ export function validate(
   const costs = Array.isArray(card.cost) ? card.cost : [card.cost];
   for (const c of costs) {
     if (!/^\d+$/.test(String(c ?? "").trim())) {
-      errors.push({ card: id, field: "cost", message: `invalid cost: ${JSON.stringify(card.cost)}` });
+      errors.push(err("cost", `invalid cost: ${JSON.stringify(card.cost)}`));
     }
   }
 
   if (type === "events" && !EVENT_TIMINGS.includes(card.timing as any)) {
-    errors.push({ card: id, field: "timing", message: `invalid timing: ${card.timing}` });
+    errors.push(err("timing", `invalid timing: ${card.timing}`));
   }
 
   // Cross-type attribute vocabulary — exact CamelCase membership in the governed
@@ -230,7 +250,7 @@ export function validate(
   const attributes = (card.attributes as string[] | undefined) ?? [];
   for (const attr of attributes) {
     if (!ATTRIBUTES.includes(attr as (typeof ATTRIBUTES)[number])) {
-      errors.push({ card: id, field: "attributes", message: `invalid attribute: ${attr}` });
+      errors.push(err("attributes", `invalid attribute: ${attr}`));
     }
   }
 
@@ -247,7 +267,7 @@ export function validate(
       // engine fault in parseKeyword — propagate with its stack rather than
       // mislabel it as this card's validation error.
       if (!(e instanceof KeywordError)) throw e;
-      errors.push({ card: id, field: "keywords", message: e.message });
+      errors.push(err("keywords", e.message));
     }
   }
 
@@ -256,16 +276,16 @@ export function validate(
   // `location_type`/`event_type`/`type` (reflected in the error `field`).
   const locationType = card.locationType as (typeof LOCATION_TYPES)[number] | undefined;
   if (type === "locations" && locationType && !LOCATION_TYPES.includes(locationType)) {
-    errors.push({ card: id, field: "location_type", message: `invalid location_type: ${locationType}` });
+    errors.push(err("location_type", `invalid location_type: ${locationType}`));
   }
   const eventType = card.eventType as (typeof EVENT_TYPES)[number] | undefined;
   if (type === "events" && eventType && !EVENT_TYPES.includes(eventType)) {
-    errors.push({ card: id, field: "event_type", message: `invalid event_type: ${eventType}` });
+    errors.push(err("event_type", `invalid event_type: ${eventType}`));
   }
   if (type === "items") {
     for (const t of (card.itemType as string[] | undefined) ?? []) {
       if (!ITEM_TYPES.includes(t as (typeof ITEM_TYPES)[number])) {
-        errors.push({ card: id, field: "type", message: `invalid item type: ${t}` });
+        errors.push(err("type", `invalid item type: ${t}`));
       }
     }
   }
@@ -279,7 +299,7 @@ export function validate(
         parseDSL(action.effect);
       } catch (e) {
         const msg = (e instanceof DSLParseError || e instanceof DSLValidationError) ? e.message : String(e);
-        errors.push({ card: id, field: "actions", message: `invalid DSL in action "${action.name}": ${msg}` });
+        errors.push(err("actions", `invalid DSL in action "${action.name}": ${msg}`));
       }
     }
   }
@@ -288,7 +308,7 @@ export function validate(
       parseDSL(card.effect as string);
     } catch (e) {
       const msg = (e instanceof DSLParseError || e instanceof DSLValidationError) ? e.message : String(e);
-      errors.push({ card: id, field: "effect", message: `invalid DSL: ${msg}` });
+      errors.push(err("effect", `invalid DSL: ${msg}`));
     }
   }
 
@@ -297,23 +317,33 @@ export function validate(
 
 // --- Main ---
 
+// Builds one set. Returns `warnings` alongside `errors`; unlike the old
+// in-function `console.warn`, warnings are only visible if the caller surfaces
+// them (see `main`'s summary) — a caller that ignores `.warnings` silently drops
+// the notices, so callers are responsible for reporting them.
 export function buildSet(setName: string, setsDir: string = SETS_DIR): {
   cards: Record<string, unknown>[];
   errors: ValidationError[];
   warnings: BuildWarning[];
 } {
-  const setDir = join(setsDir, setName);
+  const setDir: string = join(setsDir, setName);
   const cards: Record<string, unknown>[] = [];
   const errors: ValidationError[] = [];
   const warnings: BuildWarning[] = [];
 
+  // A set whose directory is entirely absent is an operator error (a typo'd set
+  // name), not a set legitimately omitting a card type — fail rather than emit
+  // five "not found" warnings and a hollow exit-0 build.
+  if (!existsSync(setDir)) {
+    errors.push({ card: setName, field: "set", message: "set directory not found", severity: "error" });
+    return { cards, errors, warnings };
+  }
+
   for (const type of CARD_TYPES) {
     const csvPath = join(setDir, `${type}.csv`);
     if (!existsSync(csvPath)) {
-      // Non-failing: a set may legitimately omit a card type. Surfaced as a
-      // structured warning (not `console.warn`) so it lands in the summary and
-      // is assertable via the return value.
-      warnings.push({ card: setName, field: type, message: `${type}.csv not found, skipping` });
+      // Non-failing: a set may legitimately omit a card type.
+      warnings.push({ card: setName, field: type, message: `${type}.csv not found, skipping`, severity: "warning" });
       continue;
     }
 
@@ -328,6 +358,21 @@ export function buildSet(setName: string, setsDir: string = SETS_DIR): {
   }
 
   return { cards, errors, warnings };
+}
+
+// Render a notice list under a count header; shared by the warning and error
+// summaries so both print with an identical `[card] field: message` line format
+// (the whole point of the common `BuildNotice` base).
+function printNotices(
+  notices: BuildNotice[],
+  header: string,
+  stream: (message: string) => void,
+): void {
+  if (notices.length === 0) return;
+  stream(`\n${notices.length} ${header}:`);
+  for (const n of notices) {
+    stream(`  [${n.card}] ${n.field}: ${n.message}`);
+  }
 }
 
 function main() {
@@ -372,19 +417,9 @@ function main() {
   );
 
   // Report — warnings first (non-failing), then errors (which fail the build).
-  if (totalWarnings.length > 0) {
-    console.warn(`\n${totalWarnings.length} warning(s):`);
-    for (const w of totalWarnings) {
-      console.warn(`  [${w.card}] ${w.field}: ${w.message}`);
-    }
-  }
-  if (totalErrors.length > 0) {
-    console.error(`\n${totalErrors.length} validation error(s):`);
-    for (const e of totalErrors) {
-      console.error(`  [${e.card}] ${e.field}: ${e.message}`);
-    }
-    process.exit(1);
-  }
+  printNotices(totalWarnings, "warning(s)", (m) => console.warn(m));
+  printNotices(totalErrors, "validation error(s)", (m) => console.error(m));
+  if (totalErrors.length > 0) process.exit(1);
 
   console.log(`\nDone. ${allCards.length} cards total across ${sets.length} set(s).`);
 }

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -183,11 +183,45 @@ describe("build warnings — structured non-failing channel", () => {
     ]);
     for (const w of warnings) {
       expect(w.card).toBe("warn-set");
+      expect(w.severity).toBe("warning");
+      // Pin the human-readable message: it names the missing file and its disposition.
+      expect(w.message).toContain(`${w.field}.csv`);
       expect(w.message).toContain("not found");
     }
   });
 
+  test("warnings and errors coexist as disjoint channels in one build", () => {
+    // units.csv holds a card with an invalid rarity (→ error); the other four
+    // types are absent (→ warnings). The channels must not bleed into each other.
+    const BAD_UNIT_CSV: string =
+      "id,name,set,rarity,cost,keywords,attributes,strength,cunning,charisma,actions\n" +
+      "bad-unit,Bad Unit,mixed-set,not-a-rarity,3,,Military,2,1,1,\n";
+    makeSet("mixed-set", { units: BAD_UNIT_CSV });
+    const { errors, warnings } = buildSet("mixed-set", fixtureRoot);
+
+    expect(errors.some((e) => e.field === "rarity")).toBe(true);
+    expect(errors.every((e) => e.severity === "error")).toBe(true);
+    expect(warnings.length).toBe(4);
+    expect(warnings.every((w) => w.severity === "warning")).toBe(true);
+    // No warning leaked into errors, no error into warnings.
+    expect(warnings.every((w) => w.message.includes("not found"))).toBe(true);
+    expect(errors.some((e) => e.message.includes("not found"))).toBe(false);
+  });
+
+  test("a nonexistent set directory fails the build instead of warning", () => {
+    const { cards, errors, warnings } = buildSet("does-not-exist", fixtureRoot);
+    expect(cards).toEqual([]);
+    expect(warnings).toEqual([]);
+    expect(errors.length).toBe(1);
+    expect(errors[0].field).toBe("set");
+    expect(errors[0].severity).toBe("error");
+  });
+
   test("no warnings when every card-type CSV is present", () => {
+    // Header-only fixtures for the non-unit types are intentional: the warning
+    // path keys purely on file existence (existsSync), so a present-but-empty CSV
+    // is enough to prove "present → no warning". Card-row flow into cards[] is
+    // covered by the UNIT_CSV rows in the tests above.
     makeSet("full-set", {
       units: UNIT_CSV,
       locations: "id,name,set,rarity,cost,keywords,attributes,location_type\n",
@@ -197,5 +231,65 @@ describe("build warnings — structured non-failing channel", () => {
     });
     const { warnings } = buildSet("full-set", fixtureRoot);
     expect(warnings).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Build CLI — main() summary rendering and exit codes (#213)
+//
+// buildSet()'s return value is unit-tested above; the fail/no-fail contract
+// itself lives in main() (warnings are non-failing, errors exit 1, warnings
+// print before errors). main() isn't exported, so we drive it as a subprocess,
+// pointing CARDS_SETS_DIR/CARDS_BUILD_DIR at temp dirs for isolation.
+// ---------------------------------------------------------------------------
+describe("build CLI — main() summary and exit codes", () => {
+  const cliRoot: string = mkdtempSync(join(tmpdir(), "cards-buildcli-"));
+  const cliBuild: string = mkdtempSync(join(tmpdir(), "cards-buildout-"));
+  afterAll(() => {
+    rmSync(cliRoot, { recursive: true, force: true });
+    rmSync(cliBuild, { recursive: true, force: true });
+  });
+
+  const BUILD_SCRIPT: string = join(import.meta.dir, "../library/build.ts");
+  const CLI_UNIT_CSV: string =
+    "id,name,set,rarity,cost,keywords,attributes,strength,cunning,charisma,actions\n" +
+    "cli-unit,CLI Unit,cli,common,3,,Military,2,1,1,\n";
+
+  /** Write a fixture set, then run `bun library/build.ts <setName>` against it. */
+  function run(
+    setName: string,
+    csvs: Partial<Record<CardType, string>>,
+  ): { code: number | null; stderr: string } {
+    const dir: string = join(cliRoot, setName);
+    mkdirSync(dir, { recursive: true });
+    for (const [type, body] of Object.entries(csvs)) {
+      writeFileSync(join(dir, `${type}.csv`), body);
+    }
+    const proc = Bun.spawnSync(["bun", BUILD_SCRIPT, setName], {
+      env: { ...process.env, CARDS_SETS_DIR: cliRoot, CARDS_BUILD_DIR: cliBuild },
+    });
+    return { code: proc.exitCode, stderr: proc.stderr.toString() };
+  }
+
+  test("a warning-only build prints the warning summary and exits 0", () => {
+    // Only units.csv → the other four types warn, nothing errors.
+    const { code, stderr } = run("cli-warn", { units: CLI_UNIT_CSV });
+    expect(code).toBe(0);
+    expect(stderr).toContain("warning(s):");
+    expect(stderr).toContain("events.csv not found");
+  });
+
+  test("a validation error fails the build (exit 1), printed after warnings", () => {
+    const BAD_UNIT_CSV: string =
+      "id,name,set,rarity,cost,keywords,attributes,strength,cunning,charisma,actions\n" +
+      "cli-bad,CLI Bad,cli,not-a-rarity,3,,Military,2,1,1,\n";
+    const { code, stderr } = run("cli-err", { units: BAD_UNIT_CSV });
+    expect(code).toBe(1);
+    expect(stderr).toContain("validation error(s):");
+    // Warnings (the four missing CSVs) must print before the error summary.
+    const warnIdx: number = stderr.indexOf("warning(s):");
+    const errIdx: number = stderr.indexOf("validation error(s):");
+    expect(warnIdx).toBeGreaterThanOrEqual(0);
+    expect(errIdx).toBeGreaterThan(warnIdx);
   });
 });

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, test } from "bun:test";
-import { readFileSync } from "fs";
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync } from "fs";
+import { tmpdir } from "os";
 import { join } from "path";
 import {
+  buildSet,
   transformCard,
   validate,
   type CardType,
@@ -139,5 +141,61 @@ describe("build validation — cost is a numeric gold amount", () => {
   test("rejects when any alternative-cost option is non-numeric", () => {
     const errors = check("units", { cost: "4|X", attributes: "Military" });
     expect(errors.some((e) => e.field === "cost")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Structured warnings channel (#213)
+//
+// Non-failing build notices (e.g. a missing per-type CSV) return via
+// `buildSet().warnings` instead of a bare `console.warn`, so they can be
+// surfaced in the summary and asserted on here. Errors stay in `.errors`.
+// ---------------------------------------------------------------------------
+describe("build warnings — structured non-failing channel", () => {
+  const fixtureRoot: string = mkdtempSync(join(tmpdir(), "cards-buildset-"));
+  afterAll(() => rmSync(fixtureRoot, { recursive: true, force: true }));
+
+  /** Write a fixture set with only the given card-type CSVs present. */
+  function makeSet(name: string, csvs: Partial<Record<CardType, string>>): void {
+    const dir: string = join(fixtureRoot, name);
+    mkdirSync(dir, { recursive: true });
+    for (const [type, body] of Object.entries(csvs)) {
+      writeFileSync(join(dir, `${type}.csv`), body);
+    }
+  }
+
+  const UNIT_CSV: string =
+    "id,name,set,rarity,cost,keywords,attributes,strength,cunning,charisma,actions\n" +
+    "warn-unit,Warn Unit,warn-set,common,3,,Military,2,1,1,\n";
+
+  test("emits a warning per missing card-type CSV, without erroring", () => {
+    // Only units.csv present → the other four types warn but don't fail.
+    makeSet("warn-set", { units: UNIT_CSV });
+    const { cards, errors, warnings } = buildSet("warn-set", fixtureRoot);
+
+    expect(cards.length).toBe(1);
+    expect(errors).toEqual([]);
+    expect(warnings.map((w) => w.field).sort()).toEqual([
+      "events",
+      "items",
+      "locations",
+      "policies",
+    ]);
+    for (const w of warnings) {
+      expect(w.card).toBe("warn-set");
+      expect(w.message).toContain("not found");
+    }
+  });
+
+  test("no warnings when every card-type CSV is present", () => {
+    makeSet("full-set", {
+      units: UNIT_CSV,
+      locations: "id,name,set,rarity,cost,keywords,attributes,location_type\n",
+      items: "id,name,set,rarity,cost,keywords,attributes,type\n",
+      events: "id,name,set,rarity,cost,keywords,attributes,timing\n",
+      policies: "id,name,set,rarity,cost,keywords,attributes,effect\n",
+    });
+    const { warnings } = buildSet("full-set", fixtureRoot);
+    expect(warnings).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- Add a structured `warnings[]` channel to `library/build.ts` `validate()` (and `buildSet`), alongside the existing `errors[]`, using a `{ card, field, message }` shape.
- Route unknown-keyword notices (currently emitted via `console.warn` in the `abilities` validation block) through this channel so they can be surfaced in the build summary and inspected programmatically.
- Keep warnings **non-failing** — unknown-keyword governance stays deferred to #194; this is purely about the reporting channel.
- Make the notices assertable via the function's return value rather than only via `spyOn(console, "warn")`.

Closes #213