### PR TITLE
45: Scrap Golden Age from alpha-1 (playable-floor cut)

### DIFF
--- a/library/sets/alpha-1/events.csv
+++ b/library/sets/alpha-1/events.csv
@@ -1,6 +1,5 @@
 id,name,set,rarity,cost,timing,duration,trigger,attributes,keywords,event_type,text,flavor,effect
 plague,Plague,alpha-1,epic,4,passive,2,,,,Catastrophe,Place on target location. All units at this location and adjacent locations get -2 strength. Discarded when the location is removed from the grid.,It spared no one.,
-golden-age,Golden Age,alpha-1,epic,5,passive,3,,,,Prosperity,You gain +1 gold per turn for 3 turns.,The coffers overflow and the people rejoice.,
 sprung-trap,Sprung Trap,alpha-1,uncommon,2,trap,,enemy_unit_enters_location,Military,,,When an enemy unit enters this location: injure that unit.,They never saw it coming.,
 diplomatic-summit,Diplomatic Summit,alpha-1,uncommon,2,passive,1,,Diplomacy,,,All Diplomacy units get +2 charisma for 1 turn.,Words sharper than any blade.,
 earthquake,Earthquake,alpha-1,epic,4,instant,,,,,Catastrophe,Remove target location from the grid. All units there are injured. Replacement is drawn.,The earth decides who stays.,injure(all + here) + remove(location)


### PR DESCRIPTION
## Summary

- Removes the `golden-age` event from the alpha-1 set — flagged as alpha-1's weakest card and slated for removal in the #45 in-place redesign.
- CSV-only cut: the card leaves the print-playtest set (build 66 → 65 cards). Build passes; the golden-age engine tests still pass (77/0).

## Deferred (intentional)

The engine factory (`engine/src/listeners/effects.ts`) and its tests are left in place and now orphaned. `owner-controller.test.ts` uses `golden-age` as its canonical player-tied passive-event exemplar, and the natural substitutes (`trade-goods`, `merchant-ledger`) are themselves slated to change in the events/items redesign — so the engine + test cleanup is deferred to the events-redesign pass, when a stable replacement exemplar is known.

## Context

Part of #45 (Refine alpha-1). First step of the "playable floor" phase, following the decision to redesign in-place and freeze the print baseline (tag `alpha-1-print-v0`).