### PR TITLE
147: Event log empty after autosave reload — persist or replay events on load

### DIFF
--- a/clients/web/src/lib/__tests__/eventLog.test.ts
+++ b/clients/web/src/lib/__tests__/eventLog.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "bun:test";
+import type { GameEvent, Session } from "cards-engine";
+import { deriveTurnStartIndices, restoreEventLogState } from "../eventLog";
+
+const turnStart = (playerId: string, round: number): GameEvent => ({
+  type: "turn_started",
+  playerId,
+  round,
+});
+const other = (): GameEvent => ({ type: "card_drawn", playerId: "p1", count: 1 });
+
+describe("deriveTurnStartIndices", () => {
+  it("returns zeros for an empty log", () => {
+    expect(deriveTurnStartIndices([])).toEqual({ prev: 0, last: 0 });
+  });
+
+  it("returns zeros when there is only one turn boundary", () => {
+    // A fresh game with one turn started: recap window is empty until turn 2.
+    const log: GameEvent[] = [turnStart("p1", 1), other()];
+    expect(deriveTurnStartIndices(log)).toEqual({ prev: 0, last: 0 });
+  });
+
+  it("points prev/last at the last two turn boundaries", () => {
+    const log: GameEvent[] = [
+      turnStart("p1", 1), // index 0
+      other(), // 1
+      turnStart("p2", 1), // 2  <- prev
+      other(), // 3
+      turnStart("p1", 2), // 4  <- last
+      other(), // 5
+    ];
+    const indices = deriveTurnStartIndices(log);
+    expect(indices).toEqual({ prev: 2, last: 4 });
+    // The recap slice is exactly the previous completed turn.
+    expect(log.slice(indices.prev, indices.last)).toEqual([
+      turnStart("p2", 1),
+      other(),
+    ]);
+  });
+
+  it("does not dump the whole history for a long restored log", () => {
+    // Regression guard for #147: restoring a non-empty log must not make the
+    // recap slice span the entire history.
+    const log: GameEvent[] = [];
+    for (let round = 1; round <= 5; round++) {
+      log.push(turnStart("p1", round), other(), turnStart("p2", round), other());
+    }
+    const indices = deriveTurnStartIndices(log);
+    expect(indices.last).toBe(log.length - 2); // last turn_started, not the end
+    expect(indices.last - indices.prev).toBe(2); // one turn's worth, not all of it
+  });
+
+  it("treats a single non-zero-index boundary as an absolute offset", () => {
+    // Real logs begin with seeding events, so the first turn_started is not at
+    // index 0. `last` must be that absolute index, not a 0 fallback.
+    const log: GameEvent[] = [
+      other(), // 0  (e.g. a seeding event)
+      other(), // 1
+      turnStart("p1", 1), // 2  <- last
+      other(), // 3
+    ];
+    expect(deriveTurnStartIndices(log)).toEqual({ prev: 0, last: 2 });
+  });
+
+  it("returns absolute offsets for both boundaries when events precede them", () => {
+    const log: GameEvent[] = [
+      other(), // 0  (seeding)
+      turnStart("p1", 1), // 1  <- prev
+      other(), // 2
+      turnStart("p2", 1), // 3  <- last
+    ];
+    const indices = deriveTurnStartIndices(log);
+    expect(indices).toEqual({ prev: 1, last: 3 });
+    expect(log.slice(indices.prev, indices.last)).toEqual([
+      turnStart("p1", 1),
+      other(),
+    ]);
+  });
+});
+
+// A truthy snapshot stub — restoreEventLogState only checks for its presence.
+const SNAP: Session["snapshot"] = {} as Session["snapshot"];
+
+describe("restoreEventLogState", () => {
+  const log: GameEvent[] = [
+    turnStart("p1", 1),
+    other(),
+    turnStart("p2", 1),
+    other(),
+  ];
+
+  it("restores the log and derives the recap indices when a snapshot is present", () => {
+    expect(restoreEventLogState({ snapshot: SNAP, events: log })).toEqual({
+      eventLog: log,
+      prev: 0,
+      last: 2,
+      malformed: false,
+    });
+  });
+
+  it("falls back to empty for a pre-#147 save with no events field", () => {
+    expect(restoreEventLogState({ snapshot: SNAP, events: undefined })).toEqual({
+      eventLog: [],
+      prev: 0,
+      last: 0,
+      malformed: false,
+    });
+  });
+
+  it("returns empty (no double-append) when there is no snapshot to resume from", () => {
+    // Without a snapshot, fromSession replays actions and onEvent rebuilds the
+    // log; pre-seeding here would double-append and clobber the indices (#147).
+    expect(restoreEventLogState({ snapshot: undefined, events: log })).toEqual({
+      eventLog: [],
+      prev: 0,
+      last: 0,
+      malformed: false,
+    });
+  });
+
+  it("flags a present-but-non-array events field as malformed", () => {
+    const bad = {} as unknown as GameEvent[];
+    expect(restoreEventLogState({ snapshot: SNAP, events: bad })).toEqual({
+      eventLog: [],
+      prev: 0,
+      last: 0,
+      malformed: true,
+    });
+  });
+
+  it("flags entries without a string `type` as malformed", () => {
+    const bad = [{ foo: 1 }] as unknown as GameEvent[];
+    const result = restoreEventLogState({ snapshot: SNAP, events: bad });
+    expect(result.malformed).toBe(true);
+    expect(result.eventLog).toEqual([]);
+  });
+});

