### PR TITLE
205: Design-principles capture: card-set-design skill + extend rules/design-principles.md

### DIFF
--- a/.claude/skills/card-design/SKILL.md
+++ b/.claude/skills/card-design/SKILL.md
@@ -7,6 +7,11 @@ description: Design new cards with real-world historical references, balanced st
 
 Design cards that are historically grounded, mechanically sound, and fun to play.
 
+> The canonical card-craft principles — **No Dominated / Feel-Bad Cards** and
+> **Synergy with Counterplay** — live in the **Card Craft** section of
+> `rules/design-principles.md`. This skill applies them to concrete card designs
+> rather than restating them.
+
 ## Arguments
 - Free-form description of what cards to design. Examples:
   - "5 common units for alpha-1"

--- a/.claude/skills/card-set-design/SKILL.md
+++ b/.claude/skills/card-set-design/SKILL.md
@@ -6,25 +6,25 @@ description: Set-level design philosophy and the iteration loop for building a c
 # Card Set Design
 
 Design a **set as a whole** — the shape of the pool, the archetypes it supports,
-and the loop that moves it from rough to playable. This is the bucket-2
-methodology: distinct from crafting one card well (the `card-design` skill) and
-from designing the game's rules/mechanics (`rules/design-principles.md`).
+and the loop that moves it from rough to playable. This is distinct from
+crafting one card well (the `card-design` skill) and from designing the game's
+rules/mechanics (`rules/design-principles.md`).
 
 Load this skill and keep it in mind for the duration of a set-design session.
 
 ## Arguments
 
 - Free-form description of the set-level goal. Examples:
-  - "shape the v0.1 alpha-1 set for first playtest"
+  - "shape the alpha-1 set for first playtest"
   - "audit alpha-1 for dead archetypes"
   - "which archetypes still lack a payoff card?"
-- Optional: target set (defaults to the set under active work).
+- Optional: target set (defaults to `alpha-1`).
 
 ## Philosophy
 
 ### Playtest-appropriate > balanced
 
-The goal of an early set (e.g. v0.1) is a set that is **playable**, not one that
+The goal of an early set (e.g. alpha-1) is a set that is **playable**, not one that
 is fully tuned. Perfect balance is a moving target that only real play reveals;
 chasing it before the set is playable wastes effort on numbers that will move.
 Ship something you can play, then tune from evidence.
@@ -35,12 +35,12 @@ Represent every mechanic and archetype **before** fine-tuning any numbers. A set
 that covers its intended strategies at rough power levels is more useful than a
 half-covered set with three perfectly-tuned cards. Breadth first, then depth.
 
-### No dead archetypes — ≥2 viable win paths
+### No dead archetypes — ≥2 viable strategies
 
 Every archetype the set gestures at should have a real path to the win
 condition; an archetype with no payoff is a trap that punishes the player who
 believes the set's own signposting. Aim for **at least two** viable, distinct
-paths to victory so deckbuilding is a genuine choice, not a solved line.
+paths to accumulating VP so deckbuilding is a genuine choice, not a solved line.
 
 ### Bounded, learnable pool
 
@@ -51,7 +51,8 @@ because an archetype needs them, not to hit a count.
 
 ### Deliberate rarity distribution
 
-The common/uncommon/epic/legendary mix is a design lever, not an afterthought.
+The rarity mix (see **Rarity** in `rules/README.md`) is a design lever, not an
+afterthought.
 Commons form the backbone every deck leans on; rarer slots carry the
 build-around payoffs. Decide the intended distribution across the set and check
 the actual pool against it — skew reveals archetypes that are over- or

