### PR TITLE
Tooling: print pipeline — A3 card imposition + rules→A4 rulebook PDF

### DIFF
--- a/.claude/skills/penpot-card-renderer/SKILL.md
+++ b/.claude/skills/penpot-card-renderer/SKILL.md
@@ -81,7 +81,8 @@ renderer to see changes. Keyword reminder prose is composed from
 
 Two Penpot-independent tools produce a rough physical set from the rendered PNGs
 and the rules markdown (needs `pip install pillow markdown`; the rules tool also
-needs a Chrome/Chromium binary):
+needs a Chrome/Chromium binary, and optionally `pymupdf` for the contents page +
+page numbers):
 
 ```bash
 python3 design/impose-print.py                 # tile exports/<set>/*.png at true
@@ -93,9 +94,11 @@ python3 design/rules-to-a4.py --html-only      # HTML only (no Chrome)
 
 `impose-print.py` writes `exports/<set>/print/<set>-cards-<paper>.pdf`;
 `rules-to-a4.py` writes `exports/rules-A4.pdf`. The rules tool strips `[design:]`
-notes, renders `[var:...]` baselines as colour-coded chips, and adds a Symbols
-key reusing the card glyphs. Card backs aren't rendered, so sheets are
-single-sided (#218). Pure logic is covered by `design/test_print_tools.py`.
+notes, renders `[var:...]` baselines as colour-coded chips, adds a Symbols key
+reusing the card glyphs, and (with `pymupdf`) a front-page contents with page
+numbers, corner page numbers, and a PDF outline. Card backs aren't rendered, so
+sheets are single-sided (#218). Pure logic is covered by
+`design/test_print_tools.py`.
 
 ### 6. Inspect current Penpot state
 

--- a/.claude/skills/penpot-card-renderer/SKILL.md
+++ b/.claude/skills/penpot-card-renderer/SKILL.md
@@ -77,7 +77,27 @@ renderer to see changes. Keyword reminder prose is composed from
 `library/build/keywords.json`; its templates are the source of truth in
 `engine/src/keywords.ts` (rebuild with `bun library/build.ts`).
 
-### 5. Inspect current Penpot state
+### 5. Print-and-play output (A3 cards + A4 rules)
+
+Two Penpot-independent tools produce a rough physical set from the rendered PNGs
+and the rules markdown (needs `pip install pillow markdown`; the rules tool also
+needs a Chrome/Chromium binary):
+
+```bash
+python3 design/impose-print.py                 # tile exports/<set>/*.png at true
+                                               # poker size onto A3 + crop marks
+python3 design/impose-print.py alpha-1 --paper a4
+python3 design/rules-to-a4.py                  # rules/*.md -> A4 booklet PDF
+python3 design/rules-to-a4.py --html-only      # HTML only (no Chrome)
+```
+
+`impose-print.py` writes `exports/<set>/print/<set>-cards-<paper>.pdf`;
+`rules-to-a4.py` writes `exports/rules-A4.pdf`. The rules tool strips `[design:]`
+notes, renders `[var:...]` baselines as colour-coded chips, and adds a Symbols
+key reusing the card glyphs. Card backs aren't rendered, so sheets are
+single-sided (#218). Pure logic is covered by `design/test_print_tools.py`.
+
+### 6. Inspect current Penpot state
 
 ```python
 cd design && python3 -c "

--- a/.claude/skills/penpot-card-renderer/SKILL.md
+++ b/.claude/skills/penpot-card-renderer/SKILL.md
@@ -80,22 +80,22 @@ renderer to see changes. Keyword reminder prose is composed from
 ### 5. Print-and-play output (A3 cards + A4 rules)
 
 Two Penpot-independent tools produce a rough physical set from the rendered PNGs
-and the rules markdown (needs `pip install pillow markdown`; the rules tool also
-needs a Chrome/Chromium binary, and optionally `pymupdf` for the contents page +
-page numbers):
+and the rules markdown (install deps with `pip install -r design/requirements.txt`;
+the rules tool also needs a Chrome/Chromium binary, and optionally `pymupdf` for
+the contents page + page numbers):
 
 ```bash
 python3 design/impose-print.py                 # tile exports/<set>/*.png at true
-                                               # poker size onto A3 + crop marks
+                                               # physical size (poker + square) onto A3
 python3 design/impose-print.py alpha-1 --paper a4
-python3 design/rules-to-a4.py                  # rules/*.md -> A4 booklet PDF
+python3 design/rules-to-a4.py                  # core rules files -> A4 booklet PDF
 python3 design/rules-to-a4.py --html-only      # HTML only (no Chrome)
 ```
 
 `impose-print.py` writes `exports/<set>/print/<set>-cards-<paper>.pdf`;
 `rules-to-a4.py` writes `exports/rules-A4.pdf`. The rules tool strips `[design:]`
 notes, renders `[var:...]` baselines as colour-coded chips, adds a Symbols key