--- a/clients/web/src/lib/eventLog.ts
+++ b/clients/web/src/lib/eventLog.ts
@@ -1,0 +1,86 @@
+import type { GameEvent, Session } from "cards-engine";
+
+/**
+ * Turn-boundary indices into the event log used by the pass-device recap.
+ * When at least two turns have started, the events in `[prev, last)` are the
+ * previous completed turn; with fewer boundaries the window is empty
+ * (`prev === last`). Immutable derived result.
+ */
+export interface TurnStartIndices {
+  readonly prev: number;
+  readonly last: number;
+}
+
+/**
+ * Derive the turn-boundary indices from an event log. Used on load (#147) to
+ * reconstruct the recap window from a restored log, and by gameStore's
+ * `onEvent` as the single source of truth for the live bookkeeping (so the two
+ * paths cannot drift).
+ *
+ * `last` is the index of the final `turn_started` (the current turn's start),
+ * or 0 when the log has no turn boundary at all. `prev` is the index of the
+ * `turn_started` before it, or 0 when the log has fewer than two boundaries.
+ * So `events.slice(prev, last)` yields the previous turn's events once at least
+ * two turns have started; with a single boundary it spans everything before
+ * that turn (e.g. the seeding events, which precede the first `turn_started` in
+ * a real log), and with no boundary it is empty.
+ */
+export function deriveTurnStartIndices(events: GameEvent[]): TurnStartIndices {
+  const turnStarts: number[] = [];
+  for (let i: number = 0; i < events.length; i++) {
+    if (events[i].type === "turn_started") turnStarts.push(i);
+  }
+  return {
+    last: turnStarts.length > 0 ? turnStarts[turnStarts.length - 1] : 0,
+    prev: turnStarts.length > 1 ? turnStarts[turnStarts.length - 2] : 0,
+  };
+}
+
+/** Outcome of reconstructing the event-log state from a saved session. */
+export interface RestoredEventLog {
+  readonly eventLog: GameEvent[];
+  readonly prev: number;
+  readonly last: number;
+  /** True when a persisted `events` field was present but not a valid log. */
+  readonly malformed: boolean;
+}
+
+/**
+ * Reconstruct the client's event-log state (`_eventLog` plus the two recap
+ * indices) from a saved session, so the restore wiring in gameStore's
+ * `loadGame` is a pure, unit-testable step (#147).
+ *
+ * - Only restores when the session carries a `snapshot`. Without one,
+ *   `GameController.fromSession` replays the action log and re-fires `onEvent`,
+ *   which rebuilds `_eventLog` from scratch; pre-seeding here would then
+ *   double-append and clobber the indices.
+ * - A genuinely absent `events` field (pre-#147 saves) falls back to empty.
+ * - Persisted data is untyped at runtime (IndexedDB returns whatever was
+ *   stored), so a schema-drifted or tampered save is validated before it is
+ *   trusted: a non-array or entries without a string `type` are reported as
+ *   `malformed` and fall back to empty, rather than deferring a crash to the
+ *   first `getEventLog`/`getLastTurnEvents` that maps/slices the log.
+ */
+export function restoreEventLogState(
+  session: Pick<Session, "events" | "snapshot">,
+): RestoredEventLog {
+  const empty: RestoredEventLog = {
+    eventLog: [],
+    prev: 0,
+    last: 0,
+    malformed: false,
+  };
+
+  if (!session.snapshot) return empty;
+
+  const raw: GameEvent[] | undefined = session.events;
+  if (raw === undefined) return empty;
+
+  const valid: boolean =
+    Array.isArray(raw) &&
+    raw.every((e) => typeof (e as GameEvent | undefined)?.type === "string");
+  if (!valid) return { eventLog: [], prev: 0, last: 0, malformed: true };
+
+  const { prev, last }: TurnStartIndices = deriveTurnStartIndices(raw);
+  return { eventLog: raw, prev, last, malformed: false };
+}