--- a/.claude/skills/card-set-design/SKILL.md
+++ b/.claude/skills/card-set-design/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: card-set-design
+description: Set-level design philosophy and the iteration loop for building a coherent, playtest-ready card set. Use when designing a new set, deciding what a set as a whole should contain, or refining an existing set toward playability. For crafting a single card, use card-design instead.
+---
+
+# Card Set Design
+
+Design a **set as a whole** — the shape of the pool, the archetypes it supports,
+and the loop that moves it from rough to playable. This is the bucket-2
+methodology: distinct from crafting one card well (the `card-design` skill) and
+from designing the game's rules/mechanics (`rules/design-principles.md`).
+
+Load this skill and keep it in mind for the duration of a set-design session.
+
+## Arguments
+
+- Free-form description of the set-level goal. Examples:
+  - "shape the v0.1 alpha-1 set for first playtest"
+  - "audit alpha-1 for dead archetypes"
+  - "which archetypes still lack a payoff card?"
+- Optional: target set (defaults to the set under active work).
+
+## Philosophy
+
+### Playtest-appropriate > balanced
+
+The goal of an early set (e.g. v0.1) is a set that is **playable**, not one that
+is fully tuned. Perfect balance is a moving target that only real play reveals;
+chasing it before the set is playable wastes effort on numbers that will move.
+Ship something you can play, then tune from evidence.
+
+### Coverage before balance
+
+Represent every mechanic and archetype **before** fine-tuning any numbers. A set
+that covers its intended strategies at rough power levels is more useful than a
+half-covered set with three perfectly-tuned cards. Breadth first, then depth.
+
+### No dead archetypes — ≥2 viable win paths
+
+Every archetype the set gestures at should have a real path to the win
+condition; an archetype with no payoff is a trap that punishes the player who
+believes the set's own signposting. Aim for **at least two** viable, distinct
+paths to victory so deckbuilding is a genuine choice, not a solved line.
+
+### Bounded, learnable pool
+
+Keep the pool small enough that a player memorizes the core after a few games.
+A learnable set produces faster, richer decisions and cleaner playtest signal;
+an oversized early pool dilutes every archetype and slows the loop. Add cards
+because an archetype needs them, not to hit a count.
+
+### Deliberate rarity distribution
+
+The common/uncommon/epic/legendary mix is a design lever, not an afterthought.
+Commons form the backbone every deck leans on; rarer slots carry the
+build-around payoffs. Decide the intended distribution across the set and check
+the actual pool against it — skew reveals archetypes that are over- or
+under-supported.
+
+## The iteration loop
+
+Set design is iterative. One pass through the loop:
+
+1. **Edit** — add or adjust cards in `library/sets/{set}/*.csv` (VisiData or a
+   spreadsheet; see the root `CLAUDE.md` → Card Library workflows).
+2. **Build** — `bun library/build.ts` to validate the CSVs and regenerate JSON.
+   A failed build is the first gate; fix it before going further.
+3. **Audit** — check the set against the rules and against coverage:
+   - `card-rule-review` skill for card↔rules consistency.
+   - `card-query` skill for coverage/rarity/cost distribution over the pool.
+   *(Deeper analysis tooling — archetype taxonomy #192, EV/value model #193 —
+   plugs in here as it lands.)*
+4. **Play** — `play-game` skill to exercise the set in real games and surface
+   dead archetypes, unbeatable lines, and non-decisions.
+5. **Query sessions** — `session-query` skill over the resulting session data:
+   win rates, game length, card usage, archetype performance.
+6. **Tune** — feed those findings back into step 1. Repeat until the set is
+   playtest-appropriate across its intended archetypes.
+
+Coverage gaps are found in steps 3–5; balance is tuned in step 6. Resist tuning
+numbers before coverage is in place (see **Coverage before balance**).
+
+## Related principles (DRY)
+
+These docs are the canonical source; this skill points at them rather than
+restating:
+
+- **Individual card craft** — `card-design` skill, plus the **Card Craft**
+  section of `rules/design-principles.md` (no dominated/feel-bad cards;
+  synergy with counterplay).
+- **Rules & mechanics design** — `rules/design-principles.md` (counterplay,
+  complexity budget, keyword/DSL-verb design, decide-the-data-model-first,
+  mechanic composition).

--- a/rules/CLAUDE.md
+++ b/rules/CLAUDE.md
@@ -25,7 +25,7 @@ This folder contains markdown files defining the card game rules.
 
 ## File Structure
 - `README.md` — Master design document (phases, card types, economy, variants)
-- `design-principles.md` — Meta-level design goals that guide rule design
+- `design-principles.md` — Meta-level design principles for rules/mechanics, whole sets, and individual cards
 - `attributes.md` — Closed cross-card-type attribute vocabulary
 - `stat-contests.md` — Stat contest mechanics (1v1 resolution, modifiers, distinction from stat checks)
 - `market.md` — Market and economy rules

--- a/rules/design-principles.md
+++ b/rules/design-principles.md
@@ -1,7 +1,9 @@
 # Design Principles
 