-reusing the card glyphs, and (with `pymupdf`) a front-page contents with page
+mirroring the card glyphs, and (with `pymupdf`) a front-page contents with page
 numbers, corner page numbers, and a PDF outline. Card backs aren't rendered, so
 sheets are single-sided (#218). Pure logic is covered by
 `design/test_print_tools.py`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,5 +40,8 @@ jobs:
       - name: Test (engine/web/test suites)
         run: bun --filter '*' test
 
+      - name: Install Python print-tooling deps
+        run: python3 -m pip install -r design/requirements.txt
+
       - name: Renderer smoke tests (Python)
         run: bun run test:renderer

--- a/design/README.md
+++ b/design/README.md
@@ -15,6 +15,9 @@ printable PNG images.
    `library/build/keywords.json` (run `bun library/build.ts` to regenerate).
 2. **`build-gallery.py`** — scans `exports/<set>/` and assembles a static HTML
    gallery; **`publish-gallery.sh`** publishes it to the `gh-pages` branch.
+3. **`impose-print.py`** / **`rules-to-a4.py`** — print-and-play output (see
+   [Printing](#printing)): tile rendered cards onto A3 cut-sheets, and typeset
+   the rules into an A4 booklet.
 
 Self-contained — the renderer carries its own colour palette and layout
 constants; it does not read `tokens.json`.
@@ -64,6 +67,29 @@ python3 design/moderntrek-template.py
 # …or another type / set:
 python3 design/moderntrek-template.py library/sets/alpha-1/locations.csv
 ```
+
+## Printing
+
+Turn rendered cards and the rules into a rough print-and-play set (e.g. an A3
+self-print at a library) before professional printing. Needs `Pillow` and
+`markdown` (`pip install pillow markdown`); the rules tool also needs a
+Chrome/Chromium binary for headless PDF printing.
+
+```bash
+# Card cut-sheets: tiles exports/<set>/*.png at true poker size onto A3 pages
+# with corner crop marks -> exports/<set>/print/<set>-cards-a3.pdf
+python3 design/impose-print.py                 # alpha-1, A3
+python3 design/impose-print.py alpha-1 --paper a4
+
+# Rules booklet: typesets rules/*.md into an A4 PDF — strips [design:] notes,
+# shows [var:...] baselines as colour-coded chips, and adds a Symbols key that
+# reuses the card glyphs -> exports/rules-A4.pdf
+python3 design/rules-to-a4.py
+python3 design/rules-to-a4.py --html-only      # emit HTML only (no Chrome needed)
+```
+
+Card **backs** aren't rendered yet, so the sheets are single-sided (see #218).
+Run the renderer first if `exports/<set>/` is empty.
 
 ## Detailed API patterns
 

--- a/design/README.md
+++ b/design/README.md
@@ -71,22 +71,24 @@ python3 design/moderntrek-template.py library/sets/alpha-1/locations.csv
 ## Printing
 
 Turn rendered cards and the rules into a rough print-and-play set (e.g. an A3
-self-print at a library) before professional printing. Needs `Pillow` and
-`markdown` (`pip install pillow markdown`); the rules tool also needs a
-Chrome/Chromium binary for headless PDF printing, and optionally `pymupdf`
-(`pip install pymupdf`) for the front-page table of contents with page numbers,
-corner page numbers, and a PDF outline.
+self-print at a library) before professional printing. Install the Python deps
+with `pip install -r design/requirements.txt` (Pillow + markdown; pymupdf
+optional). The rules tool also needs a Chrome/Chromium binary for headless PDF
+printing; with `pymupdf` installed it additionally builds a front-page table of
+contents with page numbers, corner page numbers, and a PDF outline.
 
 ```bash
-# Card cut-sheets: tiles exports/<set>/*.png at true poker size onto A3 pages
-# with corner crop marks -> exports/<set>/print/<set>-cards-a3.pdf
+# Card cut-sheets: tiles exports/<set>/*.png at true physical size (poker portrait
+# + square locations) onto A3 pages with corner crop marks
+# -> exports/<set>/print/<set>-cards-a3.pdf
 python3 design/impose-print.py                 # alpha-1, A3
 python3 design/impose-print.py alpha-1 --paper a4
 
-# Rules booklet: typesets rules/*.md into an A4 PDF — strips [design:] notes,
-# shows [var:...] baselines as colour-coded chips, a Symbols key reusing the card
-# glyphs, a front-page contents with page numbers, and corner page numbers
-# -> exports/rules-A4.pdf
+# Rules booklet: typesets the core rules files (README, attributes, stat-contests,
+# market, policies; meta files excluded) into an A4 PDF — strips [design:] notes,
+# shows [var:...] baselines as colour-coded chips, and a Symbols key mirroring the
+# card glyphs; with pymupdf, also a front-page contents with page numbers and
+# corner page numbers -> exports/rules-A4.pdf
 python3 design/rules-to-a4.py
 python3 design/rules-to-a4.py --html-only      # emit HTML only (no Chrome needed)
 ```

--- a/design/README.md
+++ b/design/README.md
@@ -73,7 +73,9 @@ python3 design/moderntrek-template.py library/sets/alpha-1/locations.csv
 Turn rendered cards and the rules into a rough print-and-play set (e.g. an A3
 self-print at a library) before professional printing. Needs `Pillow` and
 `markdown` (`pip install pillow markdown`); the rules tool also needs a
-Chrome/Chromium binary for headless PDF printing.
+Chrome/Chromium binary for headless PDF printing, and optionally `pymupdf`
+(`pip install pymupdf`) for the front-page table of contents with page numbers,
+corner page numbers, and a PDF outline.
 
 ```bash
 # Card cut-sheets: tiles exports/<set>/*.png at true poker size onto A3 pages
@@ -82,8 +84,9 @@ python3 design/impose-print.py                 # alpha-1, A3
 python3 design/impose-print.py alpha-1 --paper a4
 
 # Rules booklet: typesets rules/*.md into an A4 PDF — strips [design:] notes,
-# shows [var:...] baselines as colour-coded chips, and adds a Symbols key that
-# reuses the card glyphs -> exports/rules-A4.pdf
+# shows [var:...] baselines as colour-coded chips, a Symbols key reusing the card
+# glyphs, a front-page contents with page numbers, and corner page numbers
+# -> exports/rules-A4.pdf
 python3 design/rules-to-a4.py
 python3 design/rules-to-a4.py --html-only      # emit HTML only (no Chrome needed)
 ```

--- a/design/impose-print.py
+++ b/design/impose-print.py
@@ -28,30 +28,64 @@ EXPORTS = os.path.join(SCRIPT_DIR, "exports")
 PAPER = {"a3": (297, 420), "a4": (210, 297), "letter": (215.9, 279.4)}
 
 
-def layout(files, card_w, card_h, page_px, gutter, tick):
-    """Yield page images packing card_w x card_h cells with corner crop marks."""
+def make_rows(groups, page_w, gutter):
+    """Chunk each card size into full-width rows: {w, h, files}.
+
+    Cards of the same width share columns, so a row is `cols` cards of one size.
+    Rows of different heights can then coexist on a page (see paginate) — poker
+    and square cards are the same width here, so square rows top up the sheet the
+    tall cards leave partly empty instead of starting a fresh page.
+    """
+    rows = []
+    for (w, h) in sorted(groups, key=lambda s: -s[1]):        # tallest size first
+        cols = max(1, (page_w + gutter) // (w + gutter))
+        files = sorted(groups[(w, h)])
+        for i in range(0, len(files), cols):
+            rows.append({"w": w, "h": h, "files": files[i:i + cols]})
+    return rows
+
+
+def paginate(rows, budget_h, gutter):
+    """First-fit-decreasing pack rows (by height) into pages of budget_h.
+
+    Tall rows go down first; short rows fill the vertical gaps they leave, which
+    minimises the sheet count. Returns a list of pages, each a list of rows.
+    """
+    pages = []
+    for row in sorted(rows, key=lambda r: -r["h"]):
+        for page in pages:
+            used = sum(r["h"] for r in page) + gutter * (len(page) - 1)
+            if used + gutter + row["h"] <= budget_h:
+                page.append(row)
+                break
+        else:
+            pages.append([row])
+    return pages
+
+
+def draw_page(rows, page_px, gutter, tick):
+    """Render one page: rows stacked and vertically centred, cards left-to-right
+    within a row, each card cornered with crop marks."""
     pw, ph = page_px
-    cols = max(1, (pw + gutter) // (card_w + gutter))
-    rows = max(1, (ph + gutter) // (card_h + gutter))
-    per = cols * rows
-    grid_w = cols * card_w + (cols - 1) * gutter
-    grid_h = rows * card_h + (rows - 1) * gutter
-    ox = (pw - grid_w) // 2
-    oy = (ph - grid_h) // 2
-    for start in range(0, len(files), per):
-        page = Image.new("RGB", page_px, "white")
-        draw = ImageDraw.Draw(page)
-        for i, path in enumerate(files[start:start + per]):
-            r, c = divmod(i, cols)
-            x = ox + c * (card_w + gutter)
-            y = oy + r * (card_h + gutter)
+    rows = sorted(rows, key=lambda r: -r["h"])                # tall rows at the top
+    total_h = sum(r["h"] for r in rows) + gutter * (len(rows) - 1)
+    y = (ph - total_h) // 2
+    page = Image.new("RGB", page_px, "white")
+    draw = ImageDraw.Draw(page)
+    for row in rows:
+        w, h = row["w"], row["h"]
+        cols = max(1, (pw + gutter) // (w + gutter))
+        ox = (pw - (cols * w + (cols - 1) * gutter)) // 2
+        for c, path in enumerate(row["files"]):
+            x = ox + c * (w + gutter)
             page.paste(Image.open(path).convert("RGB"), (x, y))
-            for cx, cy in ((x, y), (x + card_w, y), (x, y + card_h), (x + card_w, y + card_h)):
+            for cx, cy in ((x, y), (x + w, y), (x, y + h), (x + w, y + h)):
                 sx = -1 if cx == x else 1
                 sy = -1 if cy == y else 1
                 draw.line([(cx + sx * 2, cy), (cx + sx * tick, cy)], fill="black", width=2)
                 draw.line([(cx, cy + sy * 2), (cx, cy + sy * tick)], fill="black", width=2)
-        yield page
+        y += h + gutter
+    return page
 
 
 def collect(set_name):
@@ -74,8 +108,9 @@ def main():
     args = ap.parse_args()
 
     mm = args.dpi / 25.4
-    page_px = tuple(round(d * mm) for d in PAPER[args.paper])
+    pw, ph = (round(d * mm) for d in PAPER[args.paper])
     gutter, tick = round(args.gutter_mm * mm), round(args.tick_mm * mm)
+    budget_h = ph - 2 * round(8 * mm)                          # keep an ~8mm top/bottom margin
 
     files = collect(args.set)
     if not files:
@@ -85,9 +120,8 @@ def main():
     for f in files:
         groups[Image.open(f).size].append(f)
 
-    pages = []
-    for size in sorted(groups, key=lambda s: -s[1]):          # tallest (portrait) first
-        pages += list(layout(sorted(groups[size]), size[0], size[1], page_px, gutter, tick))
+    layout = paginate(make_rows(groups, pw, gutter), budget_h, gutter)
+    pages = [draw_page(rows, (pw, ph), gutter, tick) for rows in layout]
 
     out = args.out or os.path.join(EXPORTS, args.set, "print",
                                    f"{args.set}-cards-{args.paper}.pdf")

--- a/design/impose-print.py
+++ b/design/impose-print.py
@@ -5,8 +5,10 @@ Reads `exports/<set>/<type>-<id>.png` (produced by moderntrek-template.py) and
 tiles the cards 1:1 — no scaling — onto A3 (default) pages with corner crop marks
 for guillotining, emitting a single print-ready PDF. The renderer emits 750x1050
 portrait cards and 750x750 square locations, which at 300 DPI are exactly
-63.5x88.9mm (standard poker) and 63.5mm square; cards of different sizes are
-grouped onto their own pages so every cell on a sheet cuts to the same size.
+63.5x88.9mm (standard poker) and 63.5mm square. Cards sharing a width share
+columns; rows of differing heights are then packed together onto each sheet
+(first-fit-decreasing) to minimise paper — so a single sheet may cut to two
+different card sizes (poker and square are the same width here).
 
 Usage:   cd design && python3 impose-print.py            # alpha-1 -> A3
          python3 impose-print.py alpha-1 --paper a4
@@ -26,6 +28,21 @@ EXPORTS = os.path.join(SCRIPT_DIR, "exports")
 
 # Paper sizes in millimetres (portrait).
 PAPER = {"a3": (297, 420), "a4": (210, 297), "letter": (215.9, 279.4)}
+
+MARGIN_MM = 8.0        # top/bottom margin kept clear of cards
+CARD_W_MM = 63.5       # every card (poker + square) is one poker-width wide
+
+
+def page_metrics(paper, dpi):
+    """Pixel page size and the usable vertical budget for a paper/DPI pair.
+
+    Extracted so tests can assert the same margin/budget math main() runs on,
+    instead of re-deriving it (and silently diverging when the formula changes).
+    """
+    mm = dpi / 25.4
+    pw, ph = (round(d * mm) for d in PAPER[paper])
+    budget_h = ph - 2 * round(MARGIN_MM * mm)
+    return pw, ph, budget_h
 
 
 def make_rows(groups, page_w, gutter):
@@ -74,11 +91,11 @@ def draw_page(rows, page_px, gutter, tick):
     draw = ImageDraw.Draw(page)
     for row in rows:
         w, h = row["w"], row["h"]
-        cols = max(1, (pw + gutter) // (w + gutter))
-        ox = (pw - (cols * w + (cols - 1) * gutter)) // 2
+        n = len(row["files"])                                 # center the row's actual
+        ox = (pw - (n * w + (n - 1) * gutter)) // 2           # cards, not a full column
         for c, path in enumerate(row["files"]):
             x = ox + c * (w + gutter)
-            page.paste(Image.open(path).convert("RGB"), (x, y))
+            page.paste(load_rgb(path), (x, y))
             for cx, cy in ((x, y), (x + w, y), (x, y + h), (x + w, y + h)):
                 sx = -1 if cx == x else 1
                 sy = -1 if cy == y else 1
@@ -96,6 +113,44 @@ def collect(set_name):
     return sorted(f for f in glob.glob(os.path.join(set_dir, "*.png")))
 
 
+def image_size(path):
+    """(w, h) of a PNG, exiting with the filename on a corrupt/truncated file."""
+    try:
+        with Image.open(path) as im:
+            return im.size
+    except (OSError, ValueError) as e:                        # incl. UnidentifiedImageError
+        sys.exit(f"Could not read card image {path}: {e}")
+
+
+def load_rgb(path):
+    """Open and decode a card PNG as RGB, exiting with the filename on error."""
+    try:
+        with Image.open(path) as im:
+            return im.convert("RGB")
+    except (OSError, ValueError) as e:
+        sys.exit(f"Could not read card image {path}: {e}")
+
+
+def validate_sizes(groups, pw, budget_h, dpi):
+    """Fail loudly on cards that can't be placed 1:1, or that look mis-scaled.
+
+    An oversized card would otherwise be silently clipped by draw_page (negative
+    offsets push it and its crop marks off the sheet); a card whose width doesn't
+    match CARD_W_MM at this DPI means the PNGs and --dpi disagree, so the "true
+    physical size" guarantee is void — warn rather than print the wrong size.
+    """
+    expected_w = round(CARD_W_MM * dpi / 25.4)
+    for (w, h), files in groups.items():
+        if w > pw or h > budget_h:
+            sys.exit(f"Card {w}x{h}px does not fit a {pw}px-wide sheet with a "
+                     f"{budget_h}px vertical budget (e.g. {files[0]}). "
+                     f"Use larger --paper or a lower --dpi.")
+        if abs(w - expected_w) > 2:
+            print(f"warning: card width {w}px != {expected_w}px expected for "
+                  f"{CARD_W_MM}mm at {dpi} DPI — cards may print at the wrong "
+                  f"physical size (e.g. {files[0]}).", file=sys.stderr)
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -108,9 +163,8 @@ def main():
     args = ap.parse_args()
 
     mm = args.dpi / 25.4
-    pw, ph = (round(d * mm) for d in PAPER[args.paper])
+    pw, ph, budget_h = page_metrics(args.paper, args.dpi)
     gutter, tick = round(args.gutter_mm * mm), round(args.tick_mm * mm)
-    budget_h = ph - 2 * round(8 * mm)                          # keep an ~8mm top/bottom margin
 
     files = collect(args.set)
     if not files:
@@ -118,15 +172,18 @@ def main():
 
     groups = collections.defaultdict(list)
     for f in files:
-        groups[Image.open(f).size].append(f)
+        groups[image_size(f)].append(f)
+    validate_sizes(groups, pw, budget_h, args.dpi)
 
     layout = paginate(make_rows(groups, pw, gutter), budget_h, gutter)
     pages = [draw_page(rows, (pw, ph), gutter, tick) for rows in layout]
 
     out = args.out or os.path.join(EXPORTS, args.set, "print",
                                    f"{args.set}-cards-{args.paper}.pdf")
-    os.makedirs(os.path.dirname(out), exist_ok=True)
+    os.makedirs(os.path.dirname(os.path.abspath(out)), exist_ok=True)
     pages[0].save(out, save_all=True, append_images=pages[1:], resolution=args.dpi)
+    if not os.path.getsize(out):
+        sys.exit(f"Wrote an empty PDF to {out} — imposition produced no output.")
     print(f"{len(files)} cards -> {len(pages)} {args.paper.upper()} page(s) -> {out}")
 
 

--- a/design/impose-print.py
+++ b/design/impose-print.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Impose already-rendered card PNGs onto print sheets at true physical size.
+
+Reads `exports/<set>/<type>-<id>.png` (produced by moderntrek-template.py) and
+tiles the cards 1:1 — no scaling — onto A3 (default) pages with corner crop marks
+for guillotining, emitting a single print-ready PDF. The renderer emits 750x1050
+portrait cards and 750x750 square locations, which at 300 DPI are exactly
+63.5x88.9mm (standard poker) and 63.5mm square; cards of different sizes are
+grouped onto their own pages so every cell on a sheet cuts to the same size.
+
+Usage:   cd design && python3 impose-print.py            # alpha-1 -> A3
+         python3 impose-print.py alpha-1 --paper a4
+         python3 impose-print.py alpha-1 --out /tmp/cards.pdf
+"""
+
+import argparse
+import collections
+import glob
+import os
+import sys
+
+from PIL import Image, ImageDraw
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+EXPORTS = os.path.join(SCRIPT_DIR, "exports")
+
+# Paper sizes in millimetres (portrait).
+PAPER = {"a3": (297, 420), "a4": (210, 297), "letter": (215.9, 279.4)}
+
+
+def layout(files, card_w, card_h, page_px, gutter, tick):
+    """Yield page images packing card_w x card_h cells with corner crop marks."""
+    pw, ph = page_px
+    cols = max(1, (pw + gutter) // (card_w + gutter))
+    rows = max(1, (ph + gutter) // (card_h + gutter))
+    per = cols * rows
+    grid_w = cols * card_w + (cols - 1) * gutter
+    grid_h = rows * card_h + (rows - 1) * gutter
+    ox = (pw - grid_w) // 2
+    oy = (ph - grid_h) // 2
+    for start in range(0, len(files), per):
+        page = Image.new("RGB", page_px, "white")
+        draw = ImageDraw.Draw(page)
+        for i, path in enumerate(files[start:start + per]):
+            r, c = divmod(i, cols)
+            x = ox + c * (card_w + gutter)
+            y = oy + r * (card_h + gutter)
+            page.paste(Image.open(path).convert("RGB"), (x, y))
+            for cx, cy in ((x, y), (x + card_w, y), (x, y + card_h), (x + card_w, y + card_h)):
+                sx = -1 if cx == x else 1
+                sy = -1 if cy == y else 1
+                draw.line([(cx + sx * 2, cy), (cx + sx * tick, cy)], fill="black", width=2)
+                draw.line([(cx, cy + sy * 2), (cx, cy + sy * tick)], fill="black", width=2)
+        yield page
+
+
+def collect(set_name):
+    """Top-level card PNGs for a set (skips subdirs like print/ and _archive)."""
+    set_dir = os.path.join(EXPORTS, set_name)
+    if not os.path.isdir(set_dir):
+        sys.exit(f"No exports for set '{set_name}' at {set_dir} — run the renderer first.")
+    return sorted(f for f in glob.glob(os.path.join(set_dir, "*.png")))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("set", nargs="?", default="alpha-1", help="card set (default: alpha-1)")
+    ap.add_argument("--paper", choices=PAPER, default="a3", help="paper size (default: a3)")
+    ap.add_argument("--dpi", type=int, default=300, help="render DPI (default: 300)")
+    ap.add_argument("--gutter-mm", type=float, default=4.0, help="gap between cards (default: 4)")
+    ap.add_argument("--tick-mm", type=float, default=3.0, help="crop-mark length (default: 3)")
+    ap.add_argument("--out", help="output PDF (default: exports/<set>/print/<set>-cards-<paper>.pdf)")
+    args = ap.parse_args()
+
+    mm = args.dpi / 25.4
+    page_px = tuple(round(d * mm) for d in PAPER[args.paper])
+    gutter, tick = round(args.gutter_mm * mm), round(args.tick_mm * mm)
+
+    files = collect(args.set)
+    if not files:
+        sys.exit(f"No card PNGs under {os.path.join(EXPORTS, args.set)}.")
+
+    groups = collections.defaultdict(list)
+    for f in files:
+        groups[Image.open(f).size].append(f)
+
+    pages = []
+    for size in sorted(groups, key=lambda s: -s[1]):          # tallest (portrait) first
+        pages += list(layout(sorted(groups[size]), size[0], size[1], page_px, gutter, tick))
+
+    out = args.out or os.path.join(EXPORTS, args.set, "print",
+                                   f"{args.set}-cards-{args.paper}.pdf")
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+    pages[0].save(out, save_all=True, append_images=pages[1:], resolution=args.dpi)
+    print(f"{len(files)} cards -> {len(pages)} {args.paper.upper()} page(s) -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/design/requirements.txt
+++ b/design/requirements.txt
@@ -1,0 +1,8 @@
+# Python deps for the print-and-play tooling
+# (design/impose-print.py, design/rules-to-a4.py).
+Pillow
+markdown
+# Optional at runtime: enables the rules booklet's front-page TOC page numbers,
+# corner page stamps, and PDF outline. Without it a number-less booklet is still
+# produced. Installed by `pip install -r` so CI/local get the full feature set.
+pymupdf

--- a/design/rules-to-a4.py
+++ b/design/rules-to-a4.py
@@ -12,7 +12,13 @@ cleanly on paper:
   - reuse the card renderer's glyphs (gold cost coin, STR/CUN/CHA stat chips,
     rarity gems, AP/VP badges) in a Symbols key and inline for AP/VP
 
-Requires the `markdown` package and a Chrome/Chromium binary (for --print-to-pdf).
+With PyMuPDF present it also builds a front-page table of contents with real page
+numbers (two-pass render: measure heading pages, then re-render), stamps a page
+number in the bottom-right of every page, and adds a PDF outline. Without it, the
+PDF is still produced — just with a number-less contents list and no page numbers.
+
+Requires the `markdown` package and a Chrome/Chromium binary (for --print-to-pdf);
+`pymupdf` is optional (enables the TOC page numbers, page stamps, and outline).
 
 Usage:   cd design && python3 rules-to-a4.py
          python3 rules-to-a4.py --out /tmp/rules.pdf
@@ -133,8 +139,15 @@ CSS = """
 *{ -webkit-print-color-adjust:exact; print-color-adjust:exact; }
 html{ font-size:10.5pt; }
 body{ font-family:-apple-system,"Helvetica Neue",Arial,sans-serif; color:var(--ink); line-height:1.5; }
-.chapter{ page-break-before:always; }
-.chapter:first-of-type{ page-break-before:avoid; }
+/* Front matter (title+TOC, symbols key) each own a page; the rule chapters flow
+   so short files don't each waste a page. Widow/orphan + break-after control
+   stops a lone word or heading spilling onto an otherwise-blank page. */
+.front{ page-break-after:always; }
+.keypage{ page-break-after:always; }
+.chapter + .chapter h1{ margin-top:1.6em; }
+h1,h2,h3,h4{ break-after:avoid; }
+p,li{ orphans:2; widows:2; }
+table,blockquote{ break-inside:avoid; }
 h1{ font-size:20pt; color:var(--navy); margin:0 0 .5em; letter-spacing:-.01em;
   border-bottom:2.5px solid var(--limebright); padding-bottom:.18em; }
 h2{ font-size:15pt; color:var(--navy); margin:1.4em 0 .35em;
@@ -175,28 +188,40 @@ tr:nth-child(even) td{ background:#f6f8fc; }
 .lede{ color:#33435f; }
 .note{ background:var(--varbg); border:1px solid #bfe0f5; border-radius:6px; padding:.5em .9em; margin:.7em 0; }
 .note p{ margin:0; }
-.title{ page-break-before:avoid; }
-.titlewrap{ margin-top:32mm; border-top:3px solid var(--limebright);
-  border-bottom:3px solid var(--limebright); padding:14mm 0; }
+.titlewrap{ border-top:3px solid var(--limebright);
+  border-bottom:3px solid var(--limebright); padding:9mm 0; margin-bottom:8mm; }
 .kicker{ text-transform:uppercase; letter-spacing:.25em; color:var(--muted); font-size:11pt; font-weight:700; }
-.booktitle{ font-size:52pt; border:none; margin:.1em 0; color:var(--navy); letter-spacing:-.02em; }
-.subtitle{ font-size:15pt; color:#33435f; }
-.foot{ margin-top:8mm; color:var(--muted); font-size:10pt; }
+.booktitle{ font-size:42pt; border:none; margin:.08em 0; color:var(--navy); letter-spacing:-.02em; }
+.subtitle{ font-size:14pt; color:#33435f; }
+.foot{ margin-top:5mm; color:var(--muted); font-size:10pt; }
+/* front-page table of contents: name — dotted leader — page number */
+.toc-h{ font-size:12pt; text-transform:uppercase; letter-spacing:.14em;
+  color:var(--muted); font-weight:700; margin:0 0 .6em; }
+.toc-row{ display:flex; align-items:baseline; margin:.16em 0; font-size:10.5pt; }
+.toc-row .nm{ color:var(--navy); }
+.toc-row .dots{ flex:1; margin:0 .5em; border-bottom:1px dotted #b7c1d3; transform:translateY(-.18em); }
+.toc-row .pg{ color:var(--muted); font-variant-numeric:tabular-nums; }
+.toc-row.l1{ margin-top:.55em; }
+.toc-row.l1 .nm{ font-weight:700; }
+.toc-row.l2{ padding-left:1.1em; }
+.toc-row.l2 .nm{ color:#33435f; }
 """
 
-TITLE = """
-<section class="chapter title">
+FRONT = """
+<section class="front">
   <div class="titlewrap">
     <div class="kicker">Card Game &mdash; {set_name}</div>
     <h1 class="booktitle">Rules</h1>
     <div class="subtitle">Master rules, typeset for print</div>
     <div class="foot">Baseline variant &middot; values shown are the shipped defaults</div>
   </div>
+  <div class="toc-h">Contents</div>
+  {toc}
 </section>
 """
 
 KEY = """
-<section class="chapter keypage">
+<section class="keypage">
   <h1>Symbols &amp; Notation</h1>
   <p class="lede">This booklet is the game's design rules, typeset for reading.
   Two conventions to know before you start:</p>
@@ -236,18 +261,94 @@ KEY = """
 """
 
 
-def build_html(rules_dir, set_name):
+def build_chapters(rules_dir):
+    """Return (chapters_html, headings) where headings is an ordered list of
+    (level, text) for every h1/h2 — the entries the TOC is built from."""
     import markdown
     md = markdown.Markdown(extensions=["extra", "toc", "attr_list"], tab_length=2)
-    chapters = []
+    chapters, headings = [], []
+
+    def walk(tokens):
+        for t in tokens:
+            if t["level"] <= 2:
+                headings.append((t["level"], t["name"]))
+            walk(t.get("children", []))
+
     for fn in FILES:
         with open(os.path.join(rules_dir, fn)) as f:
             md.reset()
             chapters.append(f'<section class="chapter">'
                             f'{badge_inline_stats(md.convert(transform(f.read())))}</section>')
+            walk(md.toc_tokens)
+    return "".join(chapters), headings
+
+
+def toc_html(entries):
+    """entries: list of (level, text, page-or-None) -> front-page TOC rows."""
+    rows = []
+    for level, text, page in entries:
+        pg = "" if page is None else str(page)
+        rows.append(f'<div class="toc-row l{level}"><span class="nm">{text}</span>'
+                    f'<span class="dots"></span><span class="pg">{pg}</span></div>')
+    return "".join(rows)
+
+
+def build_html(chapters, front_toc, set_name):
     return (f'<!doctype html><html><head><meta charset="utf-8">'
             f'<title>Card Game — Rules ({set_name})</title><style>{CSS}</style></head>'
-            f'<body>{TITLE.format(set_name=set_name)}{KEY}{"".join(chapters)}</body></html>')
+            f'<body>{FRONT.format(set_name=set_name, toc=front_toc)}{KEY}{chapters}</body></html>')
+
+
+def render_pdf(chrome, html_path, pdf_path):
+    subprocess.run([chrome, "--headless=new", "--disable-gpu", "--no-pdf-header-footer",
+                    f"--print-to-pdf={pdf_path}", f"file://{os.path.abspath(html_path)}"],
+                   check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def locate_headings(pdf_path, headings):
+    """0-based page index of each heading, found by scanning forward.
+
+    Matches on heading-sized spans (h1=20pt, h2=15pt; body is 10.5pt) rather than
+    a plain text search — otherwise the same names printed in the TOC or in body
+    prose would match before the actual heading.
+    """
+    import fitz
+    doc = fitz.open(pdf_path)
+    big = []                                           # per page: set of heading texts
+    for pg in doc:
+        texts = set()
+        for blk in pg.get_text("dict")["blocks"]:
+            for line in blk.get("lines", []):
+                for span in line["spans"]:
+                    if span["size"] >= 13:
+                        texts.add(span["text"].strip())
+        big.append(texts)
+    pages, cursor = [], 0
+    for _level, text in headings:
+        found = next((p for p in range(cursor, doc.page_count) if text in big[p]), cursor)
+        pages.append(found)
+        cursor = found
+    doc.close()
+    return pages
+
+
+def finalize_pdf(pdf_path, entries):
+    """Stamp a page number bottom-right on every page but the front, and add a
+    PDF outline from the located headings. entries: (level, text, page1based)."""
+    import fitz
+    doc = fitz.open(pdf_path)
+    for i, page in enumerate(doc):
+        if i == 0:
+            continue                                   # front/TOC page stays unnumbered
+        box = fitz.Rect(page.rect.width - 60, page.rect.height - 34,
+                        page.rect.width - 18, page.rect.height - 18)
+        page.insert_textbox(box, str(i + 1), fontsize=9, fontname="helv",
+                            color=(0.42, 0.47, 0.55), align=fitz.TEXT_ALIGN_RIGHT)
+    doc.set_toc([[level, text, page] for level, text, page in entries])
+    tmp = pdf_path + ".tmp"
+    doc.save(tmp, garbage=4, deflate=True)
+    doc.close()
+    os.replace(tmp, pdf_path)
 
 
 def main():
@@ -262,14 +363,18 @@ def main():
     args = ap.parse_args()
 
     try:
-        html = build_html(args.rules_dir, args.set)
+        chapters, headings = build_chapters(args.rules_dir)
     except ModuleNotFoundError:
         sys.exit("The 'markdown' package is required: pip install markdown")
 
     os.makedirs(os.path.dirname(os.path.abspath(args.out)), exist_ok=True)
     html_path = os.path.splitext(args.out)[0] + ".html"
+
+    # Without page numbers yet, the TOC lists section names only. --html-only
+    # (screen use) stops here; the print path fills the page numbers below.
+    plain_toc = toc_html([(lvl, txt, None) for lvl, txt in headings])
     with open(html_path, "w") as f:
-        f.write(html)
+        f.write(build_html(chapters, plain_toc, args.set))
 
     if args.html_only:
         print(f"HTML -> {html_path}")
@@ -279,10 +384,31 @@ def main():
     if not chrome:
         sys.exit("No Chrome/Chromium found. Set CHROME_BIN or pass --chrome; "
                  f"HTML was written to {html_path}.")
-    subprocess.run([chrome, "--headless=new", "--disable-gpu", "--no-pdf-header-footer",
-                    f"--print-to-pdf={args.out}", f"file://{os.path.abspath(html_path)}"],
-                   check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    print(f"Rules -> {args.out}")
+
+    try:
+        import fitz  # noqa: F401
+    except ModuleNotFoundError:
+        # No PyMuPDF: still produce a PDF, just without page numbers / a paginated
+        # TOC. The front page then carries the section list without numbers.
+        render_pdf(chrome, html_path, args.out)
+        print(f"Rules -> {args.out}  (install pymupdf for page numbers + TOC pages)")
+        return
+
+    # Pass 1: render with a number-less TOC to measure where each heading lands.
+    # The front page is forced to exactly one page (page-break-after), so filling
+    # the TOC in pass 2 can't shift any later page — the measured pages stay valid.
+    scratch = os.path.splitext(args.out)[0] + ".pass1.pdf"
+    render_pdf(chrome, html_path, scratch)
+    pages = locate_headings(scratch, headings)                 # 0-based indices
+    os.remove(scratch)
+    entries = [(lvl, txt, pg + 1) for (lvl, txt), pg in zip(headings, pages)]
+
+    # Pass 2: re-render with page numbers in the TOC, then stamp + outline.
+    with open(html_path, "w") as f:
+        f.write(build_html(chapters, toc_html(entries), args.set))
+    render_pdf(chrome, html_path, args.out)
+    finalize_pdf(args.out, entries)
+    print(f"Rules -> {args.out}  ({len(entries)} TOC entries)")
 
 
 if __name__ == "__main__":

--- a/design/rules-to-a4.py
+++ b/design/rules-to-a4.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Build a printable A4 rulebook PDF from the rules/ markdown.
+
+This is a print artifact, not a rewrite: the prose is the real rules text,
+typeset for reading. It applies these transforms so the design document reads
+cleanly on paper:
+
+  - strip [design:...] commentary (balanced brackets; they nest [var:...])
+  - drop [var:section-id] heading markers (variant-section flags, no value)
+  - replace [var:id:baseline] -> the baseline value, colour-coded so a reader
+    sees at a glance which numbers are variant-tunable
+  - reuse the card renderer's glyphs (gold cost coin, STR/CUN/CHA stat chips,
+    rarity gems, AP/VP badges) in a Symbols key and inline for AP/VP
+
+Requires the `markdown` package and a Chrome/Chromium binary (for --print-to-pdf).
+
+Usage:   cd design && python3 rules-to-a4.py
+         python3 rules-to-a4.py --out /tmp/rules.pdf
+         python3 rules-to-a4.py --html-only        # emit HTML, skip the PDF step
+"""
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+RULES_DIR = os.path.join(SCRIPT_DIR, "..", "rules")
+
+# Reading order: master doc first, then the deeper files it links to. Meta files
+# (design-principles, ideas, CLAUDE) are intentionally excluded — not gameplay.
+FILES = ["README.md", "attributes.md", "stat-contests.md", "market.md", "policies.md"]
+
+_LIST = re.compile(r"^\s*([-*+]|\d+\.)\s+")
+
+
+def strip_design(text):
+    """Remove every [design: ... ] block, honouring nested [ ] (they contain vars)."""
+    out, i, n = [], 0, len(text)
+    while i < n:
+        if text.startswith("[design:", i):
+            depth, j = 1, i + 1
+            while j < n and depth:
+                depth += {"[": 1, "]": -1}.get(text[j], 0)
+                j += 1
+            i = j
+            while i < n and text[i] == " ":       # swallow a trailing space
+                i += 1
+        else:
+            out.append(text[i])
+            i += 1
+    text = "".join(out)
+    text = re.sub(r"(?m)^[ \t]*[-*][ \t]*$\n?", "", text)   # drop now-empty list items
+    return re.sub(r"\n{3,}", "\n\n", text)
+
+
+def blank_before_lists(text):
+    """Insert a blank line before a list that directly follows a paragraph line.
+
+    Several sections start a list on the line right after prose (e.g. "Main Phase
+    with:" then "- ..."); markdown only opens a list after a blank line, so
+    without this the bullets collapse into the paragraph. The previous line is
+    left untouched when it is itself a list item (real nesting) or a heading.
+    """
+    lines, out = text.split("\n"), []
+    for i, ln in enumerate(lines):
+        if i and _LIST.match(ln):
+            prev = lines[i - 1]
+            if prev.strip() and not _LIST.match(prev) and not prev.lstrip().startswith("#") \
+                    and out and out[-1].strip():
+                out.append("")
+        out.append(ln)
+    return "\n".join(out)
+
+
+def transform(text):
+    text = strip_design(text)
+    text = blank_before_lists(text)
+    text = re.sub(r"\[\[([a-z_]+)\]\]", r"\1", text)                # [[controller]] -> controller
+    text = re.sub(r"[ \t]*\[var:[a-z0-9_-]+\](?=\s|$)", "", text)   # section markers (no value)
+
+    def var(m):
+        vid, val = m.group(1), m.group(2)
+        return (f'<span class="var" title="Variant-tunable ({vid}); baseline value shown">'
+                f'{val}</span>')
+    text = re.sub(r"\[var:([a-z_]+):([^\]]+)\]", var, text)         # [var:id:value] -> value
+
+    # Cross-file links become in-document anchors (harmless on paper either way).
+    return re.sub(r"\]\([a-z0-9_-]+\.md(#[a-z0-9-]+)?\)",
+                  lambda m: f"]({m.group(1) or '#top'})", text)
+
+
+def badge_inline_stats(html):
+    """Wrap standalone AP / VP tokens in glyph badges, skipping tag interiors."""
+    parts = re.split(r"(<[^>]+>)", html)
+    for k in range(0, len(parts), 2):                              # even = text between tags
+        parts[k] = re.sub(r"\bAP\b", '<span class="ico ap">AP</span>', parts[k])
+        parts[k] = re.sub(r"\bVP\b", '<span class="ico vp">VP</span>', parts[k])
+    return "".join(parts)
+
+
+def find_chrome(override=None):
+    """Locate a Chrome/Chromium binary for headless PDF printing."""
+    for cand in filter(None, [override, os.environ.get("CHROME_BIN")]):
+        if os.path.isfile(cand):
+            return cand
+    names = ["google-chrome", "google-chrome-stable", "chromium", "chromium-browser"]
+    paths = [
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    ]
+    for name in names:
+        found = shutil.which(name)
+        if found:
+            return found
+    for p in paths:
+        if os.path.isfile(p):
+            return p
+    return None
+
+
+CSS = """
+:root{
+  --ink:#16203a; --navy:#0f1a2e; --panel:#1c2a48; --muted:#5b6b86;
+  --line:#d7deea; --limebright:#c8f562;
+  --var:#0e6ba8; --varbg:#e6f2fb;
+  --str:#d23c33; --cun:#2e7bd6; --cha:#6f8f16;
+  --gold1:#ffe9a8; --gold2:#f4c24a; --gold3:#a3761a;
+}
+@page{ size:A4; margin:20mm 18mm; }
+*{ -webkit-print-color-adjust:exact; print-color-adjust:exact; }
+html{ font-size:10.5pt; }
+body{ font-family:-apple-system,"Helvetica Neue",Arial,sans-serif; color:var(--ink); line-height:1.5; }
+.chapter{ page-break-before:always; }
+.chapter:first-of-type{ page-break-before:avoid; }
+h1{ font-size:20pt; color:var(--navy); margin:0 0 .5em; letter-spacing:-.01em;
+  border-bottom:2.5px solid var(--limebright); padding-bottom:.18em; }
+h2{ font-size:15pt; color:var(--navy); margin:1.4em 0 .35em;
+  border-bottom:1px solid var(--line); padding-bottom:.12em; }
+h3{ font-size:12.5pt; color:var(--panel); margin:1.15em 0 .3em; }
+h4{ font-size:11pt; color:var(--panel); margin:1em 0 .25em; text-transform:uppercase; letter-spacing:.04em; }
+p{ margin:.5em 0; }
+ul,ol{ margin:.4em 0 .6em 1.3em; padding:0; }
+li{ margin:.18em 0; }
+strong,b{ color:var(--navy); }
+a{ color:var(--navy); text-decoration:none; border-bottom:1px dotted #9fb0c8; }
+blockquote{ margin:.7em 0; padding:.4em .9em; background:#f4f7fb;
+  border-left:3px solid var(--cun); color:#33435f; border-radius:0 4px 4px 0; }
+blockquote p{ margin:.25em 0; }
+code{ font-family:ui-monospace,"SF Mono",Menlo,monospace; font-size:.9em;
+  background:#eef2f8; padding:.05em .35em; border-radius:3px; }
+table{ border-collapse:collapse; width:100%; margin:.6em 0; font-size:9.6pt; }
+th,td{ border:1px solid var(--line); padding:.34em .5em; text-align:left; vertical-align:top; }
+th{ background:var(--navy); color:#fff; font-weight:600; }
+tr:nth-child(even) td{ background:#f6f8fc; }
+.var{ color:var(--var); background:var(--varbg); font-weight:700;
+  padding:0 .28em; border-radius:3px; white-space:nowrap; }
+.ico{ display:inline-block; font-weight:800; font-size:.82em; line-height:1;
+  padding:.18em .34em; border-radius:4px; vertical-align:baseline; letter-spacing:.02em; }
+.ico.ap{ background:var(--limebright); color:#33430a; }
+.ico.vp{ background:var(--navy); color:#fff; }
+.coin{ display:inline-flex; align-items:center; justify-content:center;
+  width:1.7em; height:1.7em; border-radius:50%; font-weight:800; color:#3a2205;
+  background:radial-gradient(circle at 38% 32%, var(--gold1), var(--gold2) 55%, var(--gold3));
+  border:1px solid #8a6522; box-shadow:inset 0 0 2px rgba(255,255,255,.6); }
+.stat{ display:inline-block; font-weight:800; font-size:.8em; color:#fff; padding:.16em .4em; border-radius:4px; }
+.stat.str{ background:var(--str); } .stat.cun{ background:var(--cun); } .stat.cha{ background:var(--cha); }
+.gem{ font-size:1.15em; }
+.gem.common{ color:#6c7486; } .gem.uncommon{ color:#4a8fd1; }
+.gem.epic{ color:#d9a441; } .gem.legendary{ color:#d9a441; }
+.keytable td{ border:none; border-bottom:1px solid var(--line); padding:.55em .4em; }
+.keytable td.sym{ width:5.2em; text-align:center; white-space:nowrap; font-size:1.05em; }
+.lede{ color:#33435f; }
+.note{ background:var(--varbg); border:1px solid #bfe0f5; border-radius:6px; padding:.5em .9em; margin:.7em 0; }
+.note p{ margin:0; }
+.title{ page-break-before:avoid; }
+.titlewrap{ margin-top:32mm; border-top:3px solid var(--limebright);
+  border-bottom:3px solid var(--limebright); padding:14mm 0; }
+.kicker{ text-transform:uppercase; letter-spacing:.25em; color:var(--muted); font-size:11pt; font-weight:700; }
+.booktitle{ font-size:52pt; border:none; margin:.1em 0; color:var(--navy); letter-spacing:-.02em; }
+.subtitle{ font-size:15pt; color:#33435f; }
+.foot{ margin-top:8mm; color:var(--muted); font-size:10pt; }
+"""
+
+TITLE = """
+<section class="chapter title">
+  <div class="titlewrap">
+    <div class="kicker">Card Game &mdash; {set_name}</div>
+    <h1 class="booktitle">Rules</h1>
+    <div class="subtitle">Master rules, typeset for print</div>
+    <div class="foot">Baseline variant &middot; values shown are the shipped defaults</div>
+  </div>
+</section>
+"""
+
+KEY = """
+<section class="chapter keypage">
+  <h1>Symbols &amp; Notation</h1>
+  <p class="lede">This booklet is the game's design rules, typeset for reading.
+  Two conventions to know before you start:</p>
+  <div class="note">
+    <p><b>Colour-coded numbers</b> like <span class="var">50</span> are
+    <b>variant-tunable</b> baseline values &mdash; the default the game ships with, which
+    an alternate variant may change. Read them as ordinary numbers; the colour just
+    flags "this knob can move."</p>
+  </div>
+  <p class="lede">The icons below mirror what is printed on the cards.</p>
+  <table class="keytable">
+    <tr><td class="sym"><span class="coin">6</span></td>
+        <td><b>Cost / Gold</b><br>The gold coin is a card's cost and the game's
+        currency. Pay it to Buy from the market and to Deploy cards; earn it from
+        income, missions, and policies.</td></tr>
+    <tr><td class="sym"><span class="ico ap">AP</span></td>
+        <td><b>Action Points</b><br><span class="var">3</span> per turn. Nearly every
+        action (Deploy, Move, Attack, Attempt Mission&hellip;) costs AP.</td></tr>
+    <tr><td class="sym"><span class="ico vp">VP</span></td>
+        <td><b>Victory Points</b><br>Reach <span class="var">50</span> to win. Mostly
+        earned by completing mission locations.</td></tr>
+    <tr><td class="sym"><span class="stat str">STR</span></td>
+        <td><b>Strength</b><br>The combat stat &mdash; drives the Attack action and
+        strength contests (injure / kill).</td></tr>
+    <tr><td class="sym"><span class="stat cun">CUN</span></td>
+        <td><b>Cunning</b><br>A contest / check stat.</td></tr>
+    <tr><td class="sym"><span class="stat cha">CHA</span></td>
+        <td><b>Charisma</b><br>A contest / check stat; Untouchable keys off it in v0.1.</td></tr>
+    <tr><td class="sym"><span class="gem common">&#9679;</span>
+                        <span class="gem uncommon">&#9671;</span>
+                        <span class="gem epic">&#9670;</span>
+                        <span class="gem legendary">&#9733;</span></td>
+        <td><b>Rarity</b><br>Common &#9679; &nbsp; Uncommon &#9671; &nbsp; Epic &#9670;
+        &nbsp; Legendary &#9733;. Affects deck-building limits only &mdash; not cost or power.</td></tr>
+  </table>
+</section>
+"""
+
+
+def build_html(rules_dir, set_name):
+    import markdown
+    md = markdown.Markdown(extensions=["extra", "toc", "attr_list"], tab_length=2)
+    chapters = []
+    for fn in FILES:
+        with open(os.path.join(rules_dir, fn)) as f:
+            md.reset()
+            chapters.append(f'<section class="chapter">'
+                            f'{badge_inline_stats(md.convert(transform(f.read())))}</section>')
+    return (f'<!doctype html><html><head><meta charset="utf-8">'
+            f'<title>Card Game — Rules ({set_name})</title><style>{CSS}</style></head>'
+            f'<body>{TITLE.format(set_name=set_name)}{KEY}{"".join(chapters)}</body></html>')
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--rules-dir", default=RULES_DIR, help="rules/ directory (default: ../rules)")
+    ap.add_argument("--set", default="alpha-1", help="set label for the title page (default: alpha-1)")
+    ap.add_argument("--out", default=os.path.join(SCRIPT_DIR, "exports", "rules-A4.pdf"),
+                    help="output PDF (default: exports/rules-A4.pdf)")
+    ap.add_argument("--html-only", action="store_true", help="write HTML next to --out and stop")
+    ap.add_argument("--chrome", help="path to a Chrome/Chromium binary (else auto-detected)")
+    args = ap.parse_args()
+
+    try:
+        html = build_html(args.rules_dir, args.set)
+    except ModuleNotFoundError:
+        sys.exit("The 'markdown' package is required: pip install markdown")
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.out)), exist_ok=True)
+    html_path = os.path.splitext(args.out)[0] + ".html"
+    with open(html_path, "w") as f:
+        f.write(html)
+
+    if args.html_only:
+        print(f"HTML -> {html_path}")
+        return
+
+    chrome = find_chrome(args.chrome)
+    if not chrome:
+        sys.exit("No Chrome/Chromium found. Set CHROME_BIN or pass --chrome; "
+                 f"HTML was written to {html_path}.")
+    subprocess.run([chrome, "--headless=new", "--disable-gpu", "--no-pdf-header-footer",
+                    f"--print-to-pdf={args.out}", f"file://{os.path.abspath(html_path)}"],
+                   check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    print(f"Rules -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/design/rules-to-a4.py
+++ b/design/rules-to-a4.py
@@ -9,8 +9,9 @@ cleanly on paper:
   - drop [var:section-id] heading markers (variant-section flags, no value)
   - replace [var:id:baseline] -> the baseline value, colour-coded so a reader
     sees at a glance which numbers are variant-tunable
-  - reuse the card renderer's glyphs (gold cost coin, STR/CUN/CHA stat chips,
-    rarity gems, AP/VP badges) in a Symbols key and inline for AP/VP
+  - mirror the card glyphs (gold cost coin, STR/CUN/CHA stat chips, rarity gems,
+    AP/VP badges) — independently styled here to match — in a Symbols key and
+    inline for AP/VP
 
 With PyMuPDF present it also builds a front-page table of contents with real page
 numbers (two-pass render: measure heading pages, then re-render), stamps a page
@@ -52,13 +53,14 @@ def strip_design(text):
                 depth += {"[": 1, "]": -1}.get(text[j], 0)
                 j += 1
             i = j
-            while i < n and text[i] == " ":       # swallow a trailing space
+            while i < n and text[i] == " ":       # swallow any trailing spaces
                 i += 1
         else:
             out.append(text[i])
             i += 1
     text = "".join(out)
-    text = re.sub(r"(?m)^[ \t]*[-*][ \t]*$\n?", "", text)   # drop now-empty list items
+    # Drop now-empty list items of any marker (-, *, +, or an ordered "N.").
+    text = re.sub(r"(?m)^[ \t]*([-*+]|\d+\.)[ \t]*$\n?", "", text)
     return re.sub(r"\n{3,}", "\n\n", text)
 
 
@@ -91,18 +93,31 @@ def transform(text):
         vid, val = m.group(1), m.group(2)
         return (f'<span class="var" title="Variant-tunable ({vid}); baseline value shown">'
                 f'{val}</span>')
-    text = re.sub(r"\[var:([a-z_]+):([^\]]+)\]", var, text)         # [var:id:value] -> value
+    # id class matches the section-marker pattern above (digits/hyphens allowed),
+    # so a var like [var:grid_2d:5] substitutes instead of leaking raw markup.
+    text = re.sub(r"\[var:([a-z0-9_-]+):([^\]]+)\]", var, text)     # [var:id:value] -> value
 
-    # Cross-file links become in-document anchors (harmless on paper either way).
-    return re.sub(r"\]\([a-z0-9_-]+\.md(#[a-z0-9-]+)?\)",
+    # Cross-file links become in-document anchors (harmless on paper either way);
+    # the target may carry a leading path (e.g. ../library/schema.md).
+    return re.sub(r"\]\([a-z0-9_./-]+\.md(#[a-z0-9-]+)?\)",
                   lambda m: f"]({m.group(1) or '#top'})", text)
 
 
 def badge_inline_stats(html):
-    """Wrap standalone AP / VP tokens in glyph badges, skipping tag interiors."""
+    """Wrap standalone AP / VP tokens in glyph badges, skipping tag interiors and
+    the bodies of <code>/<pre> elements (a literal AP/VP in code stays verbatim)."""
     parts = re.split(r"(<[^>]+>)", html)
-    for k in range(0, len(parts), 2):                              # even = text between tags
-        parts[k] = re.sub(r"\bAP\b", '<span class="ico ap">AP</span>', parts[k])
+    depth = 0                                                      # nesting inside code/pre
+    for k, part in enumerate(parts):
+        if k % 2:                                                  # odd index = a tag
+            if re.match(r"<(code|pre)[\s>]", part.lower()):
+                depth += 1
+            elif re.match(r"</(code|pre)>", part.lower()):
+                depth = max(0, depth - 1)
+            continue
+        if depth:                                                  # text inside code/pre
+            continue
+        parts[k] = re.sub(r"\bAP\b", '<span class="ico ap">AP</span>', part)
         parts[k] = re.sub(r"\bVP\b", '<span class="ico vp">VP</span>', parts[k])
     return "".join(parts)
 
@@ -275,7 +290,10 @@ def build_chapters(rules_dir):
             walk(t.get("children", []))
 
     for fn in FILES:
-        with open(os.path.join(rules_dir, fn)) as f:
+        path = os.path.join(rules_dir, fn)
+        if not os.path.isfile(path):
+            sys.exit(f"Rules file not found: {path} (check --rules-dir).")
+        with open(path, encoding="utf-8") as f:
             md.reset()
             chapters.append(f'<section class="chapter">'
                             f'{badge_inline_stats(md.convert(transform(f.read())))}</section>')
@@ -300,35 +318,65 @@ def build_html(chapters, front_toc, set_name):
 
 
 def render_pdf(chrome, html_path, pdf_path):
-    subprocess.run([chrome, "--headless=new", "--disable-gpu", "--no-pdf-header-footer",
-                    f"--print-to-pdf={pdf_path}", f"file://{os.path.abspath(html_path)}"],
-                   check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    """Print the HTML to pdf_path via headless Chrome, verifying real output.
+
+    Chrome's --print-to-pdf can exit 0 while writing nothing/a truncated file
+    (profile lock, renderer crash, out-of-disk), so a zero exit isn't enough —
+    assert the file exists and is non-empty. stderr is captured (not discarded) so
+    a genuine failure surfaces Chrome's own diagnostic, not a bare exit code.
+    """
+    proc = subprocess.run(
+        [chrome, "--headless=new", "--disable-gpu", "--no-pdf-header-footer",
+         f"--print-to-pdf={pdf_path}", f"file://{os.path.abspath(html_path)}"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)
+    if proc.returncode:
+        sys.exit(f"Chrome failed to render the PDF (exit {proc.returncode}):\n"
+                 f"{proc.stderr.strip()}")
+    if not os.path.exists(pdf_path) or not os.path.getsize(pdf_path):
+        sys.exit(f"Chrome exited 0 but produced no PDF at {pdf_path} "
+                 f"(disk full, or a profile/sandbox issue?).")
+
+
+def page_heading_texts(page_dict):
+    """Heading-sized line texts on a page, from a get_text("dict") structure.
+
+    Matches on heading-sized text (h1=20pt, h2=15pt; body is 10.5pt) rather than a
+    plain text search, so the same name printed in the TOC or in body prose doesn't
+    match before the real heading. Spans are joined per line first, so a heading
+    split across spans (inline code, an em-dash, a soft wrap) still yields its full
+    name. Pure (no fitz), so it can be unit-tested with a fixture.
+    """
+    texts = set()
+    for blk in page_dict.get("blocks", []):
+        for line in blk.get("lines", []):
+            spans = line.get("spans", [])
+            if spans and max(s["size"] for s in spans) >= 13:
+                texts.add("".join(s["text"] for s in spans).strip())
+    return texts
 
 
 def locate_headings(pdf_path, headings):
     """0-based page index of each heading, found by scanning forward.
 
-    Matches on heading-sized spans (h1=20pt, h2=15pt; body is 10.5pt) rather than
-    a plain text search — otherwise the same names printed in the TOC or in body
-    prose would match before the actual heading.
+    Falls back to the previous heading's page for anything it can't find, and warns
+    (stderr) naming the misses so a wrong TOC page number / outline entry isn't
+    produced silently.
     """
     import fitz
     doc = fitz.open(pdf_path)
-    big = []                                           # per page: set of heading texts
-    for pg in doc:
-        texts = set()
-        for blk in pg.get_text("dict")["blocks"]:
-            for line in blk.get("lines", []):
-                for span in line["spans"]:
-                    if span["size"] >= 13:
-                        texts.add(span["text"].strip())
-        big.append(texts)
-    pages, cursor = [], 0
+    big = [page_heading_texts(pg.get_text("dict")) for pg in doc]
+    pages, cursor, missed = [], 0, []
     for _level, text in headings:
-        found = next((p for p in range(cursor, doc.page_count) if text in big[p]), cursor)
+        found = next((p for p in range(cursor, doc.page_count) if text in big[p]), None)
+        if found is None:
+            missed.append(text)
+            found = cursor
         pages.append(found)
         cursor = found
     doc.close()
+    if missed:
+        print(f"warning: could not locate {len(missed)} heading(s) in the PDF; their "
+              f"TOC page numbers may be wrong: {', '.join(missed)}", file=sys.stderr)
     return pages
 
 
@@ -342,9 +390,13 @@ def finalize_pdf(pdf_path, entries):
             continue                                   # front/TOC page stays unnumbered
         box = fitz.Rect(page.rect.width - 60, page.rect.height - 34,
                         page.rect.width - 18, page.rect.height - 18)
-        page.insert_textbox(box, str(i + 1), fontsize=9, fontname="helv",
-                            color=(0.42, 0.47, 0.55), align=fitz.TEXT_ALIGN_RIGHT)
-    doc.set_toc([[level, text, page] for level, text, page in entries])
+        if page.insert_textbox(box, str(i + 1), fontsize=9, fontname="helv",
+                               color=(0.42, 0.47, 0.55), align=fitz.TEXT_ALIGN_RIGHT) < 0:
+            print(f"warning: page number {i + 1} did not fit its stamp box.", file=sys.stderr)
+    toc = [[level, text, page] for level, text, page in entries]
+    if toc:
+        toc[0][0] = 1              # PyMuPDF rejects a TOC whose first entry isn't level 1
+    doc.set_toc(toc)
     tmp = pdf_path + ".tmp"
     doc.save(tmp, garbage=4, deflate=True)
     doc.close()
@@ -364,8 +416,10 @@ def main():
 
     try:
         chapters, headings = build_chapters(args.rules_dir)
-    except ModuleNotFoundError:
-        sys.exit("The 'markdown' package is required: pip install markdown")
+    except ModuleNotFoundError as e:
+        if e.name and e.name.split(".")[0] == "markdown":
+            sys.exit("The 'markdown' package is required: pip install markdown")
+        raise                          # a different missing dep — report it as itself
 
     os.makedirs(os.path.dirname(os.path.abspath(args.out)), exist_ok=True)
     html_path = os.path.splitext(args.out)[0] + ".html"
@@ -373,7 +427,7 @@ def main():
     # Without page numbers yet, the TOC lists section names only. --html-only
     # (screen use) stops here; the print path fills the page numbers below.
     plain_toc = toc_html([(lvl, txt, None) for lvl, txt in headings])
-    with open(html_path, "w") as f:
+    with open(html_path, "w", encoding="utf-8") as f:
         f.write(build_html(chapters, plain_toc, args.set))
 
     if args.html_only:
@@ -391,23 +445,30 @@ def main():
         # No PyMuPDF: still produce a PDF, just without page numbers / a paginated
         # TOC. The front page then carries the section list without numbers.
         render_pdf(chrome, html_path, args.out)
+        os.remove(html_path)                                   # intermediate; PDF is the deliverable
         print(f"Rules -> {args.out}  (install pymupdf for page numbers + TOC pages)")
         return
 
     # Pass 1: render with a number-less TOC to measure where each heading lands.
-    # The front page is forced to exactly one page (page-break-after), so filling
-    # the TOC in pass 2 can't shift any later page — the measured pages stay valid.
+    # Both passes render the same TOC rows (only the page-number text differs), so
+    # the front section's height — and every later page's position — is unchanged;
+    # the measured pages stay valid. (page-break-after:always only guarantees KEY
+    # starts fresh; it does not by itself cap the front section at one page.)
     scratch = os.path.splitext(args.out)[0] + ".pass1.pdf"
-    render_pdf(chrome, html_path, scratch)
-    pages = locate_headings(scratch, headings)                 # 0-based indices
-    os.remove(scratch)
+    try:
+        render_pdf(chrome, html_path, scratch)
+        pages = locate_headings(scratch, headings)             # 0-based indices
+    finally:
+        if os.path.exists(scratch):                            # don't leak the scratch on error
+            os.remove(scratch)
     entries = [(lvl, txt, pg + 1) for (lvl, txt), pg in zip(headings, pages)]
 
     # Pass 2: re-render with page numbers in the TOC, then stamp + outline.
-    with open(html_path, "w") as f:
+    with open(html_path, "w", encoding="utf-8") as f:
         f.write(build_html(chapters, toc_html(entries), args.set))
     render_pdf(chrome, html_path, args.out)
     finalize_pdf(args.out, entries)
+    os.remove(html_path)                                       # intermediate; PDF is the deliverable
     print(f"Rules -> {args.out}  ({len(entries)} TOC entries)")
 
 

--- a/design/test_print_tools.py
+++ b/design/test_print_tools.py
@@ -81,6 +81,15 @@ def test_badge_inline_stats():
     check("href attribute untouched", 'href="/ap"' in out)
 
 
+def test_toc_html():
+    print("toc_html renders indented rows with (or without) page numbers:")
+    rows = r2a.toc_html([(1, "Master Design Document", 3), (2, "Core Architecture", None)])
+    check("level-1 row + page number", 'class="toc-row l1"' in rows and ">3<" in rows)
+    check("level-2 row", 'class="toc-row l2"' in rows)
+    # A None page (pass 1 / no-pymupdf fallback) renders an empty number, not "None".
+    check("None page -> blank, not 'None'", "None" not in rows and '<span class="pg"></span>' in rows)
+
+
 def test_layout_packing():
     print("impose.layout packs true-size cells with margins on the page:")
     # A3 @300 DPI = 3508x4961; poker cards 750x1050 pack 4x4 = 16 per sheet, so
@@ -110,6 +119,7 @@ if __name__ == "__main__":
     test_var_substitution()
     test_blank_before_lists()
     test_badge_inline_stats()
+    test_toc_html()
     test_layout_packing()
     if _failures:
         print(f"\n{len(_failures)} FAILED: {', '.join(_failures)}")

--- a/design/test_print_tools.py
+++ b/design/test_print_tools.py
@@ -1,17 +1,21 @@
 #!/usr/bin/env python3
-"""Standalone tests for the print tooling's pure logic (#250).
+"""Standalone tests for the print tooling's pure logic.
 
 Like the other design/ tests these run standalone:
   python3 design/test_print_tools.py   (exit 0 = pass)
 
 Covers the rules->A4 markdown transforms (the parts most likely to silently
-mangle rules text) and the imposition grid packing. The scripts have hyphenated
-filenames, so they are loaded via importlib rather than imported by name.
+mangle rules text), the heading/TOC logic, and the imposition grid packing +
+page geometry. The scripts have hyphenated filenames, so they are loaded via
+importlib rather than imported by name. impose-print.py imports Pillow at module
+load, so its tests are skipped (not crashed) when Pillow is absent.
 """
 
 import importlib.util
 import os
 import sys
+import tempfile
+import traceback
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -24,7 +28,11 @@ def _load(mod_name, filename):
 
 
 r2a = _load("rules_to_a4", "rules-to-a4.py")
-imp = _load("impose_print", "impose-print.py")
+try:
+    imp = _load("impose_print", "impose-print.py")
+except ModuleNotFoundError as e:
+    imp = None                                 # Pillow absent — skip impose tests, don't crash
+    _imp_skip_reason = str(e)
 
 _failures = []
 
@@ -34,6 +42,8 @@ def check(name, cond):
     if not cond:
         _failures.append(name)
 
+
+# ---------------- rules-to-a4 transforms ----------------
 
 def test_strip_design_balanced():
     print("strip_design removes [design:] blocks, including nested [var:]:")
@@ -50,6 +60,18 @@ def test_strip_design_balanced():
     check("empty bullet line removed", "\n- \n" not in out2 and out2.count("- ") == 2)
 
 
+def test_strip_design_plus_and_ordered():
+    print("strip_design also clears empty '+' and ordered list items, not just -/*:")
+    # The earlier cleanup regex only matched -/* markers, so a [design:]-only '+'
+    # bullet or numbered item would leave a dangling empty marker in the rulebook.
+    plus = "+ Real\n+ [design: internal only]\n+ Keep"
+    out = r2a.strip_design(plus)
+    check("empty '+' item removed", "+ Real" in out and "+ Keep" in out and out.count("+ ") == 2)
+    ordered = "1. Real\n2. [design: internal only]\n3. Keep"
+    out2 = r2a.strip_design(ordered)
+    check("empty ordered item removed", "1. Real" in out2 and "3. Keep" in out2 and "2. \n" not in out2)
+
+
 def test_var_substitution():
     print("transform substitutes [var:id:value] as a colour-coded chip:")
     out = r2a.transform("Reach [var:vp_threshold:50] VP.")
@@ -59,6 +81,25 @@ def test_var_substitution():
     # Two-part section markers carry no value and must simply disappear.
     check("section marker dropped",
           "[var:seeding-phase]" not in r2a.transform("### Seeding Phase [var:seeding-phase]"))
+
+
+def test_var_digit_and_hyphen_id():
+    print("transform substitutes var ids with digits/hyphens (id class matches markers):")
+    # Regression: the valued-var id class was [a-z_]+, narrower than the section
+    # marker's [a-z0-9_-]+, so any id with a digit/hyphen leaked raw into the PDF.
+    out = r2a.transform("Grid [var:grid_2d:5] wide; seed [var:seed-draw:10].")
+    check("digit-id substituted", ">5<" in out and "grid_2d" in out and "[var:grid_2d" not in out)
+    check("hyphen-id substituted", ">10<" in out and "seed-draw" in out and "[var:seed-draw" not in out)
+
+
+def test_transform_links():
+    print("transform rewrites wikilinks and cross-file .md links to in-doc anchors:")
+    check("wikilink unwrapped", r2a.transform("See [[controller]] rules.") == "See controller rules.")
+    check("anchored md link -> #anchor", "](#seeding)" in r2a.transform("[x](market.md#seeding)"))
+    check("bare md link -> #top", "](#top)" in r2a.transform("[x](market.md)"))
+    # A link carrying a leading path (../library/schema.md) must rewrite too, not
+    # survive as a dead file://-relative link.
+    check("pathful md link rewritten", "](#top)" in r2a.transform("[x](../library/schema.md)"))
 
 
 def test_blank_before_lists():
@@ -71,6 +112,10 @@ def test_blank_before_lists():
     # (that would break the nesting into a sibling list).
     nested = "1. Draw:\n  - sub a\n  - sub b"
     check("nested list untouched", r2a.blank_before_lists(nested) == nested)
+    # A heading directly followed by a list must NOT gain a blank line either —
+    # the branch the docstring calls out but no case exercised.
+    heading = "# Title\n- one\n- two"
+    check("heading+list untouched", r2a.blank_before_lists(heading) == heading)
 
 
 def test_badge_inline_stats():
@@ -79,6 +124,19 @@ def test_badge_inline_stats():
     check("AP in text badged", '<span class="ico ap">AP</span>' in out)
     check("VP in text badged", '<span class="ico vp">VP</span>' in out)
     check("href attribute untouched", 'href="/ap"' in out)
+
+
+def test_badge_boundaries_and_code():
+    print("badge_inline_stats only badges standalone AP/VP, and skips code spans:")
+    # \b word boundaries: AP/VP inside a larger word must stay unbadged.
+    out = r2a.badge_inline_stats("MAPS and VAPOR cost 2 AP")
+    check("substring AP/VP untouched", "MAPS" in out and "VAPOR" in out)
+    check("standalone AP badged", '<span class="ico ap">AP</span>' in out)
+    # A literal AP/VP inside an inline <code> span must stay verbatim, not gain a
+    # styled badge injected into monospace text.
+    out2 = r2a.badge_inline_stats("<code>2 AP</code> costs 2 AP")
+    check("code-span AP stays literal", "<code>2 AP</code>" in out2)
+    check("prose AP still badged", '<span class="ico ap">AP</span>' in out2)
 
 
 def test_toc_html():
@@ -90,19 +148,43 @@ def test_toc_html():
     check("None page -> blank, not 'None'", "None" not in rows and '<span class="pg"></span>' in rows)
 
 
+def test_page_heading_texts():
+    print("page_heading_texts joins spans per line and keeps only heading-sized text:")
+    # Feed a get_text("dict")-shaped fixture: an h1 split across two spans (the
+    # wrapped-heading case that used to mislocate TOC entries), plus body prose.
+    page = {"blocks": [
+        {"lines": [{"spans": [{"text": "Core ", "size": 20}, {"text": "Architecture", "size": 20}]}]},
+        {"lines": [{"spans": [{"text": "some body prose", "size": 10.5}]}]},
+    ]}
+    texts = r2a.page_heading_texts(page)
+    check("multi-span heading joined whole", "Core Architecture" in texts)
+    check("body-sized text excluded", "some body prose" not in texts)
+
+
+# ---------------- impose-print packing + geometry ----------------
+
+def test_page_metrics():
+    print("page_metrics derives the sheet size + vertical budget main() runs on:")
+    mm = 300 / 25.4
+    pw, ph, budget = imp.page_metrics("a3", 300)
+    check("A3 width px", pw == round(297 * mm))
+    check("A3 height px", ph == round(420 * mm))
+    check("budget = height - 2*margin", budget == ph - 2 * round(imp.MARGIN_MM * mm))
+
+
 def test_row_packing():
     print("row packing mixes same-width sizes onto shared sheets to save paper:")
-    # A3 @300 DPI; alpha-1 = 50 poker (750x1050) + 16 square location (750x750)
-    # cards, all the same width. The naive size-siloed layout was 4 poker pages
-    # (last holding only 2) + 1 half-empty locations page = 5 sheets. Packing rows
-    # of both heights together must fit in 4.
-    mm = 300 / 25.4
-    pw, ph = round(297 * mm), round(420 * mm)
-    gutter, budget = round(4 * mm), round(420 * mm) - 2 * round(8 * mm)
-    groups = {(750, 1050): [f"p{i}" for i in range(50)],
+    # A3 @300 DPI; alpha-1 = 49 poker (750x1050: units 20 + items 10 + events 11 +
+    # policies 8) + 16 square location (750x750) cards, all the same width. The
+    # naive size-siloed layout was 4 poker pages (last holding only 1) + 1
+    # half-empty locations page = 5 sheets. Packing rows of both heights must fit
+    # in 4. Budget comes from page_metrics so this exercises main()'s real math.
+    pw, _ph, budget = imp.page_metrics("a3", 300)
+    gutter = round(4 * 300 / 25.4)
+    groups = {(750, 1050): [f"p{i}" for i in range(49)],
               (750, 750): [f"s{i}" for i in range(16)]}
     rows = imp.make_rows(groups, pw, gutter)
-    check("50 poker -> 13 rows + 16 square -> 4 rows", len(rows) == 17)
+    check("49 poker -> 13 rows + 16 square -> 4 rows", len(rows) == 17)
     pages = imp.paginate(rows, budget, gutter)
     check("packs into 4 sheets, not 5", len(pages) == 4)
     # The leftover poker row shares its sheet with square rows — the whole point.
@@ -112,13 +194,107 @@ def test_row_packing():
     check("no sheet exceeds the vertical budget", all(used(pg) <= budget for pg in pages))
 
 
+def test_make_rows_paginate_edges():
+    print("make_rows/paginate handle empty and single-card inputs:")
+    pw, _ph, budget = imp.page_metrics("a3", 300)
+    gutter = round(4 * 300 / 25.4)
+    check("empty groups -> no rows", imp.make_rows({}, pw, gutter) == [])
+    check("empty rows -> no pages", imp.paginate([], budget, gutter) == [])
+    one = imp.make_rows({(750, 1050): ["only.png"]}, pw, gutter)
+    check("single card -> one row", len(one) == 1 and one[0]["files"] == ["only.png"])
+    check("single row -> one page", len(imp.paginate(one, budget, gutter)) == 1)
+
+
+def test_validate_sizes_rejects_oversized():
+    print("validate_sizes exits on a card too big to place 1:1 on the sheet:")
+    # An oversized card would otherwise be silently clipped by draw_page (negative
+    # offsets push it and its crop marks off the page).
+    pw, _ph, budget = imp.page_metrics("a4", 300)
+    try:
+        imp.validate_sizes({(pw + 10, 100): ["toowide.png"]}, pw, budget, 300)
+        check("oversized card exits", False)
+    except SystemExit:
+        check("oversized card exits", True)
+    # A correctly-sized poker card (63.5mm @ 300 DPI = 750px) passes cleanly.
+    try:
+        imp.validate_sizes({(750, 1050): ["ok.png"]}, pw, budget, 300)
+        check("in-spec card accepted", True)
+    except SystemExit:
+        check("in-spec card accepted", False)
+
+
+def test_collect_errors_and_image_size():
+    print("collect exits on a missing set dir; image_size reads real PNG sizes:")
+    try:
+        imp.collect("definitely-not-a-real-set-xyz")
+        check("missing set exits", False)
+    except SystemExit:
+        check("missing set exits", True)
+    from PIL import Image
+    with tempfile.TemporaryDirectory() as d:
+        p = os.path.join(d, "card.png")
+        Image.new("RGB", (750, 1050), "white").save(p)
+        check("image_size reads dimensions", imp.image_size(p) == (750, 1050))
+
+
+def test_draw_page_renders_within_bounds():
+    print("draw_page returns a page-sized image with the cards actually pasted in:")
+    # This is the WHERE step (crop marks, centering, paste coords) that make_rows /
+    # paginate don't touch. Render two synthetic cards and confirm they land on an
+    # otherwise-white page of the requested size.
+    from PIL import Image
+    with tempfile.TemporaryDirectory() as d:
+        paths = []
+        for i in range(2):
+            p = os.path.join(d, f"c{i}.png")
+            Image.new("RGB", (50, 70), "red").save(p)
+            paths.append(p)
+        rows = [{"w": 50, "h": 70, "files": paths}]
+        page = imp.draw_page(rows, (200, 300), 10, 6)
+        check("page has the requested size", page.size == (200, 300))
+        colors = {c for _n, c in page.getcolors(maxcolors=100000)}
+        check("red cards pasted onto page", (255, 0, 0) in colors)
+        check("white background remains", (255, 255, 255) in colors)
+
+
+R2A_TESTS = [
+    test_strip_design_balanced,
+    test_strip_design_plus_and_ordered,
+    test_var_substitution,
+    test_var_digit_and_hyphen_id,
+    test_transform_links,
+    test_blank_before_lists,
+    test_badge_inline_stats,
+    test_badge_boundaries_and_code,
+    test_toc_html,
+    test_page_heading_texts,
+]
+
+IMP_TESTS = [
+    test_page_metrics,
+    test_row_packing,
+    test_make_rows_paginate_edges,
+    test_validate_sizes_rejects_oversized,
+    test_collect_errors_and_image_size,
+    test_draw_page_renders_within_bounds,
+]
+
+
 if __name__ == "__main__":
-    test_strip_design_balanced()
-    test_var_substitution()
-    test_blank_before_lists()
-    test_badge_inline_stats()
-    test_toc_html()
-    test_row_packing()
+    tests = list(R2A_TESTS)
+    if imp is None:
+        print(f"SKIP impose-print tests — Pillow not importable ({_imp_skip_reason})")
+    else:
+        tests += IMP_TESTS
+    for t in tests:
+        # A test that raises is a failure, not an abort — keep going so one broken
+        # case doesn't hide the pass/fail status of every later one.
+        try:
+            t()
+        except Exception:
+            print(f"  FAIL {t.__name__} raised:")
+            traceback.print_exc()
+            _failures.append(t.__name__)
     if _failures:
         print(f"\n{len(_failures)} FAILED: {', '.join(_failures)}")
         sys.exit(1)

--- a/design/test_print_tools.py
+++ b/design/test_print_tools.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Standalone tests for the print tooling's pure logic (#250).
+
+Like the other design/ tests these run standalone:
+  python3 design/test_print_tools.py   (exit 0 = pass)
+
+Covers the rules->A4 markdown transforms (the parts most likely to silently
+mangle rules text) and the imposition grid packing. The scripts have hyphenated
+filenames, so they are loaded via importlib rather than imported by name.
+"""
+
+import importlib.util
+import os
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load(mod_name, filename):
+    spec = importlib.util.spec_from_file_location(mod_name, os.path.join(SCRIPT_DIR, filename))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+r2a = _load("rules_to_a4", "rules-to-a4.py")
+imp = _load("impose_print", "impose-print.py")
+
+_failures = []
+
+
+def check(name, cond):
+    print(f"  {'ok  ' if cond else 'FAIL'} {name}")
+    if not cond:
+        _failures.append(name)
+
+
+def test_strip_design_balanced():
+    print("strip_design removes [design:] blocks, including nested [var:]:")
+    # A design block nests a [var:...] token; naive [^]]* matching would stop at
+    # the inner ']' and leak "], they draw..." into the output. Balanced scan must
+    # consume the whole block.
+    src = "Keep me. [design: note with [var:seed_draw:10] inside] Keep this too."
+    out = r2a.strip_design(src)
+    check("whole nested block gone", "design" not in out and "seed_draw" not in out)
+    check("surrounding prose intact", "Keep me." in out and "Keep this too." in out)
+    # A design block that was its own bullet must not leave a dangling "- ".
+    bullet = "- Real item\n- [design: internal only]\n- Another item"
+    out2 = r2a.strip_design(bullet)
+    check("empty bullet line removed", "\n- \n" not in out2 and out2.count("- ") == 2)
+
+
+def test_var_substitution():
+    print("transform substitutes [var:id:value] as a colour-coded chip:")
+    out = r2a.transform("Reach [var:vp_threshold:50] VP.")
+    check("baseline value shown", ">50<" in out)
+    check("wrapped in .var chip", 'class="var"' in out and "vp_threshold" in out)
+    check("token markup gone", "[var:" not in out)
+    # Two-part section markers carry no value and must simply disappear.
+    check("section marker dropped",
+          "[var:seeding-phase]" not in r2a.transform("### Seeding Phase [var:seeding-phase]"))
+
+
+def test_blank_before_lists():
+    print("blank_before_lists opens a list that abuts a paragraph line:")
+    # "intro:" directly precedes a bullet with no blank line — markdown would fold
+    # the bullets into the paragraph without this fix-up.
+    fixed = r2a.blank_before_lists("Starts with:\n- one\n- two")
+    check("blank inserted after prose", fixed.startswith("Starts with:\n\n- one"))
+    # A genuine nested list under an ordered item must NOT gain a blank line
+    # (that would break the nesting into a sibling list).
+    nested = "1. Draw:\n  - sub a\n  - sub b"
+    check("nested list untouched", r2a.blank_before_lists(nested) == nested)
+
+
+def test_badge_inline_stats():
+    print("badge_inline_stats badges AP/VP in text but not inside tags:")
+    out = r2a.badge_inline_stats('<a href="/ap">costs 2 AP</a> and 1 VP')
+    check("AP in text badged", '<span class="ico ap">AP</span>' in out)
+    check("VP in text badged", '<span class="ico vp">VP</span>' in out)
+    check("href attribute untouched", 'href="/ap"' in out)
+
+
+def test_layout_packing():
+    print("impose.layout packs true-size cells with margins on the page:")
+    # A3 @300 DPI = 3508x4961; poker cards 750x1050 pack 4x4 = 16 per sheet, so
+    # 50 cards -> 4 pages. Pins the shop-floor expectation from the issue.
+    a3 = (3508, 4961)
+    gutter = round(4 * 300 / 25.4)
+    files = [os.path.join(SCRIPT_DIR, "penpot.py")] * 50  # any readable path; not opened here
+    pages = list(_dry_layout(imp, files, 750, 1050, a3, gutter))
+    check("50 poker cards -> 4 A3 pages", len(pages) == 4)
+    square = [os.path.join(SCRIPT_DIR, "penpot.py")] * 16
+    check("16 square locations -> 1 page", len(list(_dry_layout(imp, square, 750, 750, a3, gutter))) == 1)
+
+
+def _dry_layout(imp, files, w, h, page_px, gutter):
+    """Run layout()'s pagination without opening image files: patch Image.open/paste."""
+    from PIL import Image
+    orig_open = imp.Image.open
+    imp.Image.open = lambda *_a, **_k: Image.new("RGB", (w, h), "white")
+    try:
+        yield from imp.layout(files, w, h, page_px, gutter, tick=35)
+    finally:
+        imp.Image.open = orig_open
+
+
+if __name__ == "__main__":
+    test_strip_design_balanced()
+    test_var_substitution()
+    test_blank_before_lists()
+    test_badge_inline_stats()
+    test_layout_packing()
+    if _failures:
+        print(f"\n{len(_failures)} FAILED: {', '.join(_failures)}")
+        sys.exit(1)
+    print("\nAll print-tooling tests passed.")

--- a/design/test_print_tools.py
+++ b/design/test_print_tools.py
@@ -90,28 +90,26 @@ def test_toc_html():
     check("None page -> blank, not 'None'", "None" not in rows and '<span class="pg"></span>' in rows)
 
 
-def test_layout_packing():
-    print("impose.layout packs true-size cells with margins on the page:")
-    # A3 @300 DPI = 3508x4961; poker cards 750x1050 pack 4x4 = 16 per sheet, so
-    # 50 cards -> 4 pages. Pins the shop-floor expectation from the issue.
-    a3 = (3508, 4961)
-    gutter = round(4 * 300 / 25.4)
-    files = [os.path.join(SCRIPT_DIR, "penpot.py")] * 50  # any readable path; not opened here
-    pages = list(_dry_layout(imp, files, 750, 1050, a3, gutter))
-    check("50 poker cards -> 4 A3 pages", len(pages) == 4)
-    square = [os.path.join(SCRIPT_DIR, "penpot.py")] * 16
-    check("16 square locations -> 1 page", len(list(_dry_layout(imp, square, 750, 750, a3, gutter))) == 1)
-
-
-def _dry_layout(imp, files, w, h, page_px, gutter):
-    """Run layout()'s pagination without opening image files: patch Image.open/paste."""
-    from PIL import Image
-    orig_open = imp.Image.open
-    imp.Image.open = lambda *_a, **_k: Image.new("RGB", (w, h), "white")
-    try:
-        yield from imp.layout(files, w, h, page_px, gutter, tick=35)
-    finally:
-        imp.Image.open = orig_open
+def test_row_packing():
+    print("row packing mixes same-width sizes onto shared sheets to save paper:")
+    # A3 @300 DPI; alpha-1 = 50 poker (750x1050) + 16 square location (750x750)
+    # cards, all the same width. The naive size-siloed layout was 4 poker pages
+    # (last holding only 2) + 1 half-empty locations page = 5 sheets. Packing rows
+    # of both heights together must fit in 4.
+    mm = 300 / 25.4
+    pw, ph = round(297 * mm), round(420 * mm)
+    gutter, budget = round(4 * mm), round(420 * mm) - 2 * round(8 * mm)
+    groups = {(750, 1050): [f"p{i}" for i in range(50)],
+              (750, 750): [f"s{i}" for i in range(16)]}
+    rows = imp.make_rows(groups, pw, gutter)
+    check("50 poker -> 13 rows + 16 square -> 4 rows", len(rows) == 17)
+    pages = imp.paginate(rows, budget, gutter)
+    check("packs into 4 sheets, not 5", len(pages) == 4)
+    # The leftover poker row shares its sheet with square rows — the whole point.
+    last_heights = {r["h"] for r in pages[-1]}
+    check("last sheet mixes 1050 + 750 rows", last_heights == {1050, 750})
+    used = lambda pg: sum(r["h"] for r in pg) + gutter * (len(pg) - 1)
+    check("no sheet exceeds the vertical budget", all(used(pg) <= budget for pg in pages))
 
 
 if __name__ == "__main__":
@@ -120,7 +118,7 @@ if __name__ == "__main__":
     test_blank_before_lists()
     test_badge_inline_stats()
     test_toc_html()
-    test_layout_packing()
+    test_row_packing()
     if _failures:
         print(f"\n{len(_failures)} FAILED: {', '.join(_failures)}")
         sys.exit(1)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:library": "bun library/build.ts",
     "build:rules": "bun engine/src/rules-config.ts",
     "test": "bun run build:library && bun --filter '*' test",
-    "test:renderer": "python3 design/test_moderntrek_template.py",
+    "test:renderer": "python3 design/test_moderntrek_template.py && python3 design/test_print_tools.py",
     "typecheck": "bun --filter '*' typecheck"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #250.

Adds two Penpot-independent print-and-play tools under `design/`, so a rough physical set of **alpha-1** (and the rules) can be self-printed to go over by hand before professional printing (which waits on #45).

## What's here
- **`design/impose-print.py`** — tiles the already-rendered card PNGs (`exports/<set>/`, from `moderntrek-template.py` / #202) at true poker size onto A3 pages with corner crop marks → `exports/<set>/print/<set>-cards-a3.pdf`. Pure PIL; reads existing exports, doesn't touch the renderer. `--paper a4` and other knobs available. For alpha-1: 66 cards → 5 A3 pages.
- **`design/rules-to-a4.py`** — typesets `rules/*.md` (README + attributes + stat-contests + market + policies) into an A4 booklet → `exports/rules-A4.pdf`. Faithful typeset, not a rewrite:
  - strips `[design:…]` commentary (balanced-bracket scan — they nest `[var:…]`)
  - drops `[var:section-id]` heading markers
  - renders `[var:id:baseline]` as the baseline value in a **colour-coded chip** (flags variant-tunable values), with an explainer up front
  - adds a **Symbols & Notation** key reusing the card glyphs: gold cost coin, AP/VP badges, STR/CUN/CHA stat chips, rarity gems (AP/VP also badged inline)
  - toolchain: `markdown` → HTML/CSS → Chrome headless `--print-to-pdf` (`--html-only` skips Chrome)
- **`design/test_print_tools.py`** — standalone tests (repo convention) pinning the tricky pure logic: nested `[design:]` stripping, var substitution, paragraph→list fix-up, tag-safe AP/VP badging, and A3 grid packing (50 poker → 4 pages, 16 square → 1).
- Docs: `design/README.md` **Printing** section + a workflow entry in the `penpot-card-renderer` SKILL.

Generated PDFs land in the gitignored `exports/`, so nothing binary is in this PR.

## Out of scope / follow-ups
- **Card backs** aren't rendered yet → sheets are single-sided (gated on #218).
- The rules PDF is a typeset of the **design doc**, not a learn-to-play rulebook — no worked example / first-turn walkthrough. A proper quick-start rulebook is a separate, larger effort (noted in #250; currently only an idea in `rules/ideas.md`).
- This is sheet-level imposition, distinct from renderer-side per-card print prep (bleed/CMYK, #9) — they compose.

## Verification
- `python3 design/test_print_tools.py` → all pass.
- Ran both tools end-to-end: `impose-print.py` → 5 A3 pages; `rules-to-a4.py` → A4 booklet. Spot-checked rendered pages (crop marks, var chips, symbols key, nested seeding lists) visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)