--- a/clients/web/src/lib/gameStore.svelte.ts
+++ b/clients/web/src/lib/gameStore.svelte.ts
@@ -19,6 +19,11 @@ import {
   type ContestResult,
   stepCombatBuffer,
 } from "./contestResult";
+import {
+  deriveTurnStartIndices,
+  restoreEventLogState,
+  type RestoredEventLog,
+} from "./eventLog";
 import { buildMainSetup, buildSeedingSetup, DEFAULT_CONFIG } from "./gameSetup";
 import { HotseatAdapter } from "./HotseatAdapter";
 import {
@@ -303,16 +308,15 @@ function assertNever(x: never): never {
 }
 
 function onEvent(events: GameEvent[], state: GameState): void {
-  const baseIndex = _eventLog.length;
   _eventLog = [..._eventLog, ...events];
   _gamePhase = state.phase;
 
-  for (let i = 0; i < events.length; i++) {
-    if (events[i].type === "turn_started") {
-      _prevTurnStartIndex = _lastTurnStartIndex;
-      _lastTurnStartIndex = baseIndex + i;
-    }
-  }
+  // Recompute the recap boundaries from the full log via the same helper the
+  // load path uses, so live bookkeeping and restore can't drift (single source
+  // of truth). See `deriveTurnStartIndices` in eventLog.ts.
+  const turnStarts = deriveTurnStartIndices(_eventLog);
+  _prevTurnStartIndex = turnStarts.prev;
+  _lastTurnStartIndex = turnStarts.last;
 
   // Popup state — names resolved NOW because killed units will leave the
   // visible state before the popup renders. Factories live in contestResult.ts
@@ -399,7 +403,7 @@ function onEvent(events: GameEvent[], state: GameState): void {
   // Auto-save after every action
   if (controller) {
     try {
-      const session = structuredClone(controller.toSession(true));
+      const session = structuredClone(controller.toSession(true, _eventLog));
       autoSave(session)
         .then(() => {
           autoSaveFailCount = 0;
@@ -414,11 +418,14 @@ function onEvent(events: GameEvent[], state: GameState): void {
           }
         });
     } catch (err) {
+      // Serialization (structuredClone of the session, including the god-view
+      // log) failed. Manual save runs the identical clone, so don't advise it —
+      // this is likely a bug worth reporting.
       console.error("Failed to serialize session for auto-save:", err);
       autoSaveFailCount++;
       if (autoSaveFailCount >= 3) {
         _error =
-          "Auto-save is failing. Your progress may not be saved. Try saving manually.";
+          "Auto-save can't serialize the game — your progress may not be saved. This is likely a bug; please report it.";
       }
     }
   }
@@ -542,10 +549,22 @@ export async function loadGame(key: string): Promise<void> {
     );
   }
 
-  _eventLog = [];
+  // Restore the god-view event log persisted with the save (issue #147) and
+  // reconstruct the recap boundaries, so the pass-device recap shows only the
+  // last completed turn — not the whole restored history, nor an empty panel.
+  // Pure + validated + snapshot-gated in `restoreEventLogState`.
+  const restored: RestoredEventLog = restoreEventLogState(session);
+  _eventLog = restored.eventLog;
   _error = null;
-  _prevTurnStartIndex = 0;
-  _lastTurnStartIndex = 0;
+  _prevTurnStartIndex = restored.prev;
+  _lastTurnStartIndex = restored.last;
+  if (restored.malformed) {
+    console.error(
+      "Restored event log was malformed; showing empty history",
+      session.events,
+    );
+    pushError("Saved event history was unreadable and could not be restored.");
+  }
   _contestResult = null;
   _combatEvents = [];
   lastActivePlayerId = null;
@@ -630,7 +649,7 @@ export async function saveGame(name: string): Promise<void> {
     return;
   }
   try {
-    await saveSession(name, structuredClone(controller.toSession(true)));
+    await saveSession(name, structuredClone(controller.toSession(true, _eventLog)));
     await refreshSessions();
   } catch (err) {
     _error = `Failed to save game: ${err instanceof Error ? err.message : String(err)}`;

--- a/engine/src/__tests__/controller.test.ts
+++ b/engine/src/__tests__/controller.test.ts
@@ -435,6 +435,29 @@ describe("GameController", () => {
       expect(parsed.snapshot.rngState.length).toBeGreaterThan(0);
     });
 
+    it("omits events when none are passed", () => {
+      const controller = createController();
+      expect(controller.toSession(true).events).toBeUndefined();
+    });
+
+    it("persists an empty event log as an empty array (distinct from omitted)", () => {
+      const controller = createController();
+      expect(controller.toSession(true, []).events).toEqual([]);
+    });
+
+    it("persists the passed event log and survives JSON round-trip", () => {
+      const controller = createController();
+      const events: GameEvent[] = [
+        { type: "turn_started", playerId: "p1", round: 1 },
+        { type: "turn_started", playerId: "p2", round: 1 },
+      ];
+      const session = controller.toSession(true, events);
+      expect(session.events).toEqual(events);
+
+      const parsed = JSON.parse(JSON.stringify(session)) as Session;
+      expect(parsed.events).toEqual(events);
+    });
+
     it("replays actions from session", async () => {
       const controller = createController();
       await controller.playTurn();

--- a/engine/src/controller.ts
+++ b/engine/src/controller.ts
@@ -241,8 +241,13 @@ export class GameController {
     return this.state;
   }
 
-  /** Serialize the current game as a session. */
-  toSession(includeSnapshot = false): Session {
+  /**
+   * Serialize the current game as a session. The controller does not accumulate
+   * an event log itself (clients do, via the `onEvent` callback), so callers
+   * pass the god-view log in to persist it. `events` is stored independently of
+   * `includeSnapshot`; pass it only when serializing for later restore.
+   */
+  toSession(includeSnapshot = false, events?: GameEvent[]): Session {
     const round =
       this.state.phase === "main" || this.state.phase === "ended"
         ? this.state.turn.round
@@ -255,6 +260,7 @@ export class GameController {
       seed: this.seed,
       actions: this.state.actionLog,
       snapshot: includeSnapshot ? this.state : undefined,
+      events,
       result:
         this.state.phase === "ended"
           ? {

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -1102,6 +1102,12 @@ export interface Session {
   actions: Action[];
   /** Optional snapshot for quick resume. Fully JSON-serializable. */
   snapshot?: GameState;
+  /**
+   * Optional god-view event log, persisted so clients can restore prior-turn
+   * history (combat math, contest breakdowns, activity) on load. The snapshot
+   * resume path does not replay actions, so without this the log is lost.
+   */
+  events?: GameEvent[];
   result?: {
     winner?: string;
     scores: Record<string, number>;


### PR DESCRIPTION
## Summary

- The `Session` type carries `actions` + optional `snapshot` but no event log, so after an autosave reload `_eventLog` in `gameStore.svelte.ts` is empty — the player loses all prior-turn combat math, contest breakdowns, and activity history.
- Investigation issue: weigh persisting `events?: GameEvent[]` in `Session` (Option A, larger saves) vs. replaying actions on load (Option B, slower) vs. replaying just the last 1–2 turns from the snapshot point (Option C, needs RNG-slice design).
- Decide the approach at realistic game lengths, then implement.

Follow-up to #129.

Closes #147