### PR TITLE
202: Render events & policies to rules-faithful printable PNGs

### DIFF
--- a/design/moderntrek-template.py
+++ b/design/moderntrek-template.py
@@ -1120,7 +1120,9 @@ def build_event_shapes(page_id, frame_id, card, vocab):
     badge = timing.upper()
     if timing == "passive" and card["duration"]:
         badge = f"PASSIVE · {card['duration']} TURNS"
-    bw = int(len(badge) * 11 * 0.62) + 20
+    # Width must include the badge's wide letter-spacing (ls=2.2) or the long
+    # "PASSIVE · N TURNS" variant overflows its box and wraps to two lines.
+    bw = int(len(badge) * (11 * 0.62 + 2.2)) + 20
     if timing == "trap":
         rect("Timing Badge", 59, 92, bw, 28, fills=[], r1=4, r2=4, r3=4, r4=4, strokes=_stroke(accent, 2))
         text("Timing Label", 59, 96, bw, 18, badge, JB, "11", "800", accent, align="center", ls=2.2)

--- a/design/moderntrek-template.py
+++ b/design/moderntrek-template.py
@@ -11,7 +11,9 @@ Rules-faithful choices (the library is the source of truth, not the design; #202
 - Units show the governed `attributes` (synergy axis) as chips, not an invented
   "class". Locations map `edges` -> compass (blocked = red bar, rest open).
   Items/events/policies read their dedicated columns (equip/stored,
-  timing/trigger/text, effect/seeding_effect) — cleanly separated, no blob.
+  timing/trigger/text/event_type, effect/seeding_effect) — cleanly separated,
+  no blob. The event's thematic `event_type` (Catastrophe/Prosperity) renders as
+  a muted chip beside the mechanical timing badge.
 - Where a type has only a freeform `text` blob (units, location actions), it is
   rendered as-is; per-effect structuring is tracked under the effect-grammar work (#208).
 - Keyword pills come from the governed `keywords` column + the vocab artifact
@@ -1125,6 +1127,18 @@ def build_event_shapes(page_id, frame_id, card, vocab):
     else:
         rect("Timing Badge", 59, 92, bw, 28, fills=_fill(accent), r1=4, r2=4, r3=4, r4=4)
         text("Timing Label", 59, 96, bw, 18, badge, JB, "11", "800", C["card_bg"], align="center", ls=2.2)
+
+    # Thematic event category (governed `event_type` vocab: Catastrophe / Prosperity).
+    # Distinct from the mechanical timing badge, so it renders as a separate muted
+    # outlined chip to its right rather than sharing the timing accent (#202).
+    if card["event_type"]:
+        et = card["event_type"].upper()
+        ew = int(len(et) * 11 * 0.62) + 20
+        ex = 59 + bw + 10
+        rect("Event Type Badge", ex, 92, ew, 28, fills=[], r1=4, r2=4, r3=4, r4=4,
+             strokes=_stroke(C["muted"], 1.5))
+        text("Event Type Label", ex, 96, ew, 18, et, JB, "11", "700", C["muted"],
+             align="center", ls=2.2)
 
     def r_trig_row(scale):
         trig = card["trigger"].replace("_", " ").strip().capitalize()

--- a/design/test_moderntrek_template.py
+++ b/design/test_moderntrek_template.py
@@ -263,11 +263,48 @@ def test_event_type_chip():
     check("event_type parsed", typed["event_type"] == "Catastrophe")
     check("event_type chip drawn, uppercased",
           _rendered_text(ch, "Event Type Label") == "CATASTROPHE")
+    # The chip's contract is positional: it sits to the RIGHT of the timing badge,
+    # not overlapping it (renderer: ex = 59 + bw + 10). The text-content check above
+    # would still pass on a mis-positioned chip, so assert the geometry too.
+    tb = _shape_bounds(ch, "Timing Badge")
+    et = _shape_bounds(ch, "Event Type Badge")
+    check("event_type chip sits right of the timing badge, no overlap",
+          tb is not None and et is not None and et[0] >= tb[0] + tb[2])
+    # The chip label is a single word, so it never wraps (`_wrap_lines` only breaks
+    # on spaces) — the real invariant is that the rendered text fits inside the chip
+    # box rather than spilling past its outline. `_line_count == 1` would be vacuous.
+    check("CATASTROPHE chip text fits inside its box",
+          _text_width(ch, "Event Type Label") <= et[2])
 
     untyped = mt.parse_event({"id": "e2", "name": "E2", "timing": "instant"}, 0)
     ch2, _ = _quiet(mt.build_event_shapes, "pg", "fr", untyped, {})
+    # Rename-safe only because the positive assertion above anchors the
+    # "Event Type Label" name and would fail loudly if the shape were renamed.
     check("no event_type → no chip drawn",
           _rendered_text(ch2, "Event Type Label") is None)
+
+    # The other half of #202: the timing-badge width fix. A passive event with a
+    # duration renders the long "PASSIVE · N TURNS" badge, which must stay on one
+    # line. Assert the position-data line count — NOT _rendered_text, which joins
+    # lines with a space and so reads identically whether or not the badge wrapped.
+    passive = mt.parse_event({"id": "e3", "name": "E3", "timing": "passive",
+                              "duration": "3"}, 0)
+    ch3, _ = _quiet(mt.build_event_shapes, "pg", "fr", passive, {})
+    check("PASSIVE · N TURNS badge stays on one line",
+          _line_count(ch3, "Timing Label") == 1)
+
+    # Both halves together: a wide passive badge AND a chip. The chip's x offset
+    # depends on the badge width, so this is where the two features interact.
+    combo = mt.parse_event({"id": "e4", "name": "E4", "timing": "passive",
+                            "duration": "3", "event_type": "Prosperity"}, 0)
+    ch4, _ = _quiet(mt.build_event_shapes, "pg", "fr", combo, {})
+    check("combined: passive badge one line", _line_count(ch4, "Timing Label") == 1)
+    ctb = _shape_bounds(ch4, "Timing Badge")
+    cet = _shape_bounds(ch4, "Event Type Badge")
+    check("combined: PROSPERITY chip text fits inside its box",
+          _text_width(ch4, "Event Type Label") <= cet[2])
+    check("combined: chip clears the wide passive badge",
+          ctb is not None and cet is not None and cet[0] >= ctb[0] + ctb[2])
 
 
 def _real_vocab():
@@ -419,6 +456,39 @@ def _rendered_text(ch, name):
         o = c["obj"]
         if o.get("type") == "text" and name in o["name"]:
             return " ".join(e["text"] for e in o.get("position-data", []))
+    return None
+
+
+def _line_count(ch, name):
+    """Number of laid-out lines (position-data entries) of the first text shape whose
+    name contains `name`, or None if absent. Unlike `_rendered_text`, this detects
+    wrapping — the join in `_rendered_text` reads identically whether text wrapped."""
+    for c in ch:
+        o = c["obj"]
+        if o.get("type") == "text" and name in o["name"]:
+            return len(o.get("position-data", []))
+    return None
+
+
+def _shape_bounds(ch, name):
+    """(x, y, w, h) of the first shape whose name contains `name`, or None."""
+    for n, x, y, w, h in _bounds(ch):
+        if name in n:
+            return (x, y, w, h)
+    return None
+
+
+def _text_width(ch, name):
+    """Widest rendered line (position-data `width`) of the first text shape whose
+    name contains `name`, or None. This is the true rendered advance (CHAR_ADVANCE
+    + letter-spacing), so it can be compared against the shape's box width to catch
+    a label that spills past its container — which single-word labels do without
+    ever wrapping (`_wrap_lines` only breaks on spaces)."""
+    for c in ch:
+        o = c["obj"]
+        if o.get("type") == "text" and name in o["name"]:
+            pd = o.get("position-data", [])
+            return max((e["width"] for e in pd), default=0)
     return None
 
 

--- a/design/test_moderntrek_template.py
+++ b/design/test_moderntrek_template.py
@@ -252,6 +252,24 @@ def test_nonunit_keywords():
     check("kw lines: long reminder wraps to >= 2 lines", n >= 2)
 
 
+def test_event_type_chip():
+    """The governed `event_type` (Catastrophe/Prosperity) renders as its own chip
+    beside the timing badge — a rules-faithful category that was previously parsed
+    but never drawn (#202)."""
+    print("event_type chip:")
+    typed = mt.parse_event({"id": "e", "name": "E", "timing": "instant",
+                            "event_type": "Catastrophe"}, 0)
+    ch, _ = _quiet(mt.build_event_shapes, "pg", "fr", typed, {})
+    check("event_type parsed", typed["event_type"] == "Catastrophe")
+    check("event_type chip drawn, uppercased",
+          _rendered_text(ch, "Event Type Label") == "CATASTROPHE")
+
+    untyped = mt.parse_event({"id": "e2", "name": "E2", "timing": "instant"}, 0)
+    ch2, _ = _quiet(mt.build_event_shapes, "pg", "fr", untyped, {})
+    check("no event_type → no chip drawn",
+          _rendered_text(ch2, "Event Type Label") is None)
+
+
 def _real_vocab():
     """Load the real build/keywords.json (building it if absent) as a name-keyed dict."""
     root = os.path.join(SCRIPT_DIR, "..")
@@ -489,6 +507,7 @@ if __name__ == "__main__":
     test_block_fitting()
     test_overflow_containment()
     test_nonunit_keywords()
+    test_event_type_chip()
     test_real_vocab_reminders()
     test_compose_reminder_degradation()
     test_format_param_edges()

--- a/library/sets/alpha-1/items.csv
+++ b/library/sets/alpha-1/items.csv
@@ -3,7 +3,7 @@ ancient-scroll,Ancient Scroll,alpha-1,common,2,Equipped unit gets +2 cunning.,,,
 war-banner,War Banner,alpha-1,uncommon,3,All friendly units at this location get +1 strength.,Units initiating a strength contest at this location get +2 strength.,,Heavy,Banner,,Equip: +1 strength to friendly units here. Stored: +2 strength to attackers here.,It flew above a hundred fields.
 merchant-ledger,Merchant Ledger,alpha-1,epic,4,,Generates 2 gold at start of your turn.,Commerce,,,,Stored at a location: gain 2 gold per turn.,Every coin accounted for.
 compass,Compass,alpha-1,common,1,,,Exploration,Flying,,,Ignore one blocked edge when moving.,It always knows the way home.
-philosophers-stone,Philosopher's Stone,alpha-1,legendary,6,Equipped unit gains +2 to all stats.,,,,Artifact,transmute:1:gain_3_gold,+2 all stats. Action: gain 3 gold.,The real treasure was understanding.
+philosophers-stone,Philosopher's Stone,alpha-1,legendary,6,Equipped unit gains +2 to all stats.,,,,Artifact,transmute:1:gain_3_gold,Gain 3 gold.,The real treasure was understanding.
 spy-glass,Spy Glass,alpha-1,common,1,Equipped unit can look at face-down traps at its location.,,Exploration,Lightweight,,,Reveal traps at your location.,Knowledge is the best armor.
 holy-relic,Holy Relic,alpha-1,uncommon,3,Equipped Spirituality unit gets +3 charisma.,All Spirituality units at this location get +1 charisma.,,,Artifact,,+3 charisma to Spirituality (equip) or +1 charisma to Spirituality (stored).,Faith made tangible.
 siege-engine,Siege Engine,alpha-1,epic,5,,,Military,,,bombard:1:minus2_strength_all_enemy_location,All enemy units at target adjacent location get -2 strength until end of turn. Must be stored at a location to use.,The walls came down.


### PR DESCRIPTION
## Summary

- Continues #202 (the umbrella for the full rules-faithful printable set) after PR #216 delivered units, locations, and items.
- Wires the consolidated `moderntrek-template.py` renderer to render the remaining two card types — **events** and **policies** — rules-faithfully from CSV.
- Surfaces and captures any card-data model gaps specific to events/policies as follow-up sub-issues when reached.
- Checks the flagged **Philosopher's Stone** item-passive rendering (`+2 all stats` currently reads as part of the action rather than a distinct passive/stat effect).

Closes #202