-Meta-level principles that inform game rule design. These are not rules
-themselves but guide how rules are created and evaluated.
+Meta-level principles that inform design across the game — its rules and
+mechanics, whole sets, and individual cards. These are not rules themselves but
+guide how the game is designed and evaluated. (Mechanics-design and card-craft
+principles live in the **Mechanics Design** and **Card Craft** sections below.)
 
 ## Intent
 

--- a/rules/design-principles.md
+++ b/rules/design-principles.md
@@ -44,3 +44,77 @@ condition the opponent can work around, or a cost the owner pays.
 (targetable once the attacker out-stats it) rather than blanket-immune, and
 Lethal ("always kills") was replaced by Berserker (kills, but the unit injures
 itself to do it).]
+
+## Mechanics Design
+
+Principles for designing the game's rules and mechanics themselves — as
+distinct from crafting an individual card (see **Card Craft** below) or
+composing a whole set (that methodology lives in the `card-set-design` skill).
+
+### Every Mechanic Needs Counterplay
+
+A mechanic the opponent cannot answer removes their decisions and flattens the
+game. Each new mechanic should ship with at least one axis of response — a way
+to prevent, blunt, race, trade against, or punish it. **No Free Absolutes**
+(above) is the keyword-scale case of this same test; apply it equally to whole
+subsystems.
+
+### Complexity Budget vs Rules-Surface
+
+Each mechanic spends from a finite pool of rules-surface the player must hold in
+their head. A mechanic's true cost is not just its own rules text but every
+interaction it opens with the mechanics already present. Reach for a new
+mechanic only when an existing one genuinely can't carry the design; prefer
+extending established vocabulary over minting new.
+
+### Keyword / DSL-Verb Design: Clear, Reusable, Minimal
+
+Keywords and DSL verbs are the shared vocabulary of the whole set. Keep each one:
+
+- **Clear** — one unambiguous meaning; a reader shouldn't need to guess scope.
+- **Reusable** — it earns its place by appearing on many cards, not one; a
+  verb built for a single card is flavor text pretending to be a keyword.
+- **Minimal** — it does one thing and composes with others, rather than
+  bundling several behaviors. A verb that needs a paragraph of exceptions is
+  two verbs wearing a trenchcoat.
+
+### Decide the Data Model Before Populating
+
+Settle the schema and vocabulary — attribute lists, category enums, cost/stat
+fields, keyword grammar — *before* authoring cards against them. Reworking the
+model after hundreds of cards already reference it is expensive and
+error-prone.
+
+[design: cf. #160's per-type category-vocabulary governance — the cost of
+leaving categories open-ended surfaced only once cards had accumulated against
+the loose model.]
+
+### How Mechanics Compose
+
+Design mechanics to combine predictably. Prefer **orthogonal** mechanics — each
+operating on a distinct axis (combat, economy, movement, information) — so
+their interaction stays legible. Watch for pairs that multiply into unbounded
+loops or hard lockouts. A mechanic's value includes the interesting
+combinations it opens with what already exists, not only what it does alone.
+
+## Card Craft
+
+Principles for crafting an individual card well. The `card-design` skill is the
+working home for card craft and references these principles rather than
+restating them; keep the canonical wording here.
+
+### No Dominated / Feel-Bad Cards
+
+No card should be **strictly worse** than another (dominated) — a dominated card
+is one nobody plays and a design slot wasted. Equally, avoid **feel-bad** cards:
+ones that are unfun to play against out of proportion to the skill needed to
+deploy them. Both are failures of the same goal — every card should be a real,
+satisfying choice for someone.
+
+### Synergy with Counterplay
+
+Synergies are the reward for deckbuilding, but a synergy that, once assembled,
+can no longer be interacted with becomes a solved-puzzle win button. Build
+synergies an opponent can still disrupt — deny a piece, race the setup, or
+punish the commitment. This is the card-craft echo of **Every Mechanic Needs
+Counterplay**.


### PR DESCRIPTION
## Summary

- Add a new `card-set-design` skill (`.claude/skills/card-set-design/SKILL.md`) capturing set-level design philosophy and the edit → build → audit → play → tune iteration loop (Deliverable A).
- Extend `rules/design-principles.md` with mechanics-design principles: counterplay, complexity budget, keyword/DSL-verb design, decide-the-data-model-first, and how mechanics compose (Deliverable B).
- Write the two cross-bucket card-craft principles (no dominated/feel-bad cards; synergy-with-counterplay) into the docs for #106 to reference.
- Honor the delivery rule: docs are the DRY source of truth referenced by both skills and agents.

Closes #205
