### PR TITLE
244: Auto-save fails: structuredClone DataCloneError on session serialization

### DIFF
--- a/clients/web/src/lib/gameStore.svelte.ts
+++ b/clients/web/src/lib/gameStore.svelte.ts
@@ -403,7 +403,10 @@ function onEvent(events: GameEvent[], state: GameState): void {
   // Auto-save after every action
   if (controller) {
     try {
-      const session = structuredClone(controller.toSession(true, _eventLog));
+      // `_eventLog` is a Svelte `$state` proxy; `structuredClone` throws
+      // DataCloneError on reactive proxies, so snapshot it to plain data first
+      // (#244). The rest of the session is plain engine state.
+      const session = structuredClone(controller.toSession(true, $state.snapshot(_eventLog)));
       autoSave(session)
         .then(() => {
           autoSaveFailCount = 0;
@@ -649,7 +652,7 @@ export async function saveGame(name: string): Promise<void> {
     return;
   }
   try {
-    await saveSession(name, structuredClone(controller.toSession(true, _eventLog)));
+    await saveSession(name, structuredClone(controller.toSession(true, $state.snapshot(_eventLog))));
     await refreshSessions();
   } catch (err) {
     _error = `Failed to save game: ${err instanceof Error ? err.message : String(err)}`;

--- a/clients/web/src/lib/gameStore.svelte.ts
+++ b/clients/web/src/lib/gameStore.svelte.ts
@@ -404,10 +404,12 @@ function onEvent(events: GameEvent[], state: GameState): void {
   // Auto-save after every action
   if (controller) {
     try {
-      // `_eventLog` is a Svelte `$state` proxy; `structuredClone` throws
-      // DataCloneError on `$state` proxies, so snapshot it to plain data first
-      // (#244). The rest of the session is plain engine state.
-      const session: Session = structuredClone(controller.toSession(true, $state.snapshot(_eventLog)));
+      // Snapshot the session for persistence. `$state.snapshot` both unwraps the
+      // reactive `_eventLog` proxy — a bare `structuredClone` throws DataCloneError
+      // on `$state` proxies (#244) — and deep-clones the whole session to detach it
+      // from live engine state, in a single pass. The rest of the session is plain
+      // engine state.
+      const session: Session = $state.snapshot(controller.toSession(true, _eventLog));
       autoSave(session)
         .then(() => {
           autoSaveFailCount = 0;
@@ -422,9 +424,9 @@ function onEvent(events: GameEvent[], state: GameState): void {
           }
         });
     } catch (err) {
-      // Serialization (structuredClone of the session, including the god-view
-      // log) failed. Manual save runs the identical clone, so don't advise it —
-      // this is likely a bug worth reporting.
+      // Serialization (the `$state.snapshot` of the session, including the
+      // god-view log) failed. Manual save runs the identical snapshot, so don't
+      // advise it — this is likely a bug worth reporting.
       console.error("Failed to serialize session for auto-save:", err);
       autoSaveFailCount++;
       if (autoSaveFailCount >= 3) {
@@ -653,8 +655,9 @@ export async function saveGame(name: string): Promise<void> {
     return;
   }
   try {
-    // Snapshot the reactive `_eventLog` before cloning — see the auto-save site / #244.
-    await saveSession(name, structuredClone(controller.toSession(true, $state.snapshot(_eventLog))));
+    // `$state.snapshot` unwraps the reactive `_eventLog` and detaches the session
+    // in one pass — see the auto-save site / #244.
+    await saveSession(name, $state.snapshot(controller.toSession(true, _eventLog)));
     await refreshSessions();
   } catch (err) {
     _error = `Failed to save game: ${err instanceof Error ? err.message : String(err)}`;

--- a/clients/web/src/lib/gameStore.svelte.ts
+++ b/clients/web/src/lib/gameStore.svelte.ts
@@ -9,6 +9,7 @@ import {
   getVisibleEvent,
   type InvalidActionError,
   type PlayerDescriptor,
+  type Session,
   setAutoFreeze,
   type VisibleState,
 } from "cards-engine";
@@ -404,9 +405,9 @@ function onEvent(events: GameEvent[], state: GameState): void {
   if (controller) {
     try {
       // `_eventLog` is a Svelte `$state` proxy; `structuredClone` throws
-      // DataCloneError on reactive proxies, so snapshot it to plain data first
+      // DataCloneError on `$state` proxies, so snapshot it to plain data first
       // (#244). The rest of the session is plain engine state.
-      const session = structuredClone(controller.toSession(true, $state.snapshot(_eventLog)));
+      const session: Session = structuredClone(controller.toSession(true, $state.snapshot(_eventLog)));
       autoSave(session)
         .then(() => {
           autoSaveFailCount = 0;
@@ -652,6 +653,7 @@ export async function saveGame(name: string): Promise<void> {
     return;
   }
   try {
+    // Snapshot the reactive `_eventLog` before cloning — see the auto-save site / #244.
     await saveSession(name, structuredClone(controller.toSession(true, $state.snapshot(_eventLog))));
     await refreshSessions();
   } catch (err) {


### PR DESCRIPTION
## Summary

- Auto-save fails to serialize the game session: `structuredClone` throws `DataCloneError` ("[object Array] could not be cloned", naming `Window`) at `gameStore.svelte.ts:424`, via `GameController.onEvent` → `applyAction` → `playTurn`.
- A non-serializable reference (a closure / DOM / `Window` ref, or a function-bearing array) is reaching the auto-save `structuredClone`; the fix is to ensure the session/event state handed to persistence is plain, cloneable data.
- Auto-save / session persistence is a v0.1 playtest need; surfaced during web-client playtesting.

Related: #147 (event log empty after autosave reload), #224 (replay-based reconstruction), #88 (decouple engine state from Svelte reactive state — likely root-cause area). Not a duplicate of #147/#224.

Closes